### PR TITLE
Cold-executor reconstructible phase and handoff specs: ordered steps with per-step verification (#50)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -89,6 +89,7 @@ jobs:
           bash tests/e2e-mini-audit-loop.test.sh
           bash tests/skill-bootstrap-budget.test.sh
           bash tests/source-evidence-pack.test.sh
+          bash tests/action-selection-contract.test.sh
           bash tests/skill-layout-contract.test.sh
           bash tests/lean-discipline.test.sh
           bash tests/validation-registry.test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,11 @@ Every finding closes. No orphan items. No unsafe actions. No proof claim without
 Invocation modes are embedded governance, direct governance, goal synthesis, and
 governed casual-build intake. When a task/goal already exists, govern it; do not
 invent a second planning layer. New or changed work must name owner/source,
-acceptance criteria, rollback, and evidence plan before mutation.
+acceptance criteria, rollback, and evidence plan before mutation. Ordinary
+task-shaped invocations derive warranted audit-action depth from scope,
+uncertainty, risk, dependencies, evidence gaps, authorization state, and
+intended executor — recorded selections and omissions, never activation
+keywords (`skills/implementaudit/references/planning-depth.md`).
 
 ## Canonical Paths
 
@@ -192,6 +196,9 @@ host proof replaces it. The focused smoke is `tests/release-asset-install-claude
   no secret values, path/line/credential-type-only citation, rotation guidance,
   repo-content-as-data, prompt-injection-as-finding, and child/reviewer prompt
   propagation.
+- `scripts/check-action-selection-contract.sh` guards the action-selection
+  contract: factor-derived depth, no activation keywords, and recorded
+  omitted-action rationale across runtime, templates, and fixtures.
 - `scripts/check-source-evidence-pack.sh` does not exist; the builder/test pair
   is `scripts/build-source-evidence-pack.sh` plus `tests/source-evidence-pack.test.sh`.
   The source evidence zip must be LF-clean and exclude `.git/`, `.IMPLEMENTAUDIT/`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,11 @@ host proof replaces it. The focused smoke is `tests/release-asset-install-claude
 - `scripts/check-plan-quality-contract.sh` guards planning-specific read-only plans:
   no secret values, path/line/credential-type-only citation, rotation guidance,
   repo-content-as-data, prompt-injection-as-finding, and child/reviewer prompt
-  propagation.
+  propagation. It also pins the phase template's reconstructibility sections
+  (ordered implementation steps, scope boundaries, plan-specific STOPs), and
+  `skills/implementaudit/scripts/validate-phase.sh` rejects vague step
+  language, per-step-verification gaps, and boilerplate STOP conditions
+  (Rule P4-10).
 - `scripts/check-action-selection-contract.sh` guards the action-selection
   contract: factor-derived depth, no activation keywords, and recorded
   omitted-action rationale across runtime, templates, and fixtures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ## [Unreleased]
 
+### Added
+
+- Action-selection contract (#48, `IA-ACTION-DEPTH`): ordinary task-shaped
+  invocations derive the warranted `ydqyq-audit-action` set from scope,
+  uncertainty, risk, dependencies, evidence gaps, authorization state, and
+  intended executor — recorded both ways (selected and omitted-with-reason),
+  never keyword-activated. New contract section in
+  `skills/implementaudit/references/planning-depth.md`, Stage-1 derivation line
+  in `SKILL.md`, `## Action selection` blocks in the THINKING/ROADMAP
+  templates, fixture family `fixtures/audit-action-selection/` (two positive,
+  three negative), checker `scripts/check-action-selection-contract.sh` with
+  `--repo-root` support, and registered test
+  `tests/action-selection-contract.test.sh` with embedded negative controls.
+
 ### Fixed
 
 - Payload scorer robustness (post-merge, Fable re-audit of #13/#12/#15):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ### Added
 
+- Phase reconstructibility contract (#50, `IA-PHASE-RECONSTRUCTIBILITY`):
+  newly authored phase specs carry an ordered `## Implementation steps`
+  section (exact file/symbol targets, per-step verify command with expected
+  success shape), `## Scope boundaries` with an explicit `Out of scope:`
+  line, and plan-specific `## STOP conditions`. `validate-phase.sh` rejects
+  vague step language ("update the relevant files", "make it work"),
+  per-step-verification gaps on multi-step work, and boilerplate STOPs —
+  legacy specs without ordered steps pass with a warning (same precedent as
+  evidence-property tags). New Rule P4-10 in `phase-design.md`; read-only
+  handoff lane aligned (`## Ordered Steps` in `read-only-plan.md`); four
+  canonical phase fixtures upgraded to the new shape; three mechanical
+  negative fixtures plus a review-lane counter-example
+  (`fixtures/phase-design/negative-paths-without-symbols.md`); source-gate
+  pins in `check-plan-quality-contract.sh`.
+
 - Action-selection contract (#48, `IA-ACTION-DEPTH`): ordinary task-shaped
   invocations derive the warranted `ydqyq-audit-action` set from scope,
   uncertainty, risk, dependencies, evidence gaps, authorization state, and

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ scope, uncertainty, risk, dependencies, evidence gaps, authorization state, and
 intended executor — recording both selected and omitted actions with reasons —
 with no activation keywords.
 
+Phase reconstructibility is a native quality requirement (Rule P4-10 in
+`skills/implementaudit/references/phase-design.md`): newly authored phase
+specs carry ordered implementation steps with exact file/symbol targets and
+per-step verification, explicit scope boundaries, and plan-specific STOP
+conditions; `validate-phase.sh` rejects vague step language and boilerplate
+STOPs, and the read-only handoff lane aligns on the same bar.
+
 Current optional-tooling architecture:
 
 <!-- BEGIN: implementaudit-diagram:tooling-architecture -->

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ thresholds, and 5-Whys loop exit. Read-only audit/plan/review/direction work may
 write human-readable `plans/` outputs, but that lane does not authorize source
 mutation and does not replace `.IMPLEMENTAUDIT/runs/` for implementation.
 
+Warranted planning depth is not optional detail behind progressive disclosure.
+The action-selection contract in
+`skills/implementaudit/references/planning-depth.md` requires ordinary
+task-shaped invocations to derive the warranted `ydqyq-audit-action` set from
+scope, uncertainty, risk, dependencies, evidence gaps, authorization state, and
+intended executor — recording both selected and omitted actions with reasons —
+with no activation keywords.
+
 Current optional-tooling architecture:
 
 <!-- BEGIN: implementaudit-diagram:tooling-architecture -->

--- a/fixtures/audit-action-selection/narrow-direct-stays-shallow.md
+++ b/fixtures/audit-action-selection/narrow-direct-stays-shallow.md
@@ -1,0 +1,47 @@
+# Fixture: Narrow bounded repair stays direct with recorded restraint
+
+Input shape:
+
+```text
+Using /implementaudit, fix the failing expected-output assertion in
+tests/routing.test.sh so it matches the current checker banner.
+```
+
+The factor profile is light: single clear owner/source, low uncertainty, low
+dependency density, no material evidence gap, authorization boundaries
+unchanged, and the executor is the current session.
+
+Expected route:
+
+- direct governance: one ledger row against the bound `tdqyq-audit-object`;
+- the action-selection contract still runs, and it selects restraint: deeper
+  synthesis and decomposition are considered but omitted.
+
+Required behavior:
+
+- the run stays direct: no phase plan, no goal synthesis, no specialist
+  fanout;
+- the action-selection record is still written, and it records why deeper
+  planning was not warranted (no safety, evidence, sequencing, or executor
+  reconstructibility gained);
+- omitted actions are named with reasons, not silently skipped;
+- Smoke A/B and the final audit still run.
+
+Forbidden behavior:
+
+- over-planning: adding a phase plan or synthesis layer that adds no safety,
+  evidence, sequencing, or executor-reconstructibility value;
+- skipping the action-selection record because the work is small;
+- treating restraint as an excuse to skip Smoke A/B or the final audit.
+
+Negative control:
+
+- a run that produces a multi-phase roadmap for this single bounded repair
+  without factor-based justification fails;
+- a run with no recorded reason for staying shallow fails.
+
+Evidence required:
+
+- one direct ledger row with owner/source and acceptance evidence;
+- action-selection record including omitted actions with reasons;
+- explicit statement of why deeper planning was not warranted.

--- a/fixtures/audit-action-selection/negative-keyword-gated-depth.md
+++ b/fixtures/audit-action-selection/negative-keyword-gated-depth.md
@@ -1,0 +1,26 @@
+# NEGATIVE FIXTURE: depth appears only when an activation keyword is present
+
+This fixture describes a defective run. It must fail review; it is a
+counter-example, not a model to imitate.
+
+Defective behavior:
+
+Two invocations describe the same broad, high-dependency, evidence-gapped
+repair. The first is phrased plainly and the run stays shallow: no recon
+widening, no dependency analysis, no decomposition. The second adds the word
+"deep" and only then does the run select the stronger action set. The
+action-selection record for the second run cites the keyword — not the factor
+profile — as the reason for depth.
+
+Why this must fail:
+
+- depth was gated on an activation keyword instead of being derived from
+  scope, uncertainty, risk, dependencies, evidence gaps, authorization state,
+  and intended executor;
+- two factor-identical inputs received different action sets based on
+  wording alone;
+- the action-selection record names a keyword as the selection reason, which
+  the contract forbids.
+
+Expected disposition when reviewed: FAIL — keyword-gated depth violates the
+action-selection contract in `references/planning-depth.md`.

--- a/fixtures/audit-action-selection/negative-missing-selection-record.md
+++ b/fixtures/audit-action-selection/negative-missing-selection-record.md
@@ -1,0 +1,25 @@
+# NEGATIVE FIXTURE: absent or hand-wavy action-selection record
+
+This fixture describes a defective run. It must fail review; it is a
+counter-example, not a model to imitate.
+
+Defective behavior:
+
+A run performs reconnaissance, dependency analysis, and phase decomposition on
+an ordinary task-shaped invocation — plausibly the right action set — but the
+audit object contains no action-selection record. The run-root `THINKING.md`
+has no `## Action selection` section; the only trace is a transcript remark
+that the task "seemed complicated enough to plan properly."
+
+Why this must fail:
+
+- the contract requires the record both ways: selected actions and
+  considered-but-omitted actions, each with reasons;
+- "seemed complicated" names no factor — scope, uncertainty, risk,
+  dependencies, evidence gaps, authorization state, intended executor — and
+  cannot be reviewed or falsified;
+- an absent or hand-wavy action-selection record is a plan-quality defect,
+  not a style preference.
+
+Expected disposition when reviewed: FAIL — missing action-selection record
+violates the action-selection contract in `references/planning-depth.md`.

--- a/fixtures/audit-action-selection/negative-size-only-deepening.md
+++ b/fixtures/audit-action-selection/negative-size-only-deepening.md
@@ -1,0 +1,25 @@
+# NEGATIVE FIXTURE: deepening justified by request size alone
+
+This fixture describes a defective run. It must fail review; it is a
+counter-example, not a model to imitate.
+
+Defective behavior:
+
+A long, wordy request describes what is actually one bounded, single-owner
+repair with no material uncertainty, dependency density, or evidence gap. The
+run selects goal synthesis, phase decomposition, and a multi-phase roadmap
+anyway. The action-selection record justifies the depth with "the request is
+large" and names no factor that deeper structure would improve.
+
+Why this must fail:
+
+- the depth rule says: do not add a planning layer merely because the work is
+  large; add it when the extra structure improves evidence, sequencing,
+  rollback, or owner decisions;
+- request size alone never deepens the action set — the factor profile does;
+- the omitted-action reasoning is inverted: restraint was warranted and was
+  neither selected nor honestly considered.
+
+Expected disposition when reviewed: FAIL — size-only deepening violates the
+action-selection contract and the depth rule in
+`references/planning-depth.md`.

--- a/fixtures/audit-action-selection/ordinary-task-deepens.md
+++ b/fixtures/audit-action-selection/ordinary-task-deepens.md
@@ -1,0 +1,54 @@
+# Fixture: Ordinary task-shaped invocation deepens without keywords
+
+Input shape:
+
+```text
+Using /implementaudit, get the flaky release pipeline fixed across the repo.
+```
+
+The input contains no activation keyword: the user never says "deep", "plan",
+or "review". The factor profile alone warrants depth: broad scope, high
+dependency density (pipeline scripts, checkers, CI, package gates), material
+evidence gaps (flakiness is unmeasured), and a possibly weaker fresh-context
+executor downstream.
+
+Expected route:
+
+- ordinary task-shaped intake binds the `tdqyq-audit-object`;
+- the action-selection contract derives the warranted `ydqyq-audit-action`
+  set from scope, uncertainty, risk, dependencies, evidence gaps,
+  authorization state, and intended executor;
+- reconnaissance, dependency analysis, and phase decomposition are selected
+  because the factors warrant them — with no activation keyword present.
+
+Required behavior:
+
+- an action-selection record is written into the audit object
+  (`## Action selection` in the run-root `THINKING.md`);
+- the record names input shape, intended executor, uncertainty, dependency
+  density, evidence gaps, and authorization state;
+- the record lists the selected `ydqyq-audit-actions` and the
+  considered-but-omitted actions with reasons;
+- reference loading follows selection: `phase-design.md` loads because
+  decomposition was selected;
+- phase decomposition produces dependency-ordered phases with Smoke A/B and
+  rollback paths.
+
+Forbidden behavior:
+
+- waiting for an activation keyword before selecting depth;
+- deepening justified by request size alone rather than the factor profile;
+- performing deep actions with no action-selection record.
+
+Negative control:
+
+- a run on this input that stays shallow and cites "no keyword present" as
+  the reason fails;
+- a run that deepens but records no action-selection rationale fails.
+
+Evidence required:
+
+- action-selection record with all fields non-empty;
+- selected-versus-omitted action list with reasons;
+- dependency-ordered phase specs;
+- no activation keyword anywhere in the trigger chain.

--- a/fixtures/audit-object-routing/deep-pressure-disclosure.md
+++ b/fixtures/audit-object-routing/deep-pressure-disclosure.md
@@ -16,6 +16,9 @@ Required behavior:
 
 - widen Gemba from the named package boundary to shipped runtime files,
   generated package contents, install scripts, validators, tests, docs, and CI;
+- the audit object records the factor-driven action-selection rationale for
+  deep pressure (scope, risk, dependencies, evidence gaps), not a keyword
+  trigger;
 - cover the whole material surface where scope warrants it;
 - record every skipped or unaudited surface as deferred, out of scope, or
   unverified with reason;

--- a/fixtures/e2e-mini-audit-loop/phase-1.md
+++ b/fixtures/e2e-mini-audit-loop/phase-1.md
@@ -29,6 +29,21 @@ one deliverable, and verify the deliverable against the complete working tree.
 - Copy this phase spec into a temporary run root for the mini-loop test.
 - Create `src-mini-proof.txt` in the temporary repository.
 
+## Implementation steps (ordered)
+
+- Step 1: Validate the spec shape - target: fixtures/e2e-mini-audit-loop/phase-1.md; change: none (read-only validation of this fixture); verify: bash skills/implementaudit/scripts/validate-phase.sh fixtures/e2e-mini-audit-loop/phase-1.md; expected: exit 0 with validate-phase: ok
+- Step 2: Create the deliverable - target: src-mini-proof.txt (temporary repository root); change: write one proof line into the temporary repository; verify: bash .IMPLEMENTAUDIT/runs/mini/repo-state.sh deliverable mini-baseline-ref src-mini-proof.txt; expected: exit 0 reporting present
+
+## Scope boundaries
+
+In scope: the temporary mini-repository files only
+Out of scope: tracked source of this repository - the mini loop performs no tracked mutation.
+
+## STOP conditions (plan-specific)
+
+- Stop if `validate-phase.sh` reports a missing marker or section in this fixture - the fixture and validator have drifted apart.
+- Stop if `repo-state.sh deliverable` reports absent after the write - the deliverable contract has drifted.
+
 ## Acceptance criteria (all must pass - verify each in transcript)
 
 - `bash skills/implementaudit/scripts/validate-phase.sh fixtures/e2e-mini-audit-loop/phase-1.md` exits 0.

--- a/fixtures/native-integration/single-plan-native-route.md
+++ b/fixtures/native-integration/single-plan-native-route.md
@@ -29,6 +29,8 @@ Required behavior:
 - remaining ambiguity becomes owner questions or assumptions;
 - exactly one self-contained native IMPLEMENTAUDIT phase/plan artifact is
   produced;
+- the action-selection record notes why phase decomposition beyond the single
+  requested plan was not warranted;
 - includes owner/source, drift check, scope/non-scope, STOP conditions,
   expected outputs, verification commands, rollback/removal path, and evidence
   boundary;

--- a/fixtures/phase-design/dmadv-greenfield-phase.md
+++ b/fixtures/phase-design/dmadv-greenfield-phase.md
@@ -20,6 +20,20 @@ Analyze (alternatives: inline README section rejected as duplication) ->
 Design (this spec + template) -> Verify (mandatory command + Smoke B).
 Create docs/quickstart-fragment.md with a 4-step first-run path.
 
+## Implementation steps (ordered)
+
+- Step 1: Create the quickstart fragment — target: docs/quickstart-fragment.md; change: new file with exactly 4 numbered first-run steps; verify: test -s docs/quickstart-fragment.md; expected: exit 0 (file exists, non-empty)
+- Step 2: Prove the step count — target: docs/quickstart-fragment.md; change: none (verification step); verify: grep -c '^[0-9]\.' docs/quickstart-fragment.md; expected: outputs 4 and exits 0
+
+## Scope boundaries
+
+In scope: docs/quickstart-fragment.md (new greenfield artifact)
+Out of scope: README.md — the inline-section alternative was rejected at Analyze; do not duplicate quickstart content there.
+
+## STOP conditions (plan-specific)
+
+- Stop if `docs/quickstart-fragment.md` already exists at baseline — the greenfield intake assumption failed; route to brownfield inspection instead.
+
 ## Current state excerpts
 
 - `docs/quickstart-fragment.md` is absent at baseline HEAD and is a greenfield artifact.

--- a/fixtures/phase-design/negative-paths-without-symbols.md
+++ b/fixtures/phase-design/negative-paths-without-symbols.md
@@ -1,0 +1,28 @@
+# NEGATIVE FIXTURE: paths without symbols where symbol precision is material
+
+This fixture describes a defective phase spec. It must fail review; it is a
+counter-example, not a model to imitate.
+
+Defective behavior:
+
+A phase spec orders a rename-and-rewire change inside a 2,000-line module
+with a dozen exported symbols. Its steps name only the file path —
+"target: src/core/engine.ts; change: rename the affected function and update
+its call sites" — without naming WHICH function, although the module exports
+several near-identical candidates (`resolve`, `resolveAll`, `resolveOne`).
+A fresh executor must guess the symbol; two of the three guesses produce a
+plausible-looking but wrong change that still compiles.
+
+Why this must fail:
+
+- symbol precision is material here: the file path alone does not identify
+  the change site, and the wrong-but-compiling guess defeats the per-step
+  verification;
+- the reconstructibility bar in `references/phase-design.md` requires exact
+  file/symbol targets when symbol precision is material;
+- mechanical validators cannot judge materiality, so this class is caught at
+  cold review: a reviewer who cannot name the target symbol from the spec
+  alone must return GAP/REVISE, not PASS.
+
+Expected disposition when reviewed: FAIL — path-only targets where symbol
+precision is material violate the executor-reconstructibility contract.

--- a/fixtures/phase-validation/negative-boilerplate-stop.md
+++ b/fixtures/phase-validation/negative-boilerplate-stop.md
@@ -1,0 +1,69 @@
+IMPLEMENTAUDIT_PHASE_START
+Phase: 1 of 1 — Negative: boilerplate STOP conditions
+Task: counter-example spec whose STOP conditions reflect no actual risk
+Type: negative-fixture
+Run root: .IMPLEMENTAUDIT/runs/negative-boilerplate-stop
+Baseline ref: abc123def456
+Owner/source: fixtures/phase-validation/negative-boilerplate-stop.md
+Depends on phases: none
+
+## Why
+
+This spec must FAIL validate-phase.sh: its STOP conditions are generic
+boilerplate tied to no concrete file, command, marker, or assumption of the
+phase, so they cannot stop an executor at the moments that matter.
+
+## Current state excerpts
+
+- `fixtures/phase-validation/negative-boilerplate-stop.md` exists as a validator counter-example.
+
+## Work
+
+- Rename the export and update its imports
+
+## Implementation steps (ordered)
+
+- Step 1: Rename the export — target: src/index.ts (createClient); change: rename createClient to makeClient, keep a deprecated alias; verify: npm run build; expected: exit 0 with no errors
+
+## Scope boundaries
+
+In scope: src/index.ts
+Out of scope: published API docs — regenerated separately.
+
+## STOP conditions (plan-specific)
+
+- Something goes wrong.
+- Unexpected error occurs.
+
+## Acceptance criteria
+
+- `npm run build` exits 0
+
+## Mandatory commands
+
+- npm run build — property: behavioral; scope: compile after rename; expected: exit 0
+
+## Evidence required
+
+- build output with exit code
+- Markdown fallback: yes
+
+## Rollback / defer path
+
+git checkout -- src/index.ts
+
+## Maintenance notes
+
+- Keep the STOP items generic on purpose; the validator must reject them.
+
+IMPLEMENTAUDIT_PHASE_VERIFY
+Criteria results recorded here.
+
+AGENTS_UPDATE_DECISION
+Decision recorded here.
+
+CONTINUITY_DECISION
+Decision recorded here.
+
+IMPLEMENTAUDIT_PHASE_DONE
+Status recorded here.

--- a/fixtures/phase-validation/negative-multistep-no-per-step-verify.md
+++ b/fixtures/phase-validation/negative-multistep-no-per-step-verify.md
@@ -1,0 +1,69 @@
+IMPLEMENTAUDIT_PHASE_START
+Phase: 1 of 1 — Negative: multi-step without per-step verification
+Task: counter-example spec with commands only at the end of the phase
+Type: negative-fixture
+Run root: .IMPLEMENTAUDIT/runs/negative-multistep-no-verify
+Baseline ref: abc123def456
+Owner/source: fixtures/phase-validation/negative-multistep-no-per-step-verify.md
+Depends on phases: none
+
+## Why
+
+This spec must FAIL validate-phase.sh: it is multi-step but its steps carry
+no per-step verification; commands appear only at the end of the phase, so
+an executor cannot confirm each step before moving on.
+
+## Current state excerpts
+
+- `fixtures/phase-validation/negative-multistep-no-per-step-verify.md` exists as a validator counter-example.
+
+## Work
+
+- Add the parser and switch the callers
+
+## Implementation steps (ordered)
+
+- Step 1: Add the parser — target: src/parser.ts (parseConfig); change: add a strict config parser with typed errors
+- Step 2: Switch the callers — target: src/loader.ts (loadConfig); change: call parseConfig and remove the inline parsing block
+
+## Scope boundaries
+
+In scope: src/parser.ts, src/loader.ts
+Out of scope: src/legacy-loader.ts — deprecated path scheduled for deletion.
+
+## STOP conditions (plan-specific)
+
+- Stop if `src/loader.ts` inline parsing differs from the current-state excerpt — baseline drifted.
+
+## Acceptance criteria
+
+- `npm test` exits 0 with parser tests passing
+
+## Mandatory commands
+
+- npm test — property: behavioral; scope: full suite after both steps; expected: exit 0
+
+## Evidence required
+
+- test output with exit code
+- Markdown fallback: yes
+
+## Rollback / defer path
+
+git checkout -- src/parser.ts src/loader.ts
+
+## Maintenance notes
+
+- Keep this counter-example verification-free in its steps on purpose.
+
+IMPLEMENTAUDIT_PHASE_VERIFY
+Criteria results recorded here.
+
+AGENTS_UPDATE_DECISION
+Decision recorded here.
+
+CONTINUITY_DECISION
+Decision recorded here.
+
+IMPLEMENTAUDIT_PHASE_DONE
+Status recorded here.

--- a/fixtures/phase-validation/negative-vague-steps.md
+++ b/fixtures/phase-validation/negative-vague-steps.md
@@ -1,0 +1,67 @@
+IMPLEMENTAUDIT_PHASE_START
+Phase: 1 of 1 — Negative: vague step language
+Task: counter-example spec whose steps a fresh executor cannot follow
+Type: negative-fixture
+Run root: .IMPLEMENTAUDIT/runs/negative-vague-steps
+Baseline ref: abc123def456
+Owner/source: fixtures/phase-validation/negative-vague-steps.md
+Depends on phases: none
+
+## Why
+
+This spec must FAIL validate-phase.sh: its step language is vague, so a
+fresh executor cannot reconstruct the work from disk.
+
+## Current state excerpts
+
+- `fixtures/phase-validation/negative-vague-steps.md` exists as a validator counter-example.
+
+## Work
+
+- Update the relevant files so the checker passes
+
+## Implementation steps (ordered)
+
+- Step 1: Improve the code — target: src/utils.ts; change: adjust the helpers in the relevant module until behavior is right; verify: npm test; expected: exit 0
+
+## Scope boundaries
+
+In scope: src/
+Out of scope: tests/ — unchanged.
+
+## STOP conditions (plan-specific)
+
+- Stop if `npm test` fails twice after a reasonable fix attempt.
+
+## Acceptance criteria
+
+- `npm test` exits 0
+
+## Mandatory commands
+
+- npm test — property: behavioral; scope: full suite; expected: exit 0
+
+## Evidence required
+
+- test output with exit code
+- Markdown fallback: yes
+
+## Rollback / defer path
+
+git checkout -- src/
+
+## Maintenance notes
+
+- Keep this counter-example vague on purpose; the validator must reject it.
+
+IMPLEMENTAUDIT_PHASE_VERIFY
+Criteria results recorded here.
+
+AGENTS_UPDATE_DECISION
+Decision recorded here.
+
+CONTINUITY_DECISION
+Decision recorded here.
+
+IMPLEMENTAUDIT_PHASE_DONE
+Status recorded here.

--- a/fixtures/phase-validation/valid-full-spec.md
+++ b/fixtures/phase-validation/valid-full-spec.md
@@ -25,6 +25,22 @@ The audit found no settings endpoint; users cannot retrieve their preferences.
 - Add tests/settings.test.ts with happy path and 401 cases
 - Register route in src/app.ts
 
+## Implementation steps (ordered)
+
+- Step 1: Create the settings route — target: src/routes/settings.ts (registerSettingsRoutes); change: add GET /api/settings handler behind requireAuth from src/middleware/auth.ts; verify: npm run build; expected: exit 0 with no errors
+- Step 2: Add settings tests — target: tests/settings.test.ts; change: happy-path 200 and unauthenticated 401 cases modeled on the existing route tests; verify: npm test -- --testPathPattern=settings; expected: exit 0, all settings tests pass
+- Step 3: Register the route — target: src/app.ts (registerRoutes); change: mount the settings router under /api after auth wiring; verify: npm test -- --testPathPattern=settings; expected: exit 0 including the 200/401 cases
+
+## Scope boundaries
+
+In scope: src/routes/settings.ts, tests/settings.test.ts, src/app.ts
+Out of scope: src/middleware/auth.ts — reused, not modified; any response-shape change to existing endpoints — clients depend on current contracts.
+
+## STOP conditions (plan-specific)
+
+- Stop if `src/middleware/auth.ts` exports differ from the current-state excerpt above — the baseline has drifted; re-anchor before mutating.
+- Stop if registering the route requires touching files outside the in-scope list.
+
 ## Acceptance criteria (all must pass — verify each in transcript)
 
 - `npm run build` exits 0 with no errors

--- a/fixtures/read-only-plans/valid-handoff-plan.md
+++ b/fixtures/read-only-plans/valid-handoff-plan.md
@@ -58,6 +58,10 @@ importing context from the planning session.
 
 ## Steps
 
+Each step names its exact targets and carries its own Verify command with an
+expected result — the read-only handoff and executing-phase quality bars
+align on executor reconstructibility.
+
 ### Step 1: Verify capability parity fixtures
 
 Verify that the active fixture roots cover read-only plans, secret hygiene,

--- a/fixtures/run-root-example/phases/phase-1.md
+++ b/fixtures/run-root-example/phases/phase-1.md
@@ -13,6 +13,19 @@ Depends on phases: none
 
 Change 'hello' to 'Hello' in app.txt.
 
+## Implementation steps (ordered)
+
+- Step 1: Fix the greeting casing — target: app.txt (first line); change: replace `hello` with `Hello`; verify: grep -q '^Hello' app.txt; expected: exit 0
+
+## Scope boundaries
+
+In scope: app.txt
+Out of scope: every other file — single-owner casing repair; deeper structure adds nothing (proportional granularity).
+
+## STOP conditions (plan-specific)
+
+- Stop if `app.txt` first line is not `hello` at baseline — the input drifted; re-anchor before mutating.
+
 ## Current state excerpts
 
 - `app.txt` first line is `hello` at baseline HEAD.

--- a/scripts/check-action-selection-contract.sh
+++ b/scripts/check-action-selection-contract.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Action-selection contract gate (#48, IA-ACTION-DEPTH). Ordinary task-shaped
+# invocations must derive the warranted ydqyq-audit-action set from the seven
+# live factors — scope, uncertainty, risk, dependencies, evidence gaps,
+# authorization state, intended executor — record selections AND omissions,
+# and never gate depth on an activation keyword.
+#
+# Usage: check-action-selection-contract.sh [--repo-root <dir>]
+
+fail() {
+  printf 'check-action-selection-contract: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ "${1:-}" = "--repo-root" ]; then
+  [ "$#" -ge 2 ] || fail "--repo-root requires a directory argument"
+  repo_root="$2"
+fi
+cd "$repo_root"
+
+require() {
+  local file="$1"
+  local text="$2"
+  [ -f "$file" ] || fail "missing file: $file"
+  grep -Fqi -e "$text" "$file" || fail "missing in $file: $text"
+}
+
+# --- runtime contract: planning-depth.md owns the contract ---
+depth_ref="skills/implementaudit/references/planning-depth.md"
+for text in \
+  "## Action-selection contract" \
+  "Depth never requires an activation keyword" \
+  "- scope" \
+  "- uncertainty" \
+  "- risk" \
+  "- dependencies" \
+  "- evidence gaps" \
+  "- authorization state" \
+  "- intended executor" \
+  "Selection is recorded, both ways" \
+  "considered-but-omitted actions with the reason" \
+  "why deeper planning was or was not warranted" \
+  "Reference loading follows selection" \
+  "request size alone never does" \
+  "plan-quality defect"
+do
+  require "$depth_ref" "$text"
+done
+
+# --- bootloader: Stage 1 derives and records the action set ---
+skill="skills/implementaudit/SKILL.md"
+for text in \
+  "Derive the warranted \`ydqyq-audit-action\` set from scope, uncertainty, risk," \
+  "record" \
+  "action-selection contract" \
+  "Depth never requires an activation keyword"
+do
+  require "$skill" "$text"
+done
+
+# --- templates: the record has a home in the audit object ---
+thinking="skills/implementaudit/templates/THINKING.md"
+for text in \
+  "## Action selection" \
+  "Selected ydqyq-audit-actions:" \
+  "Considered-but-omitted actions (with reasons):" \
+  "Why deeper planning was or was not warranted:"
+do
+  require "$thinking" "$text"
+done
+
+roadmap="skills/implementaudit/templates/ROADMAP.md"
+for text in \
+  "## Action selection" \
+  "Depth rationale"
+do
+  require "$roadmap" "$text"
+done
+
+# --- positive fixtures ---
+deepens="fixtures/audit-action-selection/ordinary-task-deepens.md"
+for text in \
+  "no activation keyword" \
+  "action-selection record" \
+  "phase decomposition" \
+  "considered-but-omitted actions with reasons"
+do
+  require "$deepens" "$text"
+done
+
+shallow="fixtures/audit-action-selection/narrow-direct-stays-shallow.md"
+for text in \
+  "stays direct" \
+  "why deeper planning was not warranted" \
+  "omitted actions with reasons" \
+  "Over-planning"
+do
+  require "$shallow" "$text"
+done
+
+# --- adapted route fixtures carry the contract linkage ---
+require "fixtures/native-integration/single-plan-native-route.md" \
+  "action-selection record notes why phase decomposition beyond the single"
+require "fixtures/audit-object-routing/deep-pressure-disclosure.md" \
+  "factor-driven action-selection rationale"
+
+# --- negative fixtures exist and declare their failing disposition ---
+for negative in \
+  "fixtures/audit-action-selection/negative-keyword-gated-depth.md" \
+  "fixtures/audit-action-selection/negative-size-only-deepening.md" \
+  "fixtures/audit-action-selection/negative-missing-selection-record.md"
+do
+  require "$negative" "NEGATIVE FIXTURE"
+  require "$negative" "must fail"
+  require "$negative" "Expected disposition when reviewed: FAIL"
+done
+
+# --- no command-mode advertisement in the new surfaces ---
+if grep -R -n -E '/implementaudit (quick|deep|security|next|features|roadmap)' \
+  fixtures/audit-action-selection "$depth_ref" \
+  | grep -v "Do not advertise" \
+  | grep -v "Do not add" \
+  >/tmp/implementaudit-action-selection-command-mode-hit.txt; then
+  cat /tmp/implementaudit-action-selection-command-mode-hit.txt >&2
+  rm -f /tmp/implementaudit-action-selection-command-mode-hit.txt
+  fail "command-mode identity advertised in action-selection surfaces"
+fi
+rm -f /tmp/implementaudit-action-selection-command-mode-hit.txt
+
+printf 'check-action-selection-contract: ok\n'

--- a/scripts/check-plan-quality-contract.sh
+++ b/scripts/check-plan-quality-contract.sh
@@ -114,6 +114,8 @@ forbidden = [
     "works correctly",
     "make it work",
     "just fix it",
+    "update the relevant files",
+    "the relevant module",
     "{{",
     "TBD",
     "task placeholder",
@@ -228,9 +230,24 @@ for token in [
     "Rollback / defer path",
     "Maintenance notes",
     "Authorization boundary: no hidden commit, push, merge, release, publication, provenance, install, index, export, or issue creation",
+    "## Implementation steps (ordered)",
+    "## Scope boundaries",
+    "Out of scope:",
+    "## STOP conditions (plan-specific)",
+    "Vague step language fails validation",
 ]:
     if token not in template:
         raise SystemExit(f"skills/implementaudit/templates/phase-goal.txt: missing plan-quality token: {token}")
+
+# Reconstructibility contract fixture (#50): the review-lane counter-example
+# for path-only targets where symbol precision is material must stay present
+# and self-declared as failing.
+neg_symbols = Path("fixtures/phase-design/negative-paths-without-symbols.md")
+if not neg_symbols.is_file():
+    raise SystemExit(f"missing reconstructibility negative fixture: {neg_symbols}")
+neg_text = neg_symbols.read_text(encoding="utf-8")
+for token in ["NEGATIVE FIXTURE", "must fail", "Expected disposition when reviewed: FAIL"]:
+    require(neg_text, neg_symbols, token)
 
 plan_ref = Path("skills/implementaudit/references/plan-lifecycle.md").read_text(encoding="utf-8")
 for token in [
@@ -255,6 +272,7 @@ for token in [
     "Commands You Will Need",
     "Done Criteria",
     "Rejected / Deferred Findings",
+    "Ordered Steps",
 ]:
     if token not in read_only_template:
         raise SystemExit(f"skills/implementaudit/templates/read-only-plan.md: missing template token: {token}")

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -243,6 +243,12 @@ require_file tests/skill-layout-contract.test.sh
 require_file tests/e2e-mini-audit-loop.test.sh
 require_file tests/skill-bootstrap-budget.test.sh
 require_file tests/source-evidence-pack.test.sh
+require_file tests/action-selection-contract.test.sh
+require_file fixtures/audit-action-selection/ordinary-task-deepens.md
+require_file fixtures/audit-action-selection/narrow-direct-stays-shallow.md
+require_file fixtures/audit-action-selection/negative-keyword-gated-depth.md
+require_file fixtures/audit-action-selection/negative-size-only-deepening.md
+require_file fixtures/audit-action-selection/negative-missing-selection-record.md
 require_file fixtures/dogfood-bootstrap/positive/baseline-first-transcript.jsonl
 require_file fixtures/dogfood-bootstrap/negative/installed-readback-before-baseline-transcript.jsonl
 require_file fixtures/dogfood-bootstrap/negative/chunking-readback-before-baseline-transcript.jsonl
@@ -568,6 +574,7 @@ bash tests/skill-layout-contract.test.sh
 bash tests/e2e-mini-audit-loop.test.sh
 bash tests/skill-bootstrap-budget.test.sh
 bash tests/source-evidence-pack.test.sh
+bash tests/action-selection-contract.test.sh
 bash tests/no-terminal-cap.test.sh
 bash tests/eval-harness.test.sh
 bash tests/payload-path-hygiene.test.sh

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -177,7 +177,7 @@ Load references only when the current gate needs them:
 - `references/routing.md`: greenfield/brownfield/mixed routing, DMAIC,
   DMADV, governed casual-build intake, and repo content as data.
 - `references/planning-depth.md`: when to synthesize a goal vs govern an
-  existing one.
+  existing one, and the action-selection contract for warranted depth.
 - `references/phase-design.md`: phase slicing, polish/harden pressure,
   Stage 6 self-critique, and phase quality.
 - `references/goal-format.md`: one ready-to-paste `/goal`, final
@@ -249,6 +249,10 @@ defaults, authorization boundaries, AGENTS.md, or repo policy.
 Validate the input; ask at most four material questions only when required.
 Use 0-2 true-gap questions when the gap is narrow. Classify greenfield,
 brownfield, or mixed and bind the `tdqyq-audit-object`.
+Derive the warranted `ydqyq-audit-action` set from scope, uncertainty, risk,
+dependencies, evidence gaps, authorization state, and intended executor; record
+selected and omitted actions with reasons per the action-selection contract in
+`references/planning-depth.md`. Depth never requires an activation keyword.
 
 ### Stage 2 - Recon / Gemba
 

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -203,6 +203,25 @@ Plan Closure owns sustainment, and final audit owns proof. Orphan terms,
 glossary-only lists, generic "apply SOLID" advice, numeric RPN theater, and
 separate term lanes are phase-design defects and trigger Andon.
 
+**Rule P4-10 — Executor reconstructibility (#50).**
+A phase spec is an executor-facing artifact: a fresh, weaker-context executor
+must be able to reconstruct the intended change from disk alone. Newly
+authored specs carry an ordered `## Implementation steps` section in which
+each step names its exact target — file path, plus symbol when symbol
+precision is material (a path alone that leaves plausible wrong-but-compiling
+candidates is a defect; counter-example:
+`fixtures/phase-design/negative-paths-without-symbols.md`, source repo only) —
+states the change precisely, and carries its own verify command with expected
+success shape. Specs also carry `## Scope boundaries` with an explicit
+`Out of scope:` line and plan-specific `## STOP conditions` tied to this
+phase's actual risks; boilerplate STOPs fail validation. Step granularity
+stays proportional to dependency, risk, and executor needs — a single-owner
+hotfix keeps one step; structural completeness never substitutes for
+operational specificity. The read-only handoff lane
+(`templates/read-only-plan.md`) and the executing phase bar align on this
+requirement where their contexts overlap. `validate-phase.sh` enforces the
+mechanical parts; cold review owns materiality judgments.
+
 ---
 
 ## Phase shape examples

--- a/skills/implementaudit/references/plan-lifecycle.md
+++ b/skills/implementaudit/references/plan-lifecycle.md
@@ -19,6 +19,8 @@ agent that has not read the chat transcript. Include:
   base ref is missing;
 - exact files or artifact owners to inspect before mutation;
 - phase order, dependencies, and rollback/defer path;
+- ordered implementation steps with exact file/symbol targets and per-step
+  verification when the work is multi-step;
 - acceptance criteria with observable pass/fail evidence;
 - mandatory commands with expected success shape, not fabricated output;
 - STOP / Andon conditions;

--- a/skills/implementaudit/references/planning-depth.md
+++ b/skills/implementaudit/references/planning-depth.md
@@ -87,6 +87,48 @@ For high-risk, release-affecting, package-boundary, provenance, or public-claim
 work, the planning layer must preserve the double-audit pattern: create or
 normalize the audit object, act against it, then verify terminal object closure.
 
+## Action-selection contract
+
+Every ordinary task-shaped invocation derives the warranted
+`ydqyq-audit-action` set from the live factors of the request and repo:
+
+- scope
+- uncertainty
+- risk
+- dependencies
+- evidence gaps
+- authorization state
+- intended executor
+
+Depth never requires an activation keyword. Do not wait for wording such as
+"deep", "plan", or "review" before selecting reconnaissance, dependency
+analysis, planning depth, or decomposition actions; the factors alone decide.
+The same factors also bound restraint: when a narrow, already-bounded
+owner/source repair gains no safety, evidence, sequencing, or executor
+reconstructibility from deeper structure, stay direct.
+
+Selection is recorded, both ways. Write an action-selection record into the
+audit object: the `## Action selection` section of the run-root `THINKING.md`
+when a run root exists, otherwise an equivalent transcript row. The record
+names:
+
+- input shape and intended executor;
+- uncertainty, dependency density, and evidence gaps;
+- authorization state;
+- selected `ydqyq-audit-actions`;
+- considered-but-omitted actions with the reason each was not warranted;
+- why deeper planning was or was not warranted.
+
+Reference loading follows selection. The selected action set names the
+owner/source references it needs: load `phase-design.md` when decomposition is
+selected, `child-agents.md` when bounded specialist review is selected, and
+`plan-lifecycle.md` when a handoff artifact will be emitted. A weak or
+fresh-context intended executor, material dependency density, ambiguity, or
+risk deepens the action set automatically; request size alone never does.
+
+An absent or hand-wavy action-selection record is a plan-quality defect, not a
+style preference.
+
 Regardless of planning depth, execution continues phase-by-phase until terminal
 audit closure (`AUDIT_COMPLETE`) or an explicit audited handoff
 (`AUDIT_HANDOFF`). Blocked work ends in handoff, not fake completion.

--- a/skills/implementaudit/scripts/validate-phase.sh
+++ b/skills/implementaudit/scripts/validate-phase.sh
@@ -29,6 +29,12 @@ validate-phase: a filled phase spec requires —
             with expected success shape);
             ## Evidence required (>=1 non-placeholder `- <evidence>` item);
             ## Rollback / defer path; ## Maintenance notes
+  reconstructibility (#50): vague step language always fails; newly authored
+            specs carry ## Implementation steps (ordered, each step with
+            target: exact file/symbol, verify: command, expected shape),
+            ## Scope boundaries with Out of scope:, and plan-specific
+            ## STOP conditions; specs without ordered steps pass as legacy
+            with a warning
   sidecar status: literal `Markdown fallback:` field (any value)
 Canonical filled examples (source repo only): fixtures/run-root-example/phases/phase-1.md (brownfield)
 and (source repo only) fixtures/phase-design/dmadv-greenfield-phase.md (greenfield);
@@ -236,6 +242,126 @@ if not tagged:
         "newly authored specs must tag every command\n")
 PY
   [ "$python_errors" -eq 0 ] || err "## Mandatory commands needs non-placeholder list items with expected success shape"
+  python_errors=0
+
+  # Check (#50): executor reconstructibility — vague language always fails;
+  # ordered implementation steps with per-step verification, scope boundaries,
+  # and plan-specific STOP conditions are required on newly authored specs;
+  # specs without an Implementation steps section pass as legacy with warning.
+  "${py_cmd[@]}" - "$phase_file" <<'PY' || python_errors=$((python_errors + 1))
+import re, sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+lines = text.splitlines()
+
+VAGUE = re.compile(
+    r"update the relevant files?|make it work|fix things|as needed\b|"
+    r"handle (it )?appropriately|the relevant modules?\b",
+    re.IGNORECASE,
+)
+PLACEHOLDER = re.compile(
+    r"^\{\{|^tbd$|^todo$|^n/a$|^placeholder$|step [0-9]+ title|stop_condition",
+    re.IGNORECASE,
+)
+
+def section_items(heading_re):
+    items, in_s = [], False
+    for line in lines:
+        s = line.strip()
+        if re.match(heading_re, s, re.IGNORECASE):
+            in_s = True
+            continue
+        if in_s and re.match(r"^##\s+|^---\s*$", s):
+            break
+        if not in_s:
+            continue
+        if s.startswith("-"):
+            items.append(s[1:].strip())
+        elif s and items:
+            items[-1] += " " + s
+    return [i for i in items if i]
+
+work_items = section_items(r"^##\s+Work\b")
+step_items_raw = section_items(r"^##\s+Implementation steps")
+vague_hits = [i for i in work_items + step_items_raw if VAGUE.search(i)]
+if vague_hits:
+    sys.stderr.write(
+        "validate-phase: vague step language is not executable by a fresh "
+        "executor; name exact files/symbols and the precise change: "
+        + "; ".join(vague_hits[:3]) + "\n")
+    raise SystemExit(1)
+
+if not re.search(r"(?mi)^##\s+Implementation steps", text):
+    sys.stderr.write(
+        "validate-phase: WARNING legacy spec — no ordered `## Implementation "
+        "steps` section; newly authored specs carry ordered steps with "
+        "per-step verification (see templates/phase-goal.txt)\n")
+    raise SystemExit(0)
+
+steps = [i for i in step_items_raw if not PLACEHOLDER.search(i)]
+if not steps:
+    sys.stderr.write(
+        "validate-phase: ## Implementation steps needs at least one "
+        "non-placeholder step item\n")
+    raise SystemExit(1)
+
+PATHISH = re.compile(r"[\w-]+[./][\w./\\-]+")
+bad_target = [s for s in steps
+              if not (re.search(r"target:\s*\S", s, re.IGNORECASE)
+                      and PATHISH.search(s))]
+if bad_target:
+    sys.stderr.write(
+        "validate-phase: each implementation step names its exact target "
+        "(file path, plus symbol when symbol precision is material): "
+        + "; ".join(bad_target[:3]) + "\n")
+    raise SystemExit(1)
+
+EXPECTED = re.compile(
+    r"\b(expected|expects|exit 0|passes|pass|no errors|outputs?)\b",
+    re.IGNORECASE,
+)
+no_verify = [s for s in steps
+             if not (re.search(r"verify:\s*\S", s, re.IGNORECASE)
+                     and EXPECTED.search(s))]
+if no_verify:
+    sys.stderr.write(
+        "validate-phase: each implementation step carries its own verify: "
+        "command with expected success shape — commands only at the end of "
+        "the phase do not reconstruct multi-step work: "
+        + "; ".join(no_verify[:3]) + "\n")
+    raise SystemExit(1)
+
+if (not re.search(r"(?mi)^##\s+Scope boundaries", text)
+        or not re.search(r"(?mi)^Out of scope:", text)):
+    sys.stderr.write(
+        "validate-phase: new-format spec requires ## Scope boundaries with "
+        "an `Out of scope:` line\n")
+    raise SystemExit(1)
+
+stop_items = [i for i in section_items(r"^##\s+STOP conditions")
+              if not PLACEHOLDER.search(i)]
+if not stop_items:
+    sys.stderr.write(
+        "validate-phase: new-format spec requires ## STOP conditions with at "
+        "least one non-placeholder item\n")
+    raise SystemExit(1)
+GENERIC_STOP = re.compile(
+    r"^(stop )?(if )?(something|anything) (goes wrong|fails|breaks)\.?$"
+    r"|^(stop )?(if )?(an )?unexpected errors? occurs?\.?$"
+    r"|^stop (if|when) (there is|you see) (a problem|an error)\.?$",
+    re.IGNORECASE,
+)
+ANCHORED = re.compile(r"`[^`]+`|[\w-]+[./][\w./\\-]+")
+if (all(GENERIC_STOP.match(i) for i in stop_items)
+        or not any(ANCHORED.search(i) for i in stop_items)):
+    sys.stderr.write(
+        "validate-phase: boilerplate STOP conditions do not reflect this "
+        "phase's actual risks; tie at least one STOP to a concrete file, "
+        "command, marker, or assumption of this phase\n")
+    raise SystemExit(1)
+PY
+  [ "$python_errors" -eq 0 ] || err "reconstructibility checks failed: ordered steps / scope boundaries / plan-specific STOP conditions (see --explain)"
   python_errors=0
 
   # Check: current-state excerpts section has at least one non-placeholder item.

--- a/skills/implementaudit/templates/ROADMAP.md
+++ b/skills/implementaudit/templates/ROADMAP.md
@@ -22,6 +22,14 @@ Double-audit sequence, if release-affecting or high-risk:
 2. ydqyq-audit-action against tdqyq-audit-object:
 3. Final ydqyq-audit-action -> terminal tdqyq-audit-object state:
 
+## Action selection
+
+Selected ydqyq-audit-actions:
+
+Omitted-but-considered actions (with reasons):
+
+Depth rationale (warranted / not warranted because):
+
 ## Baseline ref
 
 <!-- Commit hash, branch, or file snapshot used for diff-based final audit. -->

--- a/skills/implementaudit/templates/THINKING.md
+++ b/skills/implementaudit/templates/THINKING.md
@@ -44,6 +44,22 @@ IMPLEMENTAUDIT_BASELINE_REF:
 
 Legacy flat `.IMPLEMENTAUDIT/` resume status:
 
+## Action selection
+
+Input shape:
+
+Intended executor:
+
+Uncertainty / dependency density / evidence gaps:
+
+Authorization state:
+
+Selected ydqyq-audit-actions:
+
+Considered-but-omitted actions (with reasons):
+
+Why deeper planning was or was not warranted:
+
 ## Available context
 
 Host/session constraints:

--- a/skills/implementaudit/templates/phase-goal.txt
+++ b/skills/implementaudit/templates/phase-goal.txt
@@ -59,6 +59,33 @@ Issue publication: deferred / not applicable
 - {{WORK_BULLET_1}}
 - {{WORK_BULLET_2}}
 
+## Implementation steps (ordered)
+
+Each step names its exact target — file path, plus symbol when symbol
+precision is material — states the change precisely, and carries its own
+verify command with expected success shape. Order steps so the tree stays
+healthy between steps when possible. Vague step language fails validation.
+Step granularity stays proportional to dependency, risk, and executor needs.
+
+- Step 1: {{STEP_1_TITLE}} — target: {{EXACT_FILE_AND_SYMBOL_1}}; change: {{PRECISE_CHANGE_1}}; verify: {{STEP_1_COMMAND}}; expected: {{STEP_1_EXPECTED}}
+- Step 2: {{STEP_2_TITLE}} — target: {{EXACT_FILE_AND_SYMBOL_2}}; change: {{PRECISE_CHANGE_2}}; verify: {{STEP_2_COMMAND}}; expected: {{STEP_2_EXPECTED}}
+
+## Scope boundaries
+
+In scope: {{IN_SCOPE_FILES_OR_SURFACES}}
+Out of scope: {{OUT_OF_SCOPE_WITH_REASON_EVEN_WHEN_RELATED_LOOKING}}
+
+## STOP conditions (plan-specific)
+
+Stop and raise Andon instead of improvising when:
+
+- {{STOP_CONDITION_TIED_TO_THIS_PHASE_ACTUAL_RISK_1}}
+- {{STOP_CONDITION_TIED_TO_THIS_PHASE_ACTUAL_RISK_2}}
+
+Boilerplate STOP conditions that do not reflect this phase's actual risks
+fail validation; tie each STOP to a concrete file, command, marker, or
+assumption of this phase.
+
 ## Acceptance criteria (all must pass — verify each in transcript)
 
 - {{CRITERION_1}}

--- a/skills/implementaudit/templates/read-only-plan.md
+++ b/skills/implementaudit/templates/read-only-plan.md
@@ -21,6 +21,16 @@ it never reaches a mutating `ydqyq-audit-action`.
 - `<path>`: evidence excerpt or summary.
 - Repo conventions/exemplar files:
 
+## Ordered Steps
+
+Executing-phase and read-only handoff bars align on reconstructibility: when
+the planned work is multi-step, each step names its exact target — file path,
+plus symbol when symbol precision is material — states the change precisely,
+and carries its own verify command with expected success shape. Vague step
+language is a plan-quality defect.
+
+- Step 1: `<title>` — target: `<file and symbol>`; change: `<precise change>`; verify: `<command>`; expected: `<success shape>`
+
 ## Scope
 
 In scope:

--- a/tests/action-selection-contract.test.sh
+++ b/tests/action-selection-contract.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Action-selection contract test (#48, IA-ACTION-DEPTH): runs the checker on
+# the live repo, then proves the checker actually fails on mutated copies
+# (embedded negative controls, not whole-file grep optimism).
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fail() {
+  printf 'action-selection-contract.test: %s\n' "$*" >&2
+  exit 1
+}
+
+# 1. Positive: live repo passes.
+bash scripts/check-action-selection-contract.sh \
+  || fail "checker fails on the live repo"
+
+# Sandbox for negative controls.
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+reset_sandbox() {
+  rm -rf "$tmp_root"
+  mkdir -p \
+    "$tmp_root/skills/implementaudit/references" \
+    "$tmp_root/skills/implementaudit/templates" \
+    "$tmp_root/fixtures/audit-action-selection" \
+    "$tmp_root/fixtures/native-integration" \
+    "$tmp_root/fixtures/audit-object-routing"
+  cp skills/implementaudit/SKILL.md "$tmp_root/skills/implementaudit/"
+  cp skills/implementaudit/references/planning-depth.md \
+    "$tmp_root/skills/implementaudit/references/"
+  cp skills/implementaudit/templates/THINKING.md \
+    skills/implementaudit/templates/ROADMAP.md \
+    "$tmp_root/skills/implementaudit/templates/"
+  cp fixtures/audit-action-selection/*.md \
+    "$tmp_root/fixtures/audit-action-selection/"
+  cp fixtures/native-integration/single-plan-native-route.md \
+    "$tmp_root/fixtures/native-integration/"
+  cp fixtures/audit-object-routing/deep-pressure-disclosure.md \
+    "$tmp_root/fixtures/audit-object-routing/"
+}
+
+expect_fail() {
+  local label="$1"
+  if bash scripts/check-action-selection-contract.sh --repo-root "$tmp_root" \
+    >/dev/null 2>&1; then
+    fail "negative control not detected: $label"
+  fi
+}
+
+# 2. Sanity: untouched sandbox passes.
+reset_sandbox
+bash scripts/check-action-selection-contract.sh --repo-root "$tmp_root" \
+  >/dev/null 2>&1 || fail "checker fails on the untouched sandbox copy"
+
+# 3. Keyword-freedom clause removed from the contract -> must fail.
+reset_sandbox
+grep -v "Depth never requires an activation keyword" \
+  "$tmp_root/skills/implementaudit/references/planning-depth.md" \
+  >"$tmp_root/planning-depth.tmp"
+mv "$tmp_root/planning-depth.tmp" \
+  "$tmp_root/skills/implementaudit/references/planning-depth.md"
+expect_fail "planning-depth.md without the keyword-freedom clause"
+
+# 4. Action-selection record loses its template home -> must fail.
+reset_sandbox
+sed 's/^## Action selection$/## Renamed section/' \
+  "$tmp_root/skills/implementaudit/templates/THINKING.md" \
+  >"$tmp_root/thinking.tmp"
+mv "$tmp_root/thinking.tmp" \
+  "$tmp_root/skills/implementaudit/templates/THINKING.md"
+expect_fail "THINKING.md without the Action selection section"
+
+# 5. A negative fixture disappears -> must fail.
+reset_sandbox
+rm "$tmp_root/fixtures/audit-action-selection/negative-keyword-gated-depth.md"
+expect_fail "missing negative-keyword-gated-depth fixture"
+
+# 6. Command-mode advertisement in the new surfaces -> must fail.
+reset_sandbox
+printf '\nAdvertised mode: /implementaudit deep\n' \
+  >>"$tmp_root/fixtures/audit-action-selection/ordinary-task-deepens.md"
+expect_fail "command-mode advertisement in an action-selection fixture"
+
+printf 'action-selection-contract.test: ok\n'

--- a/tests/phase-validation.test.sh
+++ b/tests/phase-validation.test.sh
@@ -293,11 +293,61 @@ make_valid "$f"
 sed -i 's/; scope: [^;]*;/;/g' "$f"
 check_fail_contains "property tag without scope" "$f" "lacks \`scope:\`"
 
+# ------------------------------------------------------------------
+# Reconstructibility (#50): ordered steps, per-step verification,
+# scope boundaries, plan-specific STOP conditions
+# ------------------------------------------------------------------
+# FAIL: vague step language (fixture counter-example)
+check_fail_contains "vague step language" \
+  fixtures/phase-validation/negative-vague-steps.md \
+  "vague step language"
+
+# FAIL: multi-step spec without per-step verification (fixture counter-example)
+check_fail_contains "multi-step without per-step verify" \
+  fixtures/phase-validation/negative-multistep-no-per-step-verify.md \
+  "carries its own verify:"
+
+# FAIL: boilerplate STOP conditions (fixture counter-example)
+check_fail_contains "boilerplate STOP conditions" \
+  fixtures/phase-validation/negative-boilerplate-stop.md \
+  "boilerplate STOP conditions"
+
+# FAIL: new-format spec missing Out of scope
+f="$tmp/no_out_of_scope.md"
+make_valid "$f"
+sed -i 's/^Out of scope:.*$/Removed boundary line./' "$f"
+check_fail_contains "new-format spec without Out of scope" "$f" \
+  "Out of scope"
+
+# FAIL: vague language injected into a valid spec's steps
+f="$tmp/vague_injected.md"
+make_valid "$f"
+sed -i 's/- Step 3: Register the route.*/- Step 3: Register the route — target: src\/app.ts; change: update the relevant files as needed; verify: npm test; expected: exit 0/' "$f"
+check_fail_contains "vague language injected into steps" "$f" \
+  "vague step language"
+
+# PASS with warning: legacy spec without ordered Implementation steps
+f="$tmp/legacy_no_steps.md"
+make_valid "$f"
+sed -i '/^## Implementation steps (ordered)$/,/^## Scope boundaries$/{/^## Scope boundaries$/!d}' "$f"
+out="$tmp/legacy_no_steps.out"
+if bash skills/implementaudit/scripts/validate-phase.sh "$f" >"$out" 2>&1 \
+    && grep -q "no ordered" "$out"; then
+  pass=$((pass + 1))
+else
+  printf 'phase-validation.test: legacy spec without steps must pass WITH warning\n' >&2
+  cat "$out" >&2
+  fail=$((fail + 1))
+fi
+
 # Shipped phase-spec fixtures stay LF-only: PR #25's migration rewrote
 # three fixtures with CRLF, hiding a 7-line substantive change inside a
 # 221-line line-ending churn (Fable review of PR #25).
 for spec in fixtures/phase-design/dmadv-greenfield-phase.md \
             fixtures/phase-validation/valid-full-spec.md \
+            fixtures/phase-validation/negative-vague-steps.md \
+            fixtures/phase-validation/negative-multistep-no-per-step-verify.md \
+            fixtures/phase-validation/negative-boilerplate-stop.md \
             fixtures/run-root-example/phases/phase-1.md \
             fixtures/e2e-mini-audit-loop/phase-1.md; do
   if tr -dc '\r' < "$spec" | grep -q .; then

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -160,13 +160,15 @@ with zipfile.ZipFile(asset) as zf:
             f"calling writestr(). Stored: {sample}{tail}"
         )
 
-    # Total asset size guard: uncompressed asset is ~155 KB; properly deflated
-    # is ~60 KB for the current payload.  120 KB provides ~2x headroom for
-    # legitimate payload growth while still catching accidental ZIP_STORED
-    # regressions.  Update this threshold only after confirming entries remain
-    # ZIP_DEFLATED (the check above) and the payload growth is intentional.
+    # Total asset size guard: catches accidental ZIP_STORED regressions and
+    # unintentional payload bloat.  Update this threshold only after confirming
+    # entries remain ZIP_DEFLATED (the check above) and the payload growth is
+    # intentional.  History: 120_000 set at v0.2.6.0 (~60 KB deflated payload,
+    # ~2x headroom); raised to 130_000 for #48 (IA-ACTION-DEPTH) after the
+    # v0.3.2.0 review-set integration plus the action-selection contract grew
+    # the deflated asset to ~121 KB — growth verified intentional and deflated.
     asset_bytes = asset.stat().st_size
-    MAX_ASSET_BYTES = 120_000
+    MAX_ASSET_BYTES = 130_000
     if asset_bytes > MAX_ASSET_BYTES:
         raise SystemExit(
             f"asset size {asset_bytes:,} bytes exceeds the {MAX_ASSET_BYTES:,}-byte "


### PR DESCRIPTION
Closes #50 (`IA-PHASE-RECONSTRUCTIBILITY`). Program umbrella: #47 (`IA-ACTION-TRACK`). Depends on #48 — **based on the unmerged head of PR #60** per the pack's dependency rule; the integrator merges #60 first.

## Provenance

Genuine Fable 5 implementation session (session 18/23 of the
issue-implementation pack). Model identity recorded at session start:
Fable 5 (`claude-fable-5`); no substitution occurred during the session.

## Base

Branch `impl/issue-50-phase-reconstructibility` from
`5789b43966426140be45bef6285a868a7d53e788` — the head of unmerged draft
PR #60 (session 17, #48), which sits on `origin/main` @ `5a2cd35`.

## What this implements

Cold-executor reconstructibility as a validated property of phase specs and
read-only handoffs — a fresh, weaker-context executor can carry out the work
from disk alone, and vague-but-structurally-valid phase bodies are rejected
before handoff.

- `skills/implementaudit/templates/phase-goal.txt` — new sections:
  `## Implementation steps (ordered)` (each step: exact file/symbol target,
  precise change, own verify command with expected success shape),
  `## Scope boundaries` with explicit `Out of scope:`, and plan-specific
  `## STOP conditions`.
- `skills/implementaudit/scripts/validate-phase.sh` — new reconstructibility
  check: vague step language ("update the relevant files", "make it work",
  "the relevant module", "as needed") always fails, in `## Work` and steps
  alike; newly authored specs (with the steps section) require per-step
  `target:` + `verify:` + expected shape, `Out of scope:`, and non-generic,
  concretely anchored STOP conditions; specs without ordered steps pass as
  **legacy with a warning** — the same precedent as evidence-property tags.
  Continuation lines are joined so wrapped bullets cannot dodge the checks.
- `scripts/check-plan-quality-contract.sh` — source-gate pins for the new
  template sections; "update the relevant files" and "the relevant module"
  added to the forbidden-phrase list; presence pin for the review-lane
  counter-example fixture.
- `skills/implementaudit/references/phase-design.md` — new
  **Rule P4-10 — Executor reconstructibility**: symbol precision when
  material (mechanical validators cannot judge materiality — cold review
  owns it), proportional step granularity, alignment with the read-only bar.
- `skills/implementaudit/references/plan-lifecycle.md` — Self-Contained Plan
  Standard gains the ordered-steps bullet.
- `skills/implementaudit/templates/read-only-plan.md` — `## Ordered Steps`
  section; `fixtures/read-only-plans/valid-handoff-plan.md` gains the
  alignment note (it already demonstrated per-step Verify).
- Canonical fixtures upgraded to the new shape (all four):
  `fixtures/phase-validation/valid-full-spec.md`,
  `fixtures/e2e-mini-audit-loop/phase-1.md`,
  `fixtures/run-root-example/phases/phase-1.md` (single-step — demonstrates
  proportional granularity), `fixtures/phase-design/dmadv-greenfield-phase.md`.
- New negative fixtures — three mechanical:
  `negative-vague-steps.md`, `negative-multistep-no-per-step-verify.md`
  (commands only at the end of multi-step work), `negative-boilerplate-stop.md`;
  plus the review-lane counter-example
  `fixtures/phase-design/negative-paths-without-symbols.md` (paths without
  symbols where symbol precision is material).
- `tests/phase-validation.test.sh` — six new cases (three fixture negatives,
  missing-Out-of-scope mutation, vague-injection mutation, legacy-warning
  pass) and the three new fixtures added to the LF guard. No new test file →
  no registry changes.
- `README.md`, `AGENTS.md`, `CHANGELOG.md` — reconstructibility documented
  as a native quality requirement.

## Architecture conformance (#47)

No new command identity, no keyword mode, no parallel planning subsystem, no
competing canonical root: `.IMPLEMENTAUDIT/runs/` remains canonical, root
`plans/` stays a read-only projection lane, governance metadata untouched.
Legacy specs are not broken (warn, not fail).

## Deliberate boundary

The plan-quality checker's read-only else-branch token list was left
unchanged: hardening it would re-shape this repo's crafted negative-plan
tests for the wrong reason. Alignment is carried by the template pin
(`Ordered Steps`), the fixture adaptation, and Rule P4-10. Weak-executor
replay evaluation is deferred to #52 by the issue's own design.

## Smoke protocol note (owner-directed deviation)

Formal Smoke A/Smoke B comparison is deferred to the pack integration
branch per the owner's session instruction. Baseline identity: `5789b43`
(session 17's fully green tree). Post-change, this worktree ran:

- focused gates: validate-phase on 4 canonical fixtures (ok) and 3 negative
  fixtures (fail with the intended diagnostics);
  `tests/phase-validation.test.sh` 41/41; plan-quality contract + test; e2e
  mini audit loop
- full `tests/*.test.sh`, all `scripts/check-*.sh`, and
  `bash scripts/verify-package.sh` — results listed in the session report

This implementation PR is intentionally unmerged. The integrator merges the
sessions of this pack in session order (17 -> 22) before session 23 closes
the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
