### PR TITLE
Fable revalidation of PR #31 — Claim-indexed success surfaces and closure evidence

### DIFF
--- a/docs/reviews/v0.3.2.0/pr-31-fable-review.md
+++ b/docs/reviews/v0.3.2.0/pr-31-fable-review.md
@@ -1,0 +1,147 @@
+# Fable review of PR #31 — Claim-indexed success surfaces and closure evidence
+
+## Provenance statement
+
+This review was produced end to end by **Claude Fable 5** (model id
+`claude-fable-5`) on 2026-07-17 (session 11/16). The harness reported Fable 5
+at session start and no substitution was observed. Every conclusion below
+was re-derived from live GitHub state, exact Git objects, current source,
+and executed probes against the production scorer.
+
+## Identity proof (exact objects)
+
+| Object | SHA |
+|---|---|
+| PR #31 head (`feat/i14-closure-surface`) | `5dbe36274beba56472e6a207c07824fab349a809` |
+| Merge commit on `main` | `49c14b600992781e9d505e17e3cc3d297d2202e7` |
+| Merge base (parent 1) | `b48c3c0e0c64d219670ddf881462e9faa70b677b` |
+| `origin/main` at review time | `82297b0683e6b1379bfeee7568c965c143a358d4` |
+
+- `git diff --exit-code 5dbe362 49c14b6^2` — empty; merged tree
+  byte-identical to reviewed head; `git diff --check` clean. Single
+  commit; 12 files, +160/−0 (PROTOCOL clause, payload scorer, five
+  fixtures, test, registries, CHANGELOG). Zero post-merge drift on the
+  scorer, test, or fixtures.
+
+## Issue #14 and closure review
+
+- Issue #14 (milestone v0.3.2.0), zero comments, closed
+  2026-07-17T14:48:17Z by merge linkage; `updatedAt == closedAt`. No
+  close-comment overclaim.
+- CI at merge ran the new test.
+- Acceptance adjudication (executed): repo-green-but-deployed-broken →
+  the source claim passes and the deployed claim fails as layer
+  promotion; uninspectable surface → truthful `unverified` + residual
+  reference passes; source-only work → single row, zero added steps;
+  `verified` with no evidence-surface fails. The PROTOCOL clause carries
+  the full contract including the unauthorized-inspection prohibition
+  (“NEVER trigger an unauthorized network or deployment check”) and the
+  honest framing (closure gate, not defect prevention) — both
+  test-asserted.
+
+## Invariant adjudication (packet checks 1–6)
+
+1. **Claim-ID, surface, evidence, status per row** — enforced; unknown
+   surface and invalid status fail-closed (executed). But duplicate
+   Claim-IDs were not detected (Finding 1). CONFIRMED WITH FIX.
+2. **No automatic promotion of lower-layer evidence** — the nine-surface
+   total order is real; generated-artifact evidence for a user-visible
+   claim fails; equal-surface passes; higher-layer evidence for a lower
+   claim is allowed by design (a stronger surface establishes a weaker
+   claim). CONFIRMED by execution.
+3. **Verification status distinct from residual disposition** —
+   `status: deferred` (a disposition token) is rejected as an invalid
+   status; residuals are referenced via `residual:` per #6. CONFIRMED.
+4. **Mixed tables evaluate rows independently** — a valid first row never
+   rescues an invalid second (executed); fail-fast reports the first
+   offending claim by ID. CONFIRMED.
+5. **Exact-key parsing** — `field()` splits on pipes and matches the
+   whole key, so `surface` never matches `evidence-surface` (executed:
+   a row with only `evidence-surface:` fails for a missing surface).
+   CONFIRMED.
+6. **Uninspectable surfaces route truthfully** — `verified` without
+   evidence-surface fails with the exact uninspectable-must-be-unverified
+   message; the unverified+residual fixture passes. CONFIRMED.
+
+## What was executed (evidence)
+
+- `bash tests/closure-surface-contract.test.sh` — green at `main`
+  (contract + 2 fail + 3 pass fixtures).
+- Probe battery against the production scorer:
+  - Generated-artifact evidence for a user-visible claim → fail.
+  - Row with `evidence-surface:` but no `surface:` → fail (exact keys).
+  - `status: deferred` → fail (enum separation).
+  - **Duplicate Claim-ID with conflicting surfaces → ACCEPTED**
+    (defect; fixed).
+  - Prose-only tokens, no canonical rows → fail (“no closure claim
+    rows”).
+  - **Capitalized `Claim:` row carrying a layer promotion → silently
+    skipped; file PASSED with the bad claim invisible** (defect; fixed).
+  - Higher-layer evidence for a lower claim → pass (by design).
+  - Mixed valid+invalid table → fail.
+- Post-fix: extended test RED against the unfixed scorer (first failure:
+  duplicate Claim-ID accepted), GREEN after; all 53 repo suites green;
+  `verify-package.sh` ok; `git diff --check` clean.
+
+## Findings by severity
+
+**Finding 1 — MEDIUM (duplicate Claim-ID undetected; fixed).**
+Two rows sharing one Claim-ID with conflicting surfaces — each valid in
+isolation — passed, making the claim’s identity ambiguous (which surface
+does “X” require?). The packet’s duplicate-ID robustness case. Fixed:
+Claim-IDs are unique per table, failure names the ID.
+
+**Finding 2 — MEDIUM (near-miss rows silently skipped; fixed).**
+Row detection was exact-case (`claim:*`): a `Claim:`-capitalized row was
+not scored at all — demonstrated with a capitalized layer-promotion row
+(deployed-service “verified” by source evidence) that passed invisibly.
+Casing a key must never hide a claim from every rule. Fixed: any line
+whose key is case-insensitively `claim:` but not exactly lowercase fails
+as malformed; nothing near-canonical is silently skipped.
+
+**Finding 3 — INFO.** All remaining behaviors reproduce exactly as the
+PR body claims, including the two prohibitions the test asserts
+(unauthorized-inspection; honest closure-gate framing). The scorer’s
+surface order matches the issue’s nine surfaces byte-for-byte.
+
+## Corrections made (this branch)
+
+Product payload bytes changed: **yes**
+(`skills/implementaudit/scripts/check-closure-surface.sh`), plus its
+test:
+
+1. Duplicate Claim-IDs fail, naming the ID.
+2. Near-miss (wrong-case key) claim rows fail as malformed instead of
+   being silently skipped.
+3. `tests/closure-surface-contract.test.sh` — three adversarial
+   regressions (duplicate ID; capitalized hidden layer-promotion row;
+   two-distinct-claims control). RED pre-fix, GREEN post-fix.
+
+## Residual risks and nonclaims
+
+- Claim IDs are free-text tokens; uniqueness is enforced per table, not
+  across tables or runs (cross-run claim identity is #15/#4 territory).
+- Evidence IDs are recorded fields; the scorer does not resolve them to
+  artifacts (that composition lives with #4 anchors and the final-audit
+  prose).
+- The scorer checks the table, not the world: whether deployed-service
+  evidence really came from the deployed service is the run’s PROTOCOL
+  duty and #9-measured.
+
+## Verdict
+
+**CONFIRMED_WITH_FIXES.**
+
+The claim-indexed surface model is faithfully implemented — total
+surface order, no lower-layer promotion, status/disposition separation,
+exact-key parsing, truthful uninspectable routing, per-row independence
+— and every acceptance behavior reproduces under execution. Two scorer
+defects (ambiguous duplicate Claim-IDs; silently skipped near-miss rows
+that could hide a layer promotion) are fixed minimally and
+regression-locked.
+
+Integrator notes: changes shipped payload bytes
+(`check-closure-surface.sh`) — release-asset hash changes at
+integration; re-run verify-package. No post-merge drift existed on this
+file; no overlap with other review branches except the distinct report
+under `docs/reviews/v0.3.2.0/`.

--- a/docs/reviews/v0.3.2.0/pr-31-fable-review.md
+++ b/docs/reviews/v0.3.2.0/pr-31-fable-review.md
@@ -145,3 +145,9 @@ Integrator notes: changes shipped payload bytes
 integration; re-run verify-package. No post-merge drift existed on this
 file; no overlap with other review branches except the distinct report
 under `docs/reviews/v0.3.2.0/`.
+
+Live-inventory note (2026-07-17, this session): issues #47–#53 (owner-
+authored `IA-*` native-audit-action remediation program, created
+21:44–21:45Z) appeared during the review program. They are issues, not
+PRs, and not part of the mixed-provenance work under review — recorded
+here per the common protocol’s inventory rule; no scope expansion.

--- a/skills/implementaudit/scripts/check-closure-surface.sh
+++ b/skills/implementaudit/scripts/check-closure-surface.sh
@@ -47,10 +47,26 @@ field() {
 }
 
 rows=0
+seen_ids=""
 while IFS= read -r line; do
+  # A near-miss row (e.g. `Claim:` capitalized) must never be silently
+  # skipped: a bad claim could hide from every rule just by casing its
+  # key (Fable review of PR #31 — a capitalized layer-promotion row
+  # passed invisibly).
+  if printf '%s' "$line" | grep -qiE '^[[:space:]]*claim:'; then
+    case "$line" in claim:*) : ;; *)
+      fail "malformed claim row (key must be exactly lowercase 'claim:'): ${line%%|*}";;
+    esac
+  fi
   case "$line" in claim:*) : ;; *) continue;; esac
   rows=$((rows + 1))
   cid="$(field "$line" claim)"
+  # Claim identity is unique per table: two rows sharing an ID with
+  # different surfaces make the claim ambiguous (Fable review of PR #31).
+  case " $seen_ids " in *" $cid "*)
+    fail "duplicate Claim-ID '$cid' — each closure claim has one row";;
+  esac
+  seen_ids="$seen_ids $cid"
   surface="$(field "$line" surface)"
   status="$(field "$line" status)"
   esurface="$(field "$line" 'evidence-surface')"

--- a/tests/closure-surface-contract.test.sh
+++ b/tests/closure-surface-contract.test.sh
@@ -32,4 +32,34 @@ pass_case uninspectable-unverified-PASS.md
 pass_case source-only-PASS.md
 pass_case installed-verified-PASS.md
 
-printf 'closure-surface-contract: ok (contract + 2 fail + 3 pass fixtures)\n'
+# --- Fable review of PR #31: adversarial regressions -----------------------
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+# Duplicate Claim-ID with conflicting surfaces is ambiguous, never valid.
+printf '%s\n%s\n' \
+  'claim: X | surface: source | property: structural | status: verified | evidence-surface: source' \
+  'claim: X | surface: deployed-service | property: behavioral | status: unverified | residual: r1' \
+  > "$tmp/dup.md"
+if bash "$scorer" "$tmp/dup.md" >/dev/null 2>&1; then
+  fail "duplicate Claim-ID accepted"
+fi
+
+# A near-miss row (capitalized key) must fail loudly, never be silently
+# skipped — otherwise a layer-promotion row hides by casing its key.
+printf '%s\n%s\n' \
+  'claim: ok | surface: source | property: structural | status: verified | evidence-surface: source' \
+  'Claim: bad | surface: deployed-service | property: behavioral | status: verified | evidence-surface: source' \
+  > "$tmp/caps.md"
+if bash "$scorer" "$tmp/caps.md" >/dev/null 2>&1; then
+  fail "capitalized near-miss claim row silently skipped"
+fi
+
+# Control: two DISTINCT claims at different surfaces remain valid.
+printf '%s\n%s\n' \
+  'claim: a | surface: source | property: structural | status: verified | evidence-surface: source' \
+  'claim: b | surface: deployed-service | property: behavioral | status: unverified | residual: r2' \
+  > "$tmp/two.md"
+bash "$scorer" "$tmp/two.md" >/dev/null 2>&1 \
+  || fail "two distinct claims at different surfaces must pass"
+
+printf 'closure-surface-contract: ok (contract + 2 fail + 3 pass fixtures + 3 adversarial)\n'


### PR DESCRIPTION
## Fable review PR (session 11/16)

Genuine **Claude Fable 5** revalidation of merged PR #31 ([original PR](https://github.com/theislampill/IMPLEMENTAUDIT.md/pull/31), [issue #14](https://github.com/theislampill/IMPLEMENTAUDIT.md/issues/14)).

- Original head: `5dbe36274beba56472e6a207c07824fab349a809`
- Original merge: `49c14b600992781e9d505e17e3cc3d297d2202e7`
- Report: `docs/reviews/v0.3.2.0/pr-31-fable-review.md`

**Verdict: CONFIRMED_WITH_FIXES.** Confirmed by execution: the nine-surface total order with no lower-layer promotion (generated-artifact evidence for a user-visible claim fails; repo-green-but-deployed-broken yields a truthful split verdict), verification status kept apart from residual dispositions (`status: deferred` rejected), genuinely exact-key parsing (`surface` never matches `evidence-surface`), per-row independence in mixed tables, truthful uninspectable routing, and both test-asserted prohibitions (no unauthorized network/deploy checks; closure gate ≠ defect prevention).

**Two scorer defects found by execution, fixed:**
1. **Duplicate Claim-ID:** two rows sharing one ID with conflicting surfaces — each valid alone — passed, making the claim's identity ambiguous. Now unique per table, failure names the ID.
2. **Silently skipped near-miss rows:** row detection was exact-case, so a `Claim:`-capitalized row was never scored — demonstrated with a capitalized **layer-promotion** row that passed invisibly. Casing a key must never hide a claim; near-miss keys now fail as malformed.

**This PR changes product payload bytes: yes** (`check-closure-surface.sh`), plus three adversarial regressions.

**Exact tests executed:**
- `bash tests/closure-surface-contract.test.sh` — green on main; extended version RED against unfixed scorer, GREEN post-fix
- Eight-case probe battery (promotion, exact keys, enum separation, duplicates, prose-only, capitalized rows, higher-evidence-allowed control, mixed tables)
- All 53 `tests/*.test.sh` green; `bash scripts/verify-package.sh` ok

**Integrator notes:** payload bytes change (release-asset hash changes; re-run verify-package). Zero post-merge drift existed on this file; no overlap with other review branches except the distinct report under `docs/reviews/v0.3.2.0/`.

This review PR is intentionally unmerged. Final integration is handled by the
dedicated review-set integrator after all sixteen sessions complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)