### PR TITLE
Andon log: occurrence linkage for plural defect classes (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ schema evidence proved four-component plugin manifest versions are accepted.
 ## [Unreleased]
 
 ### Added
+- Andon occurrence linkage (#5): the Andon log gains an `Occ` column —
+  one class per row, one or more linked rows per occurrence — so plural
+  co-occurring defects keep their linkage while per-class recurrence
+  citation (ANDON_ESCALATE) is unchanged. Legacy tables without `Occ`
+  remain valid and resume safely; validate-run-root.sh detects the table
+  generation, requires a non-empty Occ id on new-format rows only.
+  Fixtures: legacy-accepted, linked-plural-accepted, missing-occ-rejected.
 
 - Evidence property tags (#3): every mandatory command in a phase spec
   declares `property: structural|behavioral|provenance` plus a

--- a/skills/implementaudit/references/transcript-contract.md
+++ b/skills/implementaudit/references/transcript-contract.md
@@ -96,8 +96,13 @@ and blocked closure, not by a try counter. There is no arbitrary three-try or
 three-round cap.
 
 Every Andon event is recorded as one classed row in the run-root STATE.md
-`## Andon log` (`# | Phase | Class | Abnormality | Countermeasure |
-Rerun evidence | Outcome`). `Class` is exactly one official abnormality class:
+`## Andon log` (`# | Occ | Phase | Class | Abnormality | Countermeasure |
+Rerun evidence | Outcome`). One class per row; one or more linked rows per
+occurrence: an occurrence carrying several independent defects records one
+row per class sharing the same `Occ` id, so co-occurring defects stay
+linked while per-class recurrence citation is unchanged. Legacy run roots
+using the previous table shape (no `Occ` column) remain valid and resume
+safely. `Class` is exactly one official abnormality class:
 
 ```text
 failed-criterion

--- a/skills/implementaudit/scripts/validate-run-root.sh
+++ b/skills/implementaudit/scripts/validate-run-root.sh
@@ -48,11 +48,27 @@ if [ -f "$state" ]; then
     esac
   fi
 
-  # Andon log substrate must exist with the contract columns.
+  # Andon log substrate must exist with the contract columns. Two valid
+  # generations (#5): the current shape carries an `Occ` occurrence-linkage
+  # column; the legacy shape (no Occ) remains VALID — it was the correct
+  # contract of its time and legacy run roots resume unchanged.
   if ! grep -qi '^## Andon log' "$state"; then
     err "STATE.md is missing the '## Andon log' section"
+  elif grep -qi '| Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |' "$state"; then
+    # New-format table: every data row needs a non-empty Occ id so plural
+    # defect rows born from one occurrence stay linked.
+    missing_occ="$(awk -F'|' '
+      /^## Andon log/ { in_andon=1; next }
+      in_andon && /^## / { in_andon=0 }
+      in_andon && /^\|[[:space:]]*[0-9]+[[:space:]]*\|/ {
+        occ=$3; gsub(/^[ \t]+|[ \t]+$/, "", occ)
+        if (occ == "") { n=$2; gsub(/^[ \t]+|[ \t]+$/, "", n); print n }
+      }' "$state")"
+    if [ -n "$missing_occ" ]; then
+      err "STATE.md Andon log new-format rows missing an Occ occurrence id: row(s) $(printf '%s' "$missing_occ" | tr '\n' ' ')"
+    fi
   elif ! grep -qi '| Class | Abnormality | Countermeasure | Rerun evidence | Outcome |' "$state"; then
-    err "STATE.md Andon log table is missing the contract columns (# | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome)"
+    err "STATE.md Andon log table is missing the contract columns (# | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome; legacy shape without Occ also accepted)"
   fi
 fi
 

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -476,8 +476,10 @@ Steps:
    proportional to the issue; Hansei (gap, cause, countermeasure, follow-up
    evidence); the countermeasure selected; and the rerun evidence required.
 2. Append a classed row to `<run-root>/STATE.md` under `## Andon log`:
-   `#`, phase, abnormality class (exactly one official class from the
-   transcript contract: failed-criterion, regression, hung-command,
+   `#`, occurrence id (`Occ` — rows born from the same occurrence share
+   one short id; one class per row, one or more linked rows per
+   occurrence), phase, abnormality class (exactly one official class from
+   the transcript contract: failed-criterion, regression, hung-command,
    substituted-command, owner-unclear, generated-artifact-mismatch,
    stale-sidecar, policy-conflict, impossible-criterion, evidence-mismatch,
    transport-infrastructure, misplacement, false-closure),

--- a/skills/implementaudit/templates/STATE.md
+++ b/skills/implementaudit/templates/STATE.md
@@ -79,13 +79,18 @@ state is never substituted for current-state evidence.
 
 One row per ANDON_PROBE, ANDON_ESCALATE, or ANDON_HANDOFF event. `Class` is
 exactly one official abnormality class from
-`references/transcript-contract.md` §Andon escalation markers.
-ANDON_ESCALATE cites prior same-class rows by `#` before claiming recurrence.
+`references/transcript-contract.md` §Andon escalation markers. One class
+per row; one or more linked rows per occurrence: a single occurrence that
+carries several independent defects records one row per class, sharing the
+same `Occ` id (short occurrence id, e.g. `o1`), so co-occurring defects
+keep their linkage and each remedy is tracked to closure.
+ANDON_ESCALATE cites prior same-class rows by `#` before claiming
+recurrence (per-class citation semantics unchanged by linkage).
 There is no row-count limit: escalation is driven by same-class recurrence and
 blocked closure, never by how many rows exist.
 
-| # | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
-|---|---|---|---|---|---|---|
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
 
 Outcome values: `resolved` / `escalated (cites #N)` / `blocked (handoff condition)` /
 `open (rerun pending)`.

--- a/tests/run-root-validation.test.sh
+++ b/tests/run-root-validation.test.sh
@@ -77,4 +77,58 @@ if bash "$helper" "$tmp/empty" >/dev/null 2>&1; then
   exit 1
 fi
 
+# 5. Occurrence linkage (#5).
+# 5a. A LEGACY Andon table (no Occ column) remains valid and resumable.
+mkdir -p "$tmp/legacy"
+cp -r "$tmp/good/." "$tmp/legacy/"
+"${py_cmd[@]}" - "$tmp/legacy/STATE.md" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1])
+s = p.read_text(encoding="utf-8")
+s = s.replace(
+    "| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |",
+    "| # | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |")
+s = s.replace("|---|---|---|---|---|---|---|---|",
+              "|---|---|---|---|---|---|---|")
+p.write_text(s, encoding="utf-8")
+PY
+bash "$helper" "$tmp/legacy" >/dev/null \
+  || { printf 'run-root-validation.test: legacy Andon table must stay valid\n' >&2; exit 1; }
+
+# 5b. A new-format table with linked plural rows (shared Occ id) passes.
+mkdir -p "$tmp/plural"
+cp -r "$tmp/good/." "$tmp/plural/"
+"${py_cmd[@]}" - "$tmp/plural/STATE.md" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1])
+s = p.read_text(encoding="utf-8")
+s = s.replace("|---|---|---|---|---|---|---|---|",
+              "|---|---|---|---|---|---|---|---|\n"
+              "| 1 | o1 | 2 | failed-criterion | dup landing gate | dedupe | rerun gate | resolved |\n"
+              "| 2 | o1 | 2 | evidence-mismatch | zero machine rows | regenerate | rerun extract | resolved |")
+p.write_text(s, encoding="utf-8")
+PY
+bash "$helper" "$tmp/plural" >/dev/null \
+  || { printf 'run-root-validation.test: linked plural rows must pass\n' >&2; exit 1; }
+
+# 5c. A new-format row with an EMPTY Occ id fails (linkage required).
+mkdir -p "$tmp/noocc"
+cp -r "$tmp/good/." "$tmp/noocc/"
+"${py_cmd[@]}" - "$tmp/noocc/STATE.md" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1])
+s = p.read_text(encoding="utf-8")
+s = s.replace("|---|---|---|---|---|---|---|---|",
+              "|---|---|---|---|---|---|---|---|\n"
+              "| 1 |  | 2 | failed-criterion | dup landing gate | dedupe | rerun gate | resolved |")
+p.write_text(s, encoding="utf-8")
+PY
+if bash "$helper" "$tmp/noocc" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: new-format row without Occ id must fail\n' >&2
+  exit 1
+fi
+
 printf 'run-root-validation.test: ok\n'


### PR DESCRIPTION
Closes #5.

Adds the `Occ` occurrence-id column: one class per row, one or more linked rows per occurrence, so co-occurring defects stay linked and per-class recurrence citation is unchanged. Owner amendments honored: legacy tables (no Occ) stay valid and resumable — never described as malformed; the linkage requirement binds new-format tables only (generation detected from the header). Fixtures: legacy-accepted, linked-plural-accepted, missing-occ-rejected. verify-package ok locally on the stacked base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)