### PR TITLE
Release-critical eval custody hardening (v0.3.2.0): process identity, tree termination, atomic claim, checkout attestation, custody-record integrity

### DIFF
--- a/eval/hosts.py
+++ b/eval/hosts.py
@@ -138,36 +138,201 @@ class _Outcome:
         self.returncode = returncode
 
 
+class _WinJob:
+    """Windows Job Object owning the spawned host's whole process tree.
+    kill-on-close means an adapter crash (handle close) also reaps the
+    tree; terminate() reaps it atomically on timeout and verify_empty()
+    proves no descendant survived before the run terminalizes."""
+
+    def __init__(self):
+        import ctypes
+        from ctypes import wintypes
+        self._ct = ctypes
+        self.k32 = ctypes.windll.kernel32
+
+        class _BASIC(ctypes.Structure):
+            _fields_ = [("PerProcessUserTimeLimit", ctypes.c_longlong),
+                        ("PerJobUserTimeLimit", ctypes.c_longlong),
+                        ("LimitFlags", wintypes.DWORD),
+                        ("MinimumWorkingSetSize", ctypes.c_size_t),
+                        ("MaximumWorkingSetSize", ctypes.c_size_t),
+                        ("ActiveProcessLimit", wintypes.DWORD),
+                        ("Affinity", ctypes.c_size_t),
+                        ("PriorityClass", wintypes.DWORD),
+                        ("SchedulingClass", wintypes.DWORD)]
+
+        class _IOC(ctypes.Structure):
+            _fields_ = [(n, ctypes.c_ulonglong) for n in (
+                "ReadOperationCount", "WriteOperationCount",
+                "OtherOperationCount", "ReadTransferCount",
+                "WriteTransferCount", "OtherTransferCount")]
+
+        class _EXT(ctypes.Structure):
+            _fields_ = [("BasicLimitInformation", _BASIC),
+                        ("IoInfo", _IOC),
+                        ("ProcessMemoryLimit", ctypes.c_size_t),
+                        ("JobMemoryLimit", ctypes.c_size_t),
+                        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                        ("PeakJobMemoryUsed", ctypes.c_size_t)]
+
+        class _ACCT(ctypes.Structure):
+            _fields_ = [("TotalUserTime", ctypes.c_longlong),
+                        ("TotalKernelTime", ctypes.c_longlong),
+                        ("ThisPeriodTotalUserTime", ctypes.c_longlong),
+                        ("ThisPeriodTotalKernelTime", ctypes.c_longlong),
+                        ("TotalPageFaultCount", wintypes.DWORD),
+                        ("TotalProcesses", wintypes.DWORD),
+                        ("ActiveProcesses", wintypes.DWORD),
+                        ("TotalTerminatedProcesses", wintypes.DWORD)]
+
+        self._ACCT = _ACCT
+        self.handle = self.k32.CreateJobObjectW(None, None)
+        if not self.handle:
+            raise OSError("CreateJobObjectW failed")
+        info = _EXT()
+        info.BasicLimitInformation.LimitFlags = 0x2000  # KILL_ON_JOB_CLOSE
+        JobObjectExtendedLimitInformation = 9
+        if not self.k32.SetInformationJobObject(
+                self.handle, JobObjectExtendedLimitInformation,
+                ctypes.byref(info), ctypes.sizeof(info)):
+            self.close()
+            raise OSError("SetInformationJobObject failed")
+
+    def assign(self, proc):
+        if not self.k32.AssignProcessToJobObject(
+                self.handle, int(proc._handle)):
+            raise OSError("AssignProcessToJobObject failed")
+
+    def terminate(self):
+        self.k32.TerminateJobObject(self.handle, 1)
+
+    def verify_empty(self, timeout_s=10.0):
+        """True when zero processes remain in the job."""
+        import time as _t
+        JobObjectBasicAccountingInformation = 1
+        deadline = _t.monotonic() + timeout_s
+        while _t.monotonic() < deadline:
+            acct = self._ACCT()
+            ok = self.k32.QueryInformationJobObject(
+                self.handle, JobObjectBasicAccountingInformation,
+                self._ct.byref(acct), self._ct.sizeof(acct), None)
+            if ok and acct.ActiveProcesses == 0:
+                return True
+            _t.sleep(0.1)
+        return False
+
+    def close(self):
+        try:
+            self.k32.CloseHandle(self.handle)
+        except Exception:
+            pass
+
+
+def _kill_tree(proc, job=None):
+    """Terminate the OWNED process tree, not only the direct child, and
+    return a short verification note ('tree-verified-dead' when no
+    descendant provably survives). Windows: TerminateJobObject on the job
+    the child was assigned to at spawn (taskkill /T fallback). POSIX: the
+    child was spawned in its own session/process group; SIGTERM then
+    SIGKILL the group and verify with killpg(0)."""
+    import time as _t
+    if os.name == "nt":
+        if job is not None:
+            job.terminate()
+            note = ("tree-verified-dead" if job.verify_empty()
+                    else "job-terminate-descendants-unverified")
+        else:
+            try:
+                subprocess.run(["taskkill", "/PID", str(proc.pid),
+                                "/T", "/F"], capture_output=True, timeout=30)
+                note = "taskkill-tree-unverified"
+            except Exception as exc:
+                note = f"taskkill-failed:{exc!r}"
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        return note
+    import signal
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        pgid = None
+    if pgid is not None and pgid != os.getpgid(0):
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except OSError:
+            pass
+        deadline = _t.monotonic() + 5.0
+        while _t.monotonic() < deadline and proc.poll() is None:
+            _t.sleep(0.1)
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except OSError:
+            pass
+        try:
+            os.killpg(pgid, 0)
+            note = "killpg-descendants-unverified"
+        except OSError:
+            note = "tree-verified-dead"
+    else:
+        note = "no-own-process-group"
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    return note
+
+
 def _spawn_once(argv, env, cwd, timeout_s, stdin_text=None, on_started=None):
     """Exactly one spawn — no hidden retry lives anywhere in this module.
     `on_started` runs immediately after the process exists (create-once
     process-started custody); if it fails the child is killed and the run
-    terminalizes ERROR."""
+    terminalizes ERROR. The child owns a Job Object (Windows) or its own
+    session (POSIX) so every termination path reaps the WHOLE tree."""
+    popen_kw = {}
+    if os.name != "nt":
+        popen_kw["start_new_session"] = True
     try:
         proc = subprocess.Popen(argv, env=env, cwd=cwd,
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 text=True, encoding="utf-8",
-                                errors="replace")
+                                errors="replace", **popen_kw)
     except OSError as exc:
         return HostRunResult("error", f"host spawn failed: {exc}")
-    if on_started is not None:
+    job = None
+    if os.name == "nt":
         try:
-            on_started(proc)
-        except Exception as exc:
-            proc.kill()
-            proc.communicate()
-            return HostRunResult(
-                "error", f"process-started custody write failed: {exc!r}")
+            job = _WinJob()
+            job.assign(proc)
+        except OSError:
+            if job is not None:
+                job.close()
+            job = None  # taskkill /T fallback still applies on timeout
     try:
-        out, err = proc.communicate(input=stdin_text, timeout=timeout_s)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        out, err = proc.communicate()
-        r = HostRunResult("error", f"host timeout after {timeout_s}s")
-        r.stdout, r.stderr = out or "", err or ""
-        return r
+        if on_started is not None:
+            try:
+                on_started(proc)
+            except Exception as exc:
+                note = _kill_tree(proc, job)
+                proc.communicate()
+                return HostRunResult(
+                    "error", f"process-started custody write failed: "
+                             f"{exc!r} (kill: {note})")
+        try:
+            out, err = proc.communicate(input=stdin_text, timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            note = _kill_tree(proc, job)
+            out, err = proc.communicate()
+            r = HostRunResult(
+                "error", f"host timeout after {timeout_s}s (kill: {note})")
+            r.stdout, r.stderr = out or "", err or ""
+            return r
+    finally:
+        if job is not None:
+            job.close()
     if proc.returncode != 0:
         # Carry the raw streams so the caller can preserve them at the run
         # root — an ERROR run must never leave custody without the host
@@ -191,11 +356,18 @@ class _BaseAdapter:
     capabilities = frozenset()
 
     def __init__(self, host_argv_template, requested_model,
-                 product_checkout=None, host_cwd=None):
+                 product_checkout=None, host_cwd=None, formal=True,
+                 lane_id=None):
         self.host_argv_template = list(host_argv_template)
         self.requested_model = requested_model
         self.product_checkout = product_checkout
         self.host_cwd = host_cwd
+        # A FORMAL run produces evidence (smoke/baseline/comparison) and
+        # must carry an attested product checkout — zero identities are
+        # never a valid fallback for scored evidence. Only explicitly
+        # declared mock/test adapters may run without one.
+        self.formal = formal
+        self.lane_id = lane_id
         self.models_observed = []
         self._events_source = None
         self._staged_payload_hash = None
@@ -252,8 +424,19 @@ class _BaseAdapter:
          else _test_gate)()
         self.preflight()
         reconcilelib.reconcile_custody(custody_root)
-        run_root = framework.custody.resolve_and_create_output_dir(
-            custody_root, run_id)
+        # ATOMIC CLAIM: the intent is written inside a create-once staging
+        # dir which is then renamed to the final run root, so a hard crash
+        # can never leave an intent-less orphan run root — a crash before
+        # the rename leaves only a `<run_id>.claiming` staging dir, which
+        # the reconciler sweeps and terminally classifies.
+        claiming = framework.custody.resolve_and_create_output_dir(
+            custody_root, run_id + ".claiming")
+        run_root = os.path.join(os.path.dirname(claiming), run_id)
+        framework.custody.resolve_output_dir(custody_root, run_id)
+        if os.path.lexists(run_root):
+            os.rmdir(claiming)
+            raise framework.custody.CustodyError(
+                f"destination already exists: {run_root!r}")
         started_ts = _utc_now()
         self._not_before = started_ts
         fixture_path = os.path.join(HERE, "fixtures", fixture_id,
@@ -278,13 +461,26 @@ class _BaseAdapter:
                 self, "config_dir", None),
             "started_at": started_ts,
         }
-        with open(os.path.join(run_root, "run-intent.json"), "x",
-                  encoding="utf-8") as fh:
-            json.dump(intent, fh, indent=1, sort_keys=True)
+        intent_bytes = json.dumps(intent, indent=1,
+                                  sort_keys=True).encode("utf-8")
+        with open(os.path.join(claiming, "run-intent.json"), "xb") as fh:
+            fh.write(intent_bytes)
+        os.rename(claiming, run_root)  # atomic claim: intent + root together
+        # Custody-record integrity: a Config-O mission process has no OS
+        # filesystem jail (canary-proven), so it could rewrite its own
+        # custody records mid-run. Hash them at write time and re-verify on
+        # every exit path; a mismatch downgrades the run to INVALID.
+        self._custody_hashes = {
+            "run-intent.json": bundlelib._sha256_bytes(intent_bytes)}
         result = HostRunResult("error", "adapter did not terminalize")
         spawned = False
         payload_before = None
         try:
+            if self.formal and not self.product_checkout:
+                raise framework.AdapterError(
+                    "formal run without an attested product checkout — "
+                    "zero identities are not a valid fallback for scored "
+                    "evidence; INVALID before spawn")
             need = set(fx.get("required_capabilities", []))
             missing = sorted(need - set(self.capabilities))
             if missing:
@@ -306,17 +502,27 @@ class _BaseAdapter:
                     for a in self.host_argv_template]
 
             def _on_started(proc):
-                rec = {"schema": "implementaudit-process-started-v1",
-                       "run_id": run_id, "pid": proc.pid,
+                rec = {"schema": "implementaudit-process-started-v2",
+                       "run_id": run_id,
                        "cwd": self.host_cwd or repo,
                        "started_at": _utc_now(),
                        "argv_sha256": bundlelib._sha256_bytes(
                            "\x00".join(argv).encode("utf-8")),
                        "requested_model": self.requested_model_canonical(),
                        "temp_home": intent["temp_home"]}
+                # Full process identity (lane, OS, boot, pid, creation
+                # time): the reconciler refuses to treat a recycled or
+                # foreign-lane pid as the original process, so every field
+                # it compares must be captured at spawn.
+                rec.update(reconcilelib.process_identity(
+                    proc.pid, lane_id=getattr(self, "lane_id", None)))
+                rec_bytes = json.dumps(rec, indent=1,
+                                       sort_keys=True).encode("utf-8")
                 with open(os.path.join(run_root, "process-started.json"),
-                          "x", encoding="utf-8") as fh:
-                    json.dump(rec, fh, indent=1, sort_keys=True)
+                          "xb") as fh:
+                    fh.write(rec_bytes)
+                self._custody_hashes["process-started.json"] = \
+                    bundlelib._sha256_bytes(rec_bytes)
 
             spawned = True
             outcome = _spawn_once(argv, self._mission_env(repo),
@@ -431,6 +637,17 @@ class _BaseAdapter:
                     f"credential pattern {hits[0][0]!r} found in file "
                     f"{hits[0][1]!r} — moved to quarantine; custody "
                     f"violation ({len(hits)} location(s) scrubbed)")
+            for rel, want in (getattr(self, "_custody_hashes", None)
+                              or {}).items():
+                try:
+                    got = bundlelib._sha256_bytes(
+                        open(os.path.join(run_root, rel), "rb").read())
+                except OSError:
+                    got = None
+                if got != want:
+                    raise framework.AdapterError(
+                        f"custody record {rel} modified during the "
+                        f"mission — INVALID")
             result = HostRunResult("ok", bundle_root,
                                    raw_events=events,
                                    resolved_model=resolved)
@@ -460,6 +677,22 @@ class _BaseAdapter:
                             "during the mission (detected on exit)")
                 except OSError:
                     pass
+            # Custody-record integrity on EVERY exit path (Config-O canary
+            # finding, v0.3.2.0): a jail-less mission process that rewrote
+            # its own run-intent.json / process-started.json must be caught
+            # before the run terminalizes.
+            for rel, want in (getattr(self, "_custody_hashes", None)
+                              or {}).items():
+                try:
+                    got = bundlelib._sha256_bytes(
+                        open(os.path.join(run_root, rel), "rb").read())
+                except OSError:
+                    got = None
+                if got != want:
+                    result = HostRunResult(
+                        "invalid", f"custody record {rel} modified during "
+                                   f"the mission (detected on exit)")
+                    break
             # Credential nonretention on EVERY exit path (independent review
             # blocking): the run-root raw host output is scrubbed and the
             # terminal detail is redacted regardless of kind — a host that

--- a/eval/hosts.py
+++ b/eval/hosts.py
@@ -54,6 +54,7 @@ Shared guarantees (mock-tested in eval/test_hosts.py; NO live mission in CI):
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -114,6 +115,26 @@ def _parse_ts(s):
     try:
         return datetime.fromisoformat(s.replace("Z", "+00:00"))
     except ValueError:
+        return None
+
+
+
+def _read_custody_file(path, cap=4 * 1024 * 1024):
+    """Bounded, special-file-safe read for exit-time custody verification:
+    only a REGULAR, non-symlink file up to `cap` bytes is readable — a
+    mission that swapped a custody record for a FIFO/symlink/device must
+    yield a hash mismatch, never a blocked or unbounded read."""
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return None
+    import stat as _stat
+    if not _stat.S_ISREG(st.st_mode) or st.st_size > cap:
+        return None
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(cap + 1)
+    except OSError:
         return None
 
 
@@ -274,7 +295,10 @@ def _kill_tree(proc, job=None):
             os.killpg(pgid, 0)
             note = "killpg-descendants-unverified"
         except OSError:
-            note = "tree-verified-dead"
+            # HONEST LABEL: killpg(0) proves the process GROUP is empty; a
+            # descendant that called setsid() left the group and is not
+            # covered (platform-limited; cgroup containment is v0.3.3.0).
+            note = "process-group-verified-dead"
     else:
         note = "no-own-process-group"
     try:
@@ -307,10 +331,20 @@ def _spawn_once(argv, env, cwd, timeout_s, stdin_text=None, on_started=None):
         try:
             job = _WinJob()
             job.assign(proc)
-        except OSError:
+        except OSError as exc:
+            # FAIL CLOSED (independent review): a Windows mission without
+            # job-object tree ownership cannot be verifiably terminated —
+            # do not run it. (The sub-ms window between CreateProcess and
+            # assignment is a documented residual; assignment FAILURE is
+            # not tolerated.)
             if job is not None:
                 job.close()
-            job = None  # taskkill /T fallback still applies on timeout
+            note = _kill_tree(proc, None)
+            proc.communicate()
+            return HostRunResult(
+                "error", f"job-object ownership unavailable ({exc}); "
+                         f"refusing to run without verifiable tree "
+                         f"termination (kill: {note})")
     try:
         if on_started is not None:
             try:
@@ -465,7 +499,15 @@ class _BaseAdapter:
                                   sort_keys=True).encode("utf-8")
         with open(os.path.join(claiming, "run-intent.json"), "xb") as fh:
             fh.write(intent_bytes)
-        os.rename(claiming, run_root)  # atomic claim: intent + root together
+        # Atomic claim. Residual TOCTOU (POSIX rename replaces an EMPTY
+        # dst dir created between the lexists check and here) is accepted:
+        # custody is single-orchestrator with serialized lanes and no
+        # mission process is alive during the claim; the create-once
+        # .claiming dir already collides duplicate claims of the same id.
+        os.rename(claiming, run_root)
+        if not os.path.isfile(os.path.join(run_root, "run-intent.json")):
+            raise framework.custody.CustodyError(
+                f"claim postcondition failed: no intent at {run_root!r}")
         # Custody-record integrity: a Config-O mission process has no OS
         # filesystem jail (canary-proven), so it could rewrite its own
         # custody records mid-run. Hash them at write time and re-verify on
@@ -481,6 +523,41 @@ class _BaseAdapter:
                     "formal run without an attested product checkout — "
                     "zero identities are not a valid fallback for scored "
                     "evidence; INVALID before spawn")
+            if self.formal:
+                # PRE-SPAWN ATTESTATION (independent review): presence of a
+                # path is not attestation. Pin the checkout's payload hash
+                # (raises → INVALID on a bogus/non-payload dir) and its git
+                # commit into a create-once custody record BEFORE spawn.
+                try:
+                    att_payload = framework.payload_hash(
+                        self.product_checkout)
+                except Exception as exc:
+                    raise framework.AdapterError(
+                        f"product checkout unattestable "
+                        f"({exc!r}) — INVALID before spawn")
+                if att_payload == hashlib.sha256().hexdigest():
+                    raise framework.AdapterError(
+                        "product checkout unattestable (empty payload "
+                        "tree) — INVALID before spawn")
+                try:
+                    att_commit = subprocess.run(
+                        ["git", "-C", self.product_checkout, "rev-parse",
+                         "HEAD"], capture_output=True, text=True,
+                        timeout=30).stdout.strip() or None
+                except Exception:
+                    att_commit = None
+                att_bytes = json.dumps(
+                    {"schema": "implementaudit-product-attestation-v1",
+                     "run_id": run_id, "path": self.product_checkout,
+                     "payload_sha256": att_payload,
+                     "git_commit": att_commit, "attested_at": _utc_now()},
+                    indent=1, sort_keys=True).encode("utf-8")
+                with open(os.path.join(run_root,
+                                       "product-attestation.json"),
+                          "xb") as fh:
+                    fh.write(att_bytes)
+                self._custody_hashes["product-attestation.json"] = \
+                    bundlelib._sha256_bytes(att_bytes)
             need = set(fx.get("required_capabilities", []))
             missing = sorted(need - set(self.capabilities))
             if missing:
@@ -529,6 +606,31 @@ class _BaseAdapter:
                                   self.host_cwd or repo, self.timeout_s,
                                   stdin_text=mission,
                                   on_started=_on_started)
+            # FORGED-CUSTODY SWEEP (independent review blocking): the
+            # mission process is dead now; anything in the run root beyond
+            # what THIS adapter wrote pre-spawn was planted by the mission
+            # (jail-less Config-O can reach custody). A precreated
+            # terminal.json or bundle/ would otherwise become authoritative
+            # (terminal "x" would hit FileExistsError and the forged record
+            # would survive; the scorer would read forged evidence).
+            # Quarantine every unexpected entry and terminalize INVALID.
+            allowed_now = {"run-intent.json", "process-started.json",
+                           "product-attestation.json"}
+            planted = sorted(set(os.listdir(run_root)) - allowed_now)
+            if planted:
+                qdir = os.path.join(run_root, "quarantine-planted")
+                os.makedirs(qdir, exist_ok=True)
+                for n in planted:
+                    try:
+                        os.replace(os.path.join(run_root, n),
+                                   os.path.join(qdir, n))
+                    except OSError:
+                        pass
+                raise framework.AdapterError(
+                    f"mission planted {len(planted)} unexpected entr"
+                    f"{'y' if len(planted) == 1 else 'ies'} in the run "
+                    f"root ({', '.join(planted[:4])}) — quarantined; "
+                    f"INVALID")
             # Preserve the raw host stdout/stderr at the RUN ROOT immediately
             # — for BOTH the nonzero-exit/timeout error path and the normal
             # path — so no INVALID/ERROR classification ever destroys the
@@ -629,7 +731,9 @@ class _BaseAdapter:
                 hits.append(h1)
             h2 = self._quarantine_if_leak(
                 run_root, "quarantine-raw",
-                only=("host-stdout.raw", "host-stderr.raw"))
+                only=("host-stdout.raw", "host-stderr.raw",
+                      "run-intent.json", "process-started.json",
+                      "product-attestation.json"))
             if h2:
                 hits.append(h2)
             if hits:
@@ -639,11 +743,9 @@ class _BaseAdapter:
                     f"violation ({len(hits)} location(s) scrubbed)")
             for rel, want in (getattr(self, "_custody_hashes", None)
                               or {}).items():
-                try:
-                    got = bundlelib._sha256_bytes(
-                        open(os.path.join(run_root, rel), "rb").read())
-                except OSError:
-                    got = None
+                data = _read_custody_file(os.path.join(run_root, rel))
+                got = (bundlelib._sha256_bytes(data)
+                       if data is not None else None)
                 if got != want:
                     raise framework.AdapterError(
                         f"custody record {rel} modified during the "
@@ -683,11 +785,9 @@ class _BaseAdapter:
             # before the run terminalizes.
             for rel, want in (getattr(self, "_custody_hashes", None)
                               or {}).items():
-                try:
-                    got = bundlelib._sha256_bytes(
-                        open(os.path.join(run_root, rel), "rb").read())
-                except OSError:
-                    got = None
+                data = _read_custody_file(os.path.join(run_root, rel))
+                got = (bundlelib._sha256_bytes(data)
+                       if data is not None else None)
                 if got != want:
                     result = HostRunResult(
                         "invalid", f"custody record {rel} modified during "
@@ -701,7 +801,9 @@ class _BaseAdapter:
             try:
                 self._quarantine_if_leak(
                     run_root, "quarantine-raw",
-                    only=("host-stdout.raw", "host-stderr.raw"))
+                    only=("host-stdout.raw", "host-stderr.raw",
+                      "run-intent.json", "process-started.json",
+                      "product-attestation.json"))
             except Exception:
                 pass
             term = {"schema": "implementaudit-run-terminal-v1",

--- a/eval/reconcile.py
+++ b/eval/reconcile.py
@@ -50,6 +50,136 @@ def _pid_alive(pid):
         return False
 
 
+def host_os_name():
+    """Coarse host lane OS name recorded in / compared against
+    process-started.json ('windows' | 'posix')."""
+    return "windows" if os.name == "nt" else "posix"
+
+
+def host_boot_id():
+    """Stable-within-a-boot host identifier; None when unavailable.
+    Linux: the kernel boot_id. Windows: the boot epoch derived from
+    GetTickCount64, rounded to whole minutes (compared with +/-1 tolerance
+    to absorb clock slew at a minute boundary)."""
+    if os.name == "posix":
+        try:
+            return open("/proc/sys/kernel/random/boot_id",
+                        encoding="ascii").read().strip()
+        except OSError:
+            return None
+    try:
+        import ctypes
+        import time as _t
+        ticks = int(ctypes.windll.kernel32.GetTickCount64())
+        boot_ms = int(_t.time() * 1000) - ticks
+        return "winboot-" + str(int(round(boot_ms / 60000.0)))
+    except Exception:
+        return None
+
+
+def process_creation_time(pid):
+    """Absolute UTC epoch seconds when `pid` was created; None if unknown.
+    This is the identity field that distinguishes a RECYCLED pid from the
+    original process: a recycled pid has a different creation time.
+    Linux: /proc/stat btime + /proc/<pid>/stat field 22 / CLK_TCK
+    (absolute, so stable across reads within one boot).
+    Windows: GetProcessTimes creation FILETIME (absolute UTC)."""
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    if os.name == "posix":
+        try:
+            stat = open("/proc/%d/stat" % pid, "rb").read().decode("latin-1")
+            # comm may contain spaces/parens; fields resume after last ')'
+            rest = stat[stat.rindex(")") + 2:].split()
+            start_jiffies = int(rest[19])          # overall field 22
+            hz = os.sysconf("SC_CLK_TCK") or 100
+            btime = None
+            for ln in open("/proc/stat", encoding="ascii", errors="replace"):
+                if ln.startswith("btime "):
+                    btime = int(ln.split()[1])
+                    break
+            if btime is None:
+                return None
+            return round(btime + start_jiffies / float(hz), 2)
+        except Exception:
+            return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+        k32 = ctypes.windll.kernel32
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        h = k32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not h:
+            return None
+        try:
+            times = [wintypes.FILETIME() for _ in range(4)]
+            if not k32.GetProcessTimes(h, *[ctypes.byref(t) for t in times]):
+                return None
+            ft = (times[0].dwHighDateTime << 32) | times[0].dwLowDateTime
+            # FILETIME epoch 1601-01-01 UTC in 100ns units
+            return round(ft / 1e7 - 11644473600.0, 2)
+        finally:
+            k32.CloseHandle(h)
+    except Exception:
+        return None
+
+
+def process_identity(pid, lane_id=None):
+    """The identity record written into process-started.json at spawn."""
+    return {"lane_id": lane_id or host_os_name(),
+            "host_os": host_os_name(),
+            "host_boot_id": host_boot_id(),
+            "pid": pid,
+            "process_creation_time": process_creation_time(pid)}
+
+
+def _boot_ids_match(recorded, current):
+    if recorded == current:
+        return True
+    try:
+        if (str(recorded).startswith("winboot-")
+                and str(current).startswith("winboot-")):
+            return abs(int(str(recorded)[8:]) - int(str(current)[8:])) <= 1
+    except ValueError:
+        pass
+    return False
+
+
+def original_process_alive(started):
+    """(alive, reason) — True ONLY when the recorded process identity
+    provably matches a currently live process. A recycled pid, a
+    foreign-OS-lane pid, a reboot, or any missing/unreadable identity
+    field is NEVER 'alive': the reconciler must not keep a run open on a
+    pid number alone (release campaign crash lesson, v0.3.2.0)."""
+    rec_os = started.get("host_os")
+    if rec_os is not None and rec_os != host_os_name():
+        # A KNOWN different lane OS: the pid namespace differs, so local
+        # liveness checks are meaningless. (A legacy record with no
+        # host_os falls through to the identity checks below instead.)
+        return False, "foreign-lane: recorded host_os %r, reconciling on %r" \
+            % (rec_os, host_os_name())
+    pid = started.get("pid")
+    if not _pid_alive(pid):
+        return False, "process dead"
+    rec_ct = started.get("process_creation_time")
+    if rec_ct is None:
+        return False, "no recorded process_creation_time — identity " \
+                      "unverifiable, not treated as the original process"
+    cur_ct = process_creation_time(pid)
+    if cur_ct is None:
+        return False, "live pid identity unreadable — not treated as the " \
+                      "original process"
+    if abs(cur_ct - rec_ct) > 2.0:
+        return False, "pid recycled: creation time %r != recorded %r" \
+            % (cur_ct, rec_ct)
+    rec_boot = started.get("host_boot_id")
+    cur_boot = host_boot_id()
+    if rec_boot and cur_boot and not _boot_ids_match(rec_boot, cur_boot):
+        return False, "boot id mismatch: %r != recorded %r" \
+            % (cur_boot, rec_boot)
+    return True, "alive"
+
+
 def _write_terminal(run_root, record):
     """Create-once terminal write; a conflict is surfaced, never silent."""
     path = os.path.join(run_root, "terminal.json")
@@ -76,6 +206,26 @@ def reconcile_custody(custody_root):
             continue
         intent_p = os.path.join(run_root, "run-intent.json")
         term_p = os.path.join(run_root, "terminal.json")
+        if name.endswith(".claiming"):
+            # Orphan claim staging dir: the adapter crashed between creating
+            # the staging dir and atomically renaming it to the final run
+            # root. It never became a claimed run — terminally classify it
+            # (never silently ignore), keyed by the intended run id.
+            if os.path.isfile(term_p):
+                continue
+            intended = name[:-len(".claiming")]
+            rec = {"schema": "implementaudit-run-terminal-v1",
+                   "run_id": intended, "reconciled": True,
+                   "resolved_model": None, "policy_resolved": {},
+                   "kind": "error", "spawned": False,
+                   "detail": "orphan-claim-swept: staging dir never renamed "
+                             "to a claimed run root (intent %s)"
+                             % ("present" if os.path.isfile(intent_p)
+                                else "absent")}
+            results.append({"run_id": intended,
+                            "disposition": "orphan-claim-swept",
+                            "write": _write_terminal(run_root, rec)})
+            continue
         if not os.path.isfile(intent_p) or os.path.isfile(term_p):
             continue
         base = {"schema": "implementaudit-run-terminal-v1", "run_id": name,
@@ -94,10 +244,20 @@ def reconcile_custody(custody_root):
             started = json.load(open(started_p, encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             started = {}
-        pid = started.get("pid")
-        if _pid_alive(pid):
+        alive, why = original_process_alive(started)
+        if alive:
             results.append({"run_id": name, "disposition": "running",
                             "write": "none"})
+            continue
+        if why.startswith("foreign-lane"):
+            # A pid from another OS lane cannot be adjudicated here at all
+            # (different pid namespace): classify truthfully rather than
+            # guessing liveness from an unrelated same-numbered process.
+            base.update({"kind": "error", "spawned": True,
+                         "detail": "terminal-state-unverified: " + why})
+            results.append({"run_id": name,
+                            "disposition": "terminal-state-unverified",
+                            "write": _write_terminal(run_root, base)})
             continue
         # dead process: is there host terminal evidence (a sealed bundle)?
         bundle_manifest = os.path.join(run_root, "bundle", "manifest.json")
@@ -114,8 +274,8 @@ def reconcile_custody(custody_root):
             continue
         base.update({"kind": "error", "spawned": True,
                      "detail": "terminal-state-unverified: bound process is "
-                               "dead and no terminal or bundle evidence "
-                               "exists"})
+                               "not verifiably the original (%s) and no "
+                               "terminal or bundle evidence exists" % why})
         results.append({"run_id": name,
                         "disposition": "terminal-state-unverified",
                         "write": _write_terminal(run_root, base)})

--- a/eval/reconcile.py
+++ b/eval/reconcile.py
@@ -162,14 +162,17 @@ def original_process_alive(started):
     if not _pid_alive(pid):
         return False, "process dead"
     rec_ct = started.get("process_creation_time")
-    if rec_ct is None:
+    if not isinstance(rec_ct, (int, float)):
         return False, "no recorded process_creation_time — identity " \
                       "unverifiable, not treated as the original process"
     cur_ct = process_creation_time(pid)
     if cur_ct is None:
         return False, "live pid identity unreadable — not treated as the " \
                       "original process"
-    if abs(cur_ct - rec_ct) > 2.0:
+    # 1.0s absorbs representation jitter (POSIX btime can slew under NTP)
+    # while keeping the recycled-pid coincidence window minimal — both
+    # reads come from the same kernel source for the same live pid.
+    if abs(cur_ct - rec_ct) > 1.0:
         return False, "pid recycled: creation time %r != recorded %r" \
             % (cur_ct, rec_ct)
     rec_boot = started.get("host_boot_id")
@@ -204,6 +207,17 @@ def reconcile_custody(custody_root):
         run_root = os.path.join(custody_root, name)
         if not os.path.isdir(run_root):
             continue
+        try:
+            results.extend(_reconcile_one(name, run_root))
+        except Exception as exc:  # per-dir contract: never raises
+            results.append({"run_id": name, "disposition": "reconcile-error",
+                            "write": "none", "detail": repr(exc)[:200]})
+    return results
+
+
+def _reconcile_one(name, run_root):
+    results = []
+    for _ in (0,):  # single pass; body uses `continue` as early-exit
         intent_p = os.path.join(run_root, "run-intent.json")
         term_p = os.path.join(run_root, "terminal.json")
         if name.endswith(".claiming"):
@@ -243,6 +257,11 @@ def reconcile_custody(custody_root):
         try:
             started = json.load(open(started_p, encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
+            started = {}
+        if not isinstance(started, dict):
+            # a rewritten/garbage record must yield a truthful terminal
+            # disposition, never crash the reconciler (contract: never
+            # raises for an individual run dir)
             started = {}
         alive, why = original_process_alive(started)
         if alive:

--- a/eval/test_hosts.py
+++ b/eval/test_hosts.py
@@ -790,6 +790,79 @@ def main():
         check("H37 real-codex-refuses-stdout-transcript",
               r37.kind == "invalid"
               and "refusing to score raw stdout" in str(r37.detail))
+
+        # 38. forged-custody sweep: a mission that PLANTS terminal.json /
+        # bundle/ in its own run root (jail-less Config-O) must be
+        # quarantined and terminalize INVALID — the adapter's own terminal
+        # record must win, never the forged one.
+        real_spawn38 = hosts._spawn_once
+
+        def _planting_spawn(argv, env, cwd, timeout_s, **kw):
+            out = real_spawn38(argv, env, cwd, timeout_s, **kw)
+            rr = os.path.join(tmp, "custody", "r-h38")
+            json.dump({"kind": "ok", "reconciled": False, "forged": True},
+                      open(os.path.join(rr, "terminal.json"), "w"))
+            os.makedirs(os.path.join(rr, "bundle"))
+            json.dump({"forged": True},
+                      open(os.path.join(rr, "bundle", "manifest.json"), "w"))
+            return out
+
+        hosts._spawn_once = _planting_spawn
+        try:
+            r38 = run(make_adapter(tmp, "ok-codex",
+                                   home=os.path.join(tmp, "codex-home-h38")),
+                      tmp, "r-h38")
+        finally:
+            hosts._spawn_once = real_spawn38
+        rr38 = os.path.join(tmp, "custody", "r-h38")
+        t38 = json.load(open(os.path.join(rr38, "terminal.json"),
+                             encoding="utf-8"))
+        check("H38 planted-custody-quarantined-INVALID",
+              r38.kind == "invalid" and "planted" in str(r38.detail)
+              and t38.get("forged") is None
+              and t38.get("kind") == "invalid"
+              and os.path.isfile(os.path.join(
+                  rr38, "quarantine-planted", "terminal.json"))
+              and os.path.isdir(os.path.join(
+                  rr38, "quarantine-planted", "bundle")))
+
+        # 39. pre-spawn product attestation: a formal run pins the payload
+        # hash BEFORE spawn; an unattestable checkout is INVALID with no
+        # process launched.
+        canon39 = os.path.join(tmp, "canon39")
+        os.makedirs(os.path.join(canon39, "skills", "implementaudit"))
+        open(os.path.join(canon39, "skills", "implementaudit", "SKILL.md"),
+             "w").write("payload body" + chr(10))
+        prev_ident39 = framework.product_identity
+        framework.product_identity = (
+            lambda checkout, expected_tag="v0.3.1.0": {
+                "product_tag": "v0.3.1.0", "product_commit": "x",
+                "product_tree": "y"})
+        try:
+            a39 = make_adapter(tmp, "ok-codex", checkout=canon39,
+                               home=os.path.join(tmp, "codex-home-h39"))
+            a39.formal = True
+            r39 = run(a39, tmp, "r-h39")
+        finally:
+            framework.product_identity = prev_ident39
+        att = json.load(open(os.path.join(tmp, "custody", "r-h39",
+                                          "product-attestation.json"),
+                             encoding="utf-8"))
+        check("H39 formal-prespawn-attestation",
+              r39.kind == "ok"
+              and att.get("payload_sha256")
+              == framework.payload_hash(canon39))
+        a39b = make_adapter(tmp, "ok-codex",
+                            checkout=os.path.join(tmp, "empty39"),
+                            home=os.path.join(tmp, "codex-home-h39b"))
+        os.makedirs(os.path.join(tmp, "empty39"))
+        a39b.formal = True
+        r39b = run(a39b, tmp, "r-h39b")
+        check("H39b unattestable-checkout-INVALID",
+              r39b.kind == "invalid"
+              and "unattestable" in str(r39b.detail)
+              and not os.path.isfile(os.path.join(
+                  tmp, "custody", "r-h39b", "process-started.json")))
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     if failures:

--- a/eval/test_hosts.py
+++ b/eval/test_hosts.py
@@ -92,6 +92,11 @@ elif scenario == "substituted-codex":
 elif scenario == "no-provenance":
     write_session(omit_model=True, agent_msgs=["output text"])
     print(json.dumps({"type": "agent_message", "message": "output text"}))
+elif scenario == "stdout-only":
+    # NO session file at all: raw stdout is the only "transcript" — a real
+    # codex lane must refuse to score it (forgeable echo).
+    print("IMPLEMENTAUDIT_PHASE_START p1")
+    print("IMPLEMENTAUDIT_RUN_COMPLETE")
 elif scenario == "wrong-effort":
     write_session(effort="low", agent_msgs=["output text"])
     print(json.dumps({"type": "agent_message", "message": "output text"}))
@@ -164,12 +169,12 @@ def make_adapter(tmp, scenario, kind="codex", counter=None, checkout=None,
     if kind == "codex":
         a = hosts.CodexAdapter(
             codex_home=home or os.path.join(tmp, "codex-home"),
-            product_checkout=checkout)
+            product_checkout=checkout, formal=False)
         os.makedirs(a.codex_home, exist_ok=True)
         a.preflight = lambda: None  # version/auth gates unit-tested below
     else:
         a = hosts.ClaudeAdapter(config_dir=os.path.join(tmp, "claude-cfg"),
-                                product_checkout=checkout)
+                                product_checkout=checkout, formal=False)
         os.makedirs(a.config_dir, exist_ok=True)
     a.host_argv_template = argv
     a.timeout_s = 5
@@ -403,7 +408,7 @@ def main():
             json.dump({"run_id": name},
                       open(os.path.join(d, "run-intent.json"), "w"))
             if started is not None:
-                json.dump({"pid": started},
+                json.dump(reconcilelib.process_identity(started),
                           open(os.path.join(d, "process-started.json"),
                                "w"))
             if bundle:
@@ -542,7 +547,8 @@ def main():
 
             def post_checks(self, out):
                 pass
-        rl = _RawLeak(codex_home=os.path.join(tmp, "codex-home-26b"))
+        rl = _RawLeak(codex_home=os.path.join(tmp, "codex-home-26b"),
+                      formal=False)
         os.makedirs(rl.codex_home, exist_ok=True)
         mock = os.path.join(tmp, "mock_host.py")
         rl.host_argv_template = [sys.executable, "-c",
@@ -605,6 +611,185 @@ def main():
             status, verd = runner.score_bundle(r.detail, repo_dir=None)
             ok = ok and status in ("PASS", "FAIL")
         check("H28 e5-live-host-observation", ok)
+
+        # 30. process identity recorded at spawn: process-started.json must
+        # carry every field the reconciler compares (lane/os/boot/pid/
+        # creation time) — pid alone can be recycled.
+        a30 = make_adapter(tmp, "ok-codex",
+                           home=os.path.join(tmp, "codex-home-h30"))
+        a30.lane_id = "test-lane-h30"
+        r = run(a30, tmp, "r-h30")
+        ps = json.load(open(os.path.join(tmp, "custody", "r-h30",
+                                         "process-started.json"),
+                            encoding="utf-8"))
+        check("H30 process-identity-recorded",
+              r.kind == "ok" and ps.get("lane_id") == "test-lane-h30"
+              and ps.get("host_os") == reconcilelib.host_os_name()
+              and ps.get("host_boot_id")
+              and isinstance(ps.get("pid"), int)
+              and isinstance(ps.get("process_creation_time"), float))
+
+        # 31. recycled-pid refusal: an intent bound to a LIVE pid whose
+        # recorded creation time does not match the live process must NOT
+        # stay open as 'running' — it terminalizes truthfully.
+        rr31 = os.path.join(tmp, "custody", "r-h31")
+        os.makedirs(rr31)
+        json.dump({"run_id": "r-h31"},
+                  open(os.path.join(rr31, "run-intent.json"), "w"))
+        json.dump({"run_id": "r-h31", "pid": os.getpid(),
+                   "host_os": reconcilelib.host_os_name(),
+                   "host_boot_id": reconcilelib.host_boot_id(),
+                   "process_creation_time": 12345.0},
+                  open(os.path.join(rr31, "process-started.json"), "w"))
+        out31 = reconcilelib.reconcile_custody(os.path.join(tmp, "custody"))
+        d31 = {o["run_id"]: o["disposition"] for o in out31}
+        t31 = json.load(open(os.path.join(rr31, "terminal.json"),
+                             encoding="utf-8"))
+        check("H31 recycled-pid-not-running",
+              d31.get("r-h31") == "terminal-state-unverified"
+              and t31.get("reconciled") is True
+              and "recycled" in t31.get("detail", ""))
+
+        # 31b. matching identity IS running: same live pid with the TRUE
+        # creation time stays open (no terminal write).
+        rr31b = os.path.join(tmp, "custody", "r-h31b")
+        os.makedirs(rr31b)
+        json.dump({"run_id": "r-h31b"},
+                  open(os.path.join(rr31b, "run-intent.json"), "w"))
+        json.dump({"run_id": "r-h31b", "pid": os.getpid(),
+                   "host_os": reconcilelib.host_os_name(),
+                   "host_boot_id": reconcilelib.host_boot_id(),
+                   "process_creation_time":
+                       reconcilelib.process_creation_time(os.getpid())},
+                  open(os.path.join(rr31b, "process-started.json"), "w"))
+        out31b = reconcilelib.reconcile_custody(os.path.join(tmp, "custody"))
+        d31b = {o["run_id"]: o["disposition"] for o in out31b}
+        check("H31b matching-identity-running",
+              d31b.get("r-h31b") == "running"
+              and not os.path.isfile(os.path.join(rr31b, "terminal.json")))
+        try:
+            os.remove(os.path.join(rr31b, "run-intent.json"))
+        except OSError:
+            pass
+
+        # 32. foreign-lane pid: a recorded host_os from the OTHER lane can
+        # never be adjudicated as alive here (different pid namespace).
+        rr32 = os.path.join(tmp, "custody", "r-h32")
+        os.makedirs(rr32)
+        json.dump({"run_id": "r-h32"},
+                  open(os.path.join(rr32, "run-intent.json"), "w"))
+        other = "posix" if reconcilelib.host_os_name() == "windows" \
+            else "windows"
+        json.dump({"run_id": "r-h32", "pid": os.getpid(),
+                   "host_os": other, "host_boot_id": "x",
+                   "process_creation_time": 1.0},
+                  open(os.path.join(rr32, "process-started.json"), "w"))
+        out32 = reconcilelib.reconcile_custody(os.path.join(tmp, "custody"))
+        d32 = {o["run_id"]: o["disposition"] for o in out32}
+        t32 = json.load(open(os.path.join(rr32, "terminal.json"),
+                             encoding="utf-8"))
+        check("H32 foreign-lane-pid-unverified",
+              d32.get("r-h32") == "terminal-state-unverified"
+              and "foreign-lane" in t32.get("detail", ""))
+
+        # 33. orphan claim sweep: a crash between staging-dir creation and
+        # the atomic rename leaves `<id>.claiming`; the reconciler must
+        # terminally classify it, never silently ignore it.
+        rr33 = os.path.join(tmp, "custody", "r-h33.claiming")
+        os.makedirs(rr33)
+        out33 = reconcilelib.reconcile_custody(os.path.join(tmp, "custody"))
+        d33 = {o["run_id"]: o["disposition"] for o in out33}
+        t33 = json.load(open(os.path.join(rr33, "terminal.json"),
+                             encoding="utf-8"))
+        check("H33 orphan-claim-swept",
+              d33.get("r-h33") == "orphan-claim-swept"
+              and t33.get("reconciled") is True
+              and t33.get("spawned") is False)
+
+        # 34. formal-run checkout attestation: a formal adapter without a
+        # product checkout is INVALID before spawn (no process launched).
+        a34 = make_adapter(tmp, "ok-codex",
+                           home=os.path.join(tmp, "codex-home-h34"))
+        a34.formal = True  # declared formal, but no product_checkout
+        r34 = run(a34, tmp, "r-h34")
+        check("H34 formal-run-requires-checkout",
+              r34.kind == "invalid" and "attested product checkout"
+              in str(r34.detail)
+              and not os.path.isfile(os.path.join(
+                  tmp, "custody", "r-h34", "process-started.json")))
+
+        # 35. tree kill on timeout: the host spawns a GRANDCHILD sleeper
+        # and then blocks past the timeout; after timeout handling neither
+        # the child nor the grandchild may survive.
+        killmock = os.path.join(tmp, "kill_mock.py")
+        open(killmock, "w", encoding="utf-8").write(
+            "import os, subprocess, sys, time\n"
+            "gc = subprocess.Popen([sys.executable, '-c',\n"
+            "                       'import time; time.sleep(120)'])\n"
+            "open(sys.argv[1], 'w').write(str(gc.pid))\n"
+            "time.sleep(120)\n")
+        gcpid_file = os.path.join(tmp, "grandchild.pid")
+        a35 = make_adapter(tmp, "ok-codex",
+                           home=os.path.join(tmp, "codex-home-h35"))
+        a35.host_argv_template = [sys.executable, killmock, gcpid_file]
+        a35.timeout_s = 3
+        r35 = run(a35, tmp, "r-h35")
+        gcpid = int(open(gcpid_file).read().strip())
+        deadline = 10.0
+        import time as _t
+        while deadline > 0 and reconcilelib._pid_alive(gcpid):
+            _t.sleep(0.2)
+            deadline -= 0.2
+        gc_dead = not reconcilelib._pid_alive(gcpid)
+        check("H35 timeout-kills-process-tree",
+              r35.kind == "error" and "timeout" in str(r35.detail)
+              and gc_dead)
+        if not gc_dead:  # never leak a sleeper on failure
+            try:
+                subprocess.run(["taskkill", "/PID", str(gcpid), "/F"]
+                               if os.name == "nt"
+                               else ["kill", "-9", str(gcpid)],
+                               capture_output=True, timeout=15)
+            except Exception:
+                pass
+
+        # 36. custody-record integrity: a mission that rewrites its own
+        # run-intent.json (possible under jail-less Config-O — canary
+        # finding) must terminalize INVALID, on every exit path.
+        real_spawn = hosts._spawn_once
+
+        def _tampering_spawn(argv, env, cwd, timeout_s, **kw):
+            out = real_spawn(argv, env, cwd, timeout_s, **kw)
+            ip = os.path.join(tmp, "custody", "r-h36", "run-intent.json")
+            body = json.load(open(ip, encoding="utf-8"))
+            body["model_requested"] = "forged-model"
+            json.dump(body, open(ip, "w", encoding="utf-8"))
+            return out
+
+        hosts._spawn_once = _tampering_spawn
+        try:
+            r36 = run(make_adapter(tmp, "ok-codex",
+                                   home=os.path.join(tmp, "codex-home-h36")),
+                      tmp, "r-h36")
+        finally:
+            hosts._spawn_once = real_spawn
+        t36 = json.load(open(os.path.join(tmp, "custody", "r-h36",
+                                          "terminal.json"),
+                             encoding="utf-8"))
+        check("H36 custody-record-tamper-INVALID",
+              r36.kind == "invalid"
+              and "custody record run-intent.json modified"
+              in str(r36.detail) and t36.get("kind") == "invalid")
+
+        # 37. structured-event authority: a REAL codex lane (temp
+        # CODEX_HOME) whose host recorded NO session agent messages must
+        # refuse to score raw stdout — echoed text can forge markers.
+        r37 = run(make_adapter(tmp, "stdout-only",
+                               home=os.path.join(tmp, "codex-home-h37")),
+                  tmp, "r-h37")
+        check("H37 real-codex-refuses-stdout-transcript",
+              r37.kind == "invalid"
+              and "refusing to score raw stdout" in str(r37.detail))
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     if failures:


### PR DESCRIPTION
Closes #20.

Fable 5 recovery re-adjudication of the v0.3.3.0 backlog promoted these to release-critical after the real campaign crashed and was crash-reconciled. All deterministic suites green locally (selftest, host H1–H37, adapters, adversarial); no model calls in tests.

**Changes** (eval/hosts.py, eval/reconcile.py, eval/test_hosts.py; +612/−34):
- `process-started.json` schema v2 with full process identity; identity-gated reconciliation (recycled pid / foreign lane / reboot / identity-less → never 'running')
- Windows Job Object tree termination with post-kill `ActiveProcesses==0` verification; POSIX own-session `killpg` with verification; grandchild-reap proven by test
- Atomic run claim via `<run_id>.claiming` + rename; reconciler terminally sweeps orphaned claim dirs
- Formal runs require an attested product checkout before spawn; mocks declare `formal=False`
- Real-codex structured-event authority test-locked
- NEW custody-record integrity guard (canary-proven Config-O out-of-root write): custody records hashed at write, re-verified on all exit paths, tamper → INVALID

🤖 Generated with [Claude Code](https://claude.com/claude-code)