### PR TITLE
PROTOCOL: long-running/background command contract (#2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Run focused behavior tests
         run: |
           bash tests/andon-class-contract.test.sh
+          bash tests/background-chain-contract.test.sh
           bash tests/evidence-anchoring.test.sh
           bash tests/marker-order.test.sh
           bash tests/planner-stages.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ### Added
 
+- Long-running/background command contract (#2): new PROTOCOL section —
+  detached launch with `launch-intent.md`, append-only
+  `chain-status.txt`, `chain.done` completion marker; state model
+  running / succeeded / failed / aborted / terminal-state-unverified /
+  contaminated / infrastructure-failed; a missing completion record is
+  never a failure verdict; aborts kill only the owned tree and record
+  possible sibling contamination; infrastructure signatures ground
+  SUSPICION only — producer countermeasures are prohibited until origin
+  is classified. SKILL.md pointer added; six state-transition fixtures
+  in `tests/background-chain-contract.test.sh`.
+
 - Evidence-version anchoring (#4): `detect-env.sh` Stage-0 output now
   names `head=<short-sha> (<committer-date>)`, `upstream=<ref>
   behind_ahead=<L/R>` or `upstream=none`, and

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -196,6 +196,7 @@ require_file fixtures/lean/sidecar-graphify-absent-markdown-fallback.md
 require_file fixtures/lean/sidecar-graphify-dmaic-analyze.md
 require_file fixtures/lean/sidecar-activegraph-dmaic-custody.md
 require_file tests/andon-class-contract.test.sh
+require_file tests/background-chain-contract.test.sh
 require_file tests/evidence-anchoring.test.sh
 require_file tests/marker-order.test.sh
 require_file tests/planner-stages.test.sh
@@ -514,6 +515,7 @@ bash scripts/check-terminology-integration.sh
 bash scripts/check-added-lines-clean.sh HEAD
 bash tests/lean-discipline.test.sh
 bash tests/andon-class-contract.test.sh
+bash tests/background-chain-contract.test.sh
 bash tests/evidence-anchoring.test.sh
 bash tests/marker-order.test.sh
 bash tests/planner-stages.test.sh

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -329,6 +329,11 @@ Hansei records gap, cause, countermeasure, and follow-up evidence. 5 Whys is
 for root cause, not loops. Poka-yoke means structural prevention through
 checkers, fixtures, templates, or durable AGENTS rules.
 
+Commands expected to outlive host tool timeouts follow the PROTOCOL
+"Long-running and background commands" contract (detached launch,
+chain-status.txt + chain.done markers, owned-tree abort containment,
+terminal-state-unverified when the completion marker is absent).
+
 ---
 
 ## Trace And Closure

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -280,6 +280,38 @@ When resuming after interruption:
 4. Do not re-print IMPLEMENTAUDIT_PHASE_START; it was already printed.
 5. Continue from the paused step, not from Step 1.
 
+### Long-running and background commands
+
+A command expected to outlive the host tool timeout is launched DETACHED
+with a durable status contract, never awaited inline:
+
+1. Before launch, write `<run-root>/background/<chain-id>/launch-intent.md`
+   (command, owner/source, expected completion marker, abort containment
+   plan). Launch detached; append one line per observed state change to
+   `<chain-id>/chain-status.txt`; the command's last act is creating
+   `<chain-id>/chain.done` (the completion marker).
+2. State model — exactly one terminal token per chain, recorded in
+   `chain-status.txt`: `running`, `succeeded` (exit recorded + `chain.done`
+   present), `failed` (nonzero exit recorded + `chain.done` present),
+   `aborted` (operator kill of the OWNED process tree only, recorded),
+   `terminal-state-unverified` (no completion marker — NEVER reported as
+   failed and NEVER as passed), `contaminated` (an abort or crash may have
+   affected sibling lanes; name the siblings), `infrastructure-failed`
+   (classified `transport-infrastructure` per the abnormality classes).
+3. A missing completion record is not a failure verdict: the chain is
+   `terminal-state-unverified` until origin is classified with recorded
+   evidence.
+4. Abort containment: an abort kills only the chain's OWNED process tree.
+   If containment cannot be proven, record `contaminated` on every sibling
+   that shared resources, and treat their in-flight results as
+   non-evidence.
+5. Infrastructure signatures (cross-lane simultaneous fast-fail,
+   process-init exit codes such as 0xC0000142, known outage windows) are
+   grounds to SUSPECT infrastructure, not proof: origin classification with
+   recorded evidence comes first, and producer countermeasures are
+   PROHIBITED until the run's origin is classified — a lane inside an
+   outage window may still be a genuine producer failure.
+
 ## Nemawashi — owner-decision gate
 
 Before Stage 7 handoff (or before dispatching any phase that crosses a

--- a/tests/background-chain-contract.test.sh
+++ b/tests/background-chain-contract.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Long-running/background command contract (#2): the PROTOCOL section, the
+# SKILL.md pointer, the state vocabulary, and the owner-amended
+# state-transition fixtures (marker files -> resulting state token).
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+proto="skills/implementaudit/templates/PROTOCOL.md"
+skill="skills/implementaudit/SKILL.md"
+
+fail() { printf 'background-chain-contract: %s\n' "$*" >&2; exit 1; }
+
+grep -q '^### Long-running and background commands' "$proto" \
+  || fail "PROTOCOL section missing"
+for tok in running succeeded failed aborted terminal-state-unverified \
+    contaminated infrastructure-failed chain-status.txt chain.done \
+    launch-intent.md transport-infrastructure; do
+  grep -q -- "$tok" "$proto" || fail "PROTOCOL missing token: $tok"
+done
+# suspicion-not-proof amendment: producer countermeasures barred until
+# origin classification
+flat="$(tr '\n' ' ' < "$proto")"
+printf '%s' "$flat" | grep -qi 'suspect infrastructure, not proof' \
+  || fail "suspicion-not-proof rule missing"
+printf '%s' "$flat" | grep -qi 'PROHIBITED until the run.s origin is classified' \
+  || fail "producer-countermeasure prohibition missing"
+printf '%s' "$flat" | grep -qi 'missing completion record is not a failure verdict' \
+  || fail "missing-marker rule missing"
+
+grep -q 'Long-running and background commands' "$skill" \
+  || fail "SKILL.md pointer missing"
+
+# --- state-transition fixtures (owner amendment): marker files on disk ----
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# classify <chain-dir> [siblings-contaminated] -> the state token the
+# contract assigns. This is the deterministic disposition rule from the
+# PROTOCOL section, exercised as fixtures.
+classify() {
+  d="$1"
+  last="$(tail -n 1 "$d/chain-status.txt" 2>/dev/null || true)"
+  case "$last" in
+    *infrastructure-failed*) printf 'infrastructure-failed'; return ;;
+    *contaminated*)          printf 'contaminated'; return ;;
+    *aborted*)               printf 'aborted'; return ;;
+  esac
+  if [ ! -f "$d/chain.done" ]; then
+    printf 'terminal-state-unverified'; return
+  fi
+  case "$last" in
+    *"exit=0"*) printf 'succeeded' ;;
+    *"exit="*)  printf 'failed' ;;
+    *)          printf 'terminal-state-unverified' ;;
+  esac
+}
+
+mk() { mkdir -p "$tmp/$1"; printf 'cmd\n' > "$tmp/$1/launch-intent.md"; }
+
+# running -> succeeded (marker present, exit 0 recorded)
+mk ok; printf 'running\nexit=0\n' > "$tmp/ok/chain-status.txt"
+: > "$tmp/ok/chain.done"
+[ "$(classify "$tmp/ok")" = succeeded ] || fail "fixture ok != succeeded"
+
+# running -> failed (nonzero exit recorded + marker present)
+mk bad; printf 'running\nexit=3\n' > "$tmp/bad/chain-status.txt"
+: > "$tmp/bad/chain.done"
+[ "$(classify "$tmp/bad")" = failed ] || fail "fixture bad != failed"
+
+# running -> aborted (owned-tree kill recorded)
+mk ab; printf 'running\naborted owned-tree-kill pid=123\n' \
+  > "$tmp/ab/chain-status.txt"
+[ "$(classify "$tmp/ab")" = aborted ] || fail "fixture ab != aborted"
+
+# running -> terminal-state-unverified (no completion marker)
+mk tsu; printf 'running\n' > "$tmp/tsu/chain-status.txt"
+[ "$(classify "$tmp/tsu")" = terminal-state-unverified ] \
+  || fail "fixture tsu != terminal-state-unverified"
+
+# aborted -> contaminated (sibling contamination recorded)
+mk cont; printf 'running\naborted\ncontaminated siblings=lane-B\n' \
+  > "$tmp/cont/chain-status.txt"
+[ "$(classify "$tmp/cont")" = contaminated ] \
+  || fail "fixture cont != contaminated"
+
+# infrastructure-failed classification (recorded evidence, e.g. 0xC0000142)
+mk infra
+printf 'running\ninfrastructure-failed evidence=0xC0000142 cross-lane\n' \
+  > "$tmp/infra/chain-status.txt"
+[ "$(classify "$tmp/infra")" = infrastructure-failed ] \
+  || fail "fixture infra != infrastructure-failed"
+
+printf 'background-chain-contract: ok (section + vocabulary + 6 transition fixtures)\n'


### PR DESCRIPTION
Closes #2.

New PROTOCOL section (detached launch + launch-intent.md + append-only chain-status.txt + chain.done completion marker), the seven-token state model, the missing-marker rule (terminal-state-unverified — never failed, never passed), owned-tree abort containment with sibling-contamination recording, and the owner amendment (infrastructure signatures ground suspicion only; producer countermeasures prohibited until origin classification). SKILL.md pointer; six state-transition fixtures in tests/background-chain-contract.test.sh (registered both registries). Budget preserved (393/18,180). verify-package ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)