### PR TITLE
Phase specs: evidence property tags on mandatory commands (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ### Added
 
+- Evidence property tags (#3): every mandatory command in a phase spec
+  declares `property: structural|behavioral|provenance` plus a
+  plain-language scope (authorization stays a separate gate, never a
+  property). validate-phase.sh rejects invalid tags and mixed
+  tagged/untagged specs, and warns (without failing) on fully untagged
+  legacy specs; the final audit may not claim a property class no
+  command exercised; ANDON_ESCALATE asks whether the check tests the
+  property the claim needs. Shipped fixtures migrated; three new
+  validator fixtures in tests/phase-validation.test.sh.
+
 - Long-running/background command contract (#2): new PROTOCOL section —
   detached launch with `launch-intent.md`, append-only
   `chain-status.txt`, `chain.done` completion marker; state model

--- a/fixtures/e2e-mini-audit-loop/phase-1.md
+++ b/fixtures/e2e-mini-audit-loop/phase-1.md
@@ -36,8 +36,8 @@ one deliverable, and verify the deliverable against the complete working tree.
 
 ## Mandatory commands (run each; include expected success shape, surface last ~10 lines + exit code in transcript)
 
-- bash skills/implementaudit/scripts/validate-phase.sh fixtures/e2e-mini-audit-loop/phase-1.md - expected: exit 0 with `validate-phase: ok`.
-- bash .IMPLEMENTAUDIT/runs/mini/repo-state.sh deliverable <baseline> src-mini-proof.txt - expected: exit 0 with `present`.
+- bash skills/implementaudit/scripts/validate-phase.sh fixtures/e2e-mini-audit-loop/phase-1.md - property: structural; scope: spec shape only, not work correctness; expected: exit 0 with `validate-phase: ok`.
+- bash .IMPLEMENTAUDIT/runs/mini/repo-state.sh deliverable <baseline> src-mini-proof.txt - property: behavioral; scope: the deliverable file exists in the working tree after the work; expected: exit 0 with `present`.
 
 ## Evidence required in transcript
 

--- a/fixtures/phase-design/dmadv-greenfield-phase.md
+++ b/fixtures/phase-design/dmadv-greenfield-phase.md
@@ -31,8 +31,8 @@ Create docs/quickstart-fragment.md with a 4-step first-run path.
 
 ## Mandatory commands
 
-- test -s docs/quickstart-fragment.md — expected: exit 0 when the file exists and is non-empty
-- grep -c '^[0-9]\.' docs/quickstart-fragment.md — expected: outputs 4 and exits 0
+- test -s docs/quickstart-fragment.md — property: structural; scope: file exists and is non-empty, not content quality; expected: exit 0 when the file exists and is non-empty
+- grep -c '^[0-9]\.' docs/quickstart-fragment.md — property: behavioral; scope: the numbered-step count in the produced doc; expected: outputs 4 and exits 0
 
 ## Evidence required
 

--- a/fixtures/phase-validation/valid-full-spec.md
+++ b/fixtures/phase-validation/valid-full-spec.md
@@ -33,8 +33,8 @@ The audit found no settings endpoint; users cannot retrieve their preferences.
 
 ## Mandatory commands (run each; surface last ~10 lines + exit code in transcript)
 
-- npm run build — expected: exit 0 with no errors
-- npm test -- --testPathPattern=settings — expected: exit 0 with settings tests passing
+- npm run build — property: behavioral; scope: the app compiles from current sources; expected: exit 0 with no errors
+- npm test -- --testPathPattern=settings — property: behavioral; scope: settings behavior under the test suite, not full-app correctness; expected: exit 0 with settings tests passing
 
 ## Evidence required in transcript
 

--- a/fixtures/run-root-example/phases/phase-1.md
+++ b/fixtures/run-root-example/phases/phase-1.md
@@ -24,7 +24,7 @@ Change 'hello' to 'Hello' in app.txt.
 
 ## Mandatory commands
 
-- grep -q '^Hello' app.txt — expected: exit 0 and first line matches `Hello`
+- grep -q '^Hello' app.txt — property: behavioral; scope: the greeting file's first line after the work; expected: exit 0 and first line matches `Hello`
 
 ## Evidence required
 

--- a/skills/implementaudit/scripts/validate-phase.sh
+++ b/skills/implementaudit/scripts/validate-phase.sh
@@ -190,6 +190,37 @@ if missing_expected:
         + "\n"
     )
     raise SystemExit(1)
+
+# Evidence property tags (#3): every command declares which property class
+# it exercises (structural / behavioral / provenance). Newly authored specs
+# (any tagged item present) REQUIRE tags on every item; a fully untagged
+# spec is treated as legacy and warned, not failed. Authorization is not an
+# evidence property and is not accepted as one.
+TAG = re.compile(r"property:\s*(structural|behavioral|provenance)\b",
+                 re.IGNORECASE)
+BAD_TAG = re.compile(r"property:\s*(?!structural|behavioral|provenance)\w+",
+                     re.IGNORECASE)
+tagged = [i for i in items if TAG.search(i)]
+badly = [i for i in items if BAD_TAG.search(i)]
+if badly:
+    sys.stderr.write(
+        "validate-phase: invalid evidence property tag (allowed: "
+        "structural / behavioral / provenance; authorization is a separate "
+        "gate, not a property): " + "; ".join(badly[:3]) + "\n")
+    raise SystemExit(1)
+if tagged and len(tagged) != len(items):
+    untagged = [i for i in items if not TAG.search(i)]
+    sys.stderr.write(
+        "validate-phase: ## Mandatory commands mixes tagged and untagged "
+        "items — every command in a newly authored spec declares "
+        "`property: structural|behavioral|provenance`; untagged: "
+        + "; ".join(untagged[:3]) + "\n")
+    raise SystemExit(1)
+if not tagged:
+    sys.stderr.write(
+        "validate-phase: WARNING legacy spec — mandatory commands carry no "
+        "`property:` evidence tags (structural / behavioral / provenance); "
+        "newly authored specs must tag every command\n")
 PY
   [ "$python_errors" -eq 0 ] || err "## Mandatory commands needs non-placeholder list items with expected success shape"
   python_errors=0

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -504,9 +504,12 @@ owner/source is disputed.
 Steps:
 1. Print `ANDON_ESCALATE` with: phase number, failing criterion, prior
    ANDON_PROBE history, why the first countermeasure failed, and a revised or
-   deeper 5 Whys. Before claiming a same-class recurrence, cite the prior
-   same-class `## Andon log` rows by `#`; a recurrence claim without a cited
-   same-class row is invalid.
+   deeper 5 Whys. Ask explicitly: is the check testing the evidence
+   property (structural / behavioral / provenance) the claim actually
+   needs? A validator that PASSES while exercising a weaker property than
+   the claim requires is itself suspect. Before claiming a same-class
+   recurrence, cite the prior same-class `## Andon log` rows by `#`; a
+   recurrence claim without a cited same-class row is invalid.
 2. Record `New evidence:` and/or `Changed approach:` for this escalation. If
    neither can be truthfully filled, do not escalate — evaluate the
    ANDON_HANDOFF conditions instead. Append the escalation as a new classed

--- a/skills/implementaudit/templates/phase-goal.txt
+++ b/skills/implementaudit/templates/phase-goal.txt
@@ -66,8 +66,17 @@ Issue publication: deferred / not applicable
 
 ## Mandatory commands (run each; include expected success shape, surface last ~10 lines + exit code in transcript)
 
-- {{COMMAND_1}} — expected: {{EXPECTED_SUCCESS_SHAPE_1}}
-- {{COMMAND_2}} — expected: {{EXPECTED_SUCCESS_SHAPE_2}}
+Each command declares the evidence property it exercises —
+`property: structural` (shape/presence/config), `property: behavioral`
+(the system observed doing the claimed thing), or `property: provenance`
+(who/what produced the artifact and from which state) — plus a
+plain-language scope, and explicit non-claims where confusion is
+plausible. The final audit may not claim a property class no command
+exercised. Authorization is NOT an evidence property; it stays a
+separate gate.
+
+- {{COMMAND_1}} — property: {{structural|behavioral|provenance}}; scope: {{WHAT_THIS_CHECK_ACTUALLY_TESTS}}; expected: {{EXPECTED_SUCCESS_SHAPE_1}}
+- {{COMMAND_2}} — property: {{structural|behavioral|provenance}}; scope: {{WHAT_THIS_CHECK_ACTUALLY_TESTS}}; expected: {{EXPECTED_SUCCESS_SHAPE_2}}
 
 ## Evidence required in transcript
 

--- a/tests/phase-validation.test.sh
+++ b/tests/phase-validation.test.sh
@@ -249,6 +249,35 @@ sed -i '/^Markdown fallback:/d' "$f"
 check_fail "missing Markdown fallback status" "$f"
 
 # ------------------------------------------------------------------
+# Evidence property tags (#3)
+# ------------------------------------------------------------------
+# FAIL: mixed tagged/untagged mandatory commands (newly authored spec)
+f="$tmp/mixed_property_tags.md"
+make_valid "$f"
+sed -i 's/- npm run build .* property: behavioral; scope: [^;]*; expected:/- npm run build - expected:/' "$f"
+check_fail_contains "mixed property tags" "$f" "mixes tagged and untagged"
+
+# FAIL: invalid property tag (authorization is not an evidence property)
+f="$tmp/invalid_property_tag.md"
+make_valid "$f"
+sed -i 's/property: behavioral; scope: the app compiles from current sources;/property: authorization; scope: x;/' "$f"
+check_fail_contains "invalid property tag" "$f" "invalid evidence property tag"
+
+# PASS with warning: fully untagged legacy spec
+f="$tmp/legacy_untagged.md"
+make_valid "$f"
+sed -i 's/property: behavioral; scope: [^;]*; expected:/expected:/g' "$f"
+out="$tmp/legacy_untagged.out"
+if bash skills/implementaudit/scripts/validate-phase.sh "$f" >"$out" 2>&1 \
+    && grep -q "WARNING legacy spec" "$out"; then
+  pass=$((pass + 1))
+else
+  printf 'phase-validation.test: legacy untagged spec must pass WITH warning\n' >&2
+  cat "$out" >&2
+  fail=$((fail + 1))
+fi
+
+# ------------------------------------------------------------------
 # Summary
 # ------------------------------------------------------------------
 total=$((pass + fail))


### PR DESCRIPTION
Closes #3.

Every mandatory command now declares `property: structural|behavioral|provenance` plus a plain-language scope (authorization remains a separate gate). validate-phase.sh: invalid tag → fail; mixed tagged/untagged → fail; fully-untagged legacy spec → warning, still passes. Final audit may not claim an unexercised property class; ANDON_ESCALATE asks whether the check tests the property the claim needs. Shipped fixtures migrated in this PR; 3 new validator fixtures (suite 26/26). verify-package ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)