### PR TITLE
Eval: candidate-product attestation for post-change/comparison phases (product_expected_rev, H41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ### Added
 
+- Eval: candidate-product attestation for the post-change/comparison
+  phases — host adapters gain `product_expected_rev` (default
+  `v0.3.1.0`, so every baseline path is byte-identical); campaign
+  runners pass the campaign intent's candidate commit and the identity
+  gate cross-checks the checkout HEAD against that INTENDED identity
+  (mismatch still refuses; never self-attestation). Tests
+  H41/H41b/H41c.
+
 - Context-epoch continuity contract (#35): a compacted/reconstructed
   summary is an observation of history, not current-state authority. New
   packaged reference `references/continuity.md`; PROTOCOL template

--- a/eval/hosts.py
+++ b/eval/hosts.py
@@ -391,10 +391,16 @@ class _BaseAdapter:
 
     def __init__(self, host_argv_template, requested_model,
                  product_checkout=None, host_cwd=None, formal=True,
-                 lane_id=None):
+                 lane_id=None, product_expected_rev="v0.3.1.0"):
         self.host_argv_template = list(host_argv_template)
         self.requested_model = requested_model
         self.product_checkout = product_checkout
+        # The rev the product checkout MUST be at to attest (tag or full
+        # SHA). Defaults to the immutable baseline tag; candidate-product
+        # campaigns (post-change B3, cluster/final comparisons) pass the
+        # campaign intent's candidate commit so the gate cross-checks the
+        # checkout against the INTENDED identity — never self-attestation.
+        self.product_expected_rev = product_expected_rev
         self.host_cwd = host_cwd
         # A FORMAL run produces evidence (smoke/baseline/comparison) and
         # must carry an attested product checkout — zero identities are
@@ -970,7 +976,9 @@ class _BaseAdapter:
                  "product_tree": "0" * 40,
                  "installed_payload_sha256": "0" * 64}
         if self.product_checkout:
-            ident.update(framework.product_identity(self.product_checkout))
+            ident.update(framework.product_identity(
+                self.product_checkout,
+                expected_tag=self.product_expected_rev))
             canonical = framework.payload_hash(os.path.join(
                 self.product_checkout, "skills", "implementaudit"))
             ident["payload_source_sha256"] = canonical

--- a/eval/test_hosts.py
+++ b/eval/test_hosts.py
@@ -908,6 +908,55 @@ def main():
         check("H40c kindless-terminal-fails-closed",
               s40c == "INVALID"
               and "terminal" in (v40c.get("reason") or ""))
+
+        # 41. Candidate-product attestation (#35 post-change / comparison
+        # phases): product_identity attests a checkout at an explicitly
+        # intended non-baseline rev, still refuses a mismatched rev, and
+        # the adapter's product_expected_rev is what identity_fields
+        # passes down — the gate cross-checks against the campaign
+        # intent's identity, never self-attestation.
+        cand41 = os.path.join(tmp, "cand41")
+        subprocess.run(["git", "init", "-q", cand41], check=True)
+        for k, v in (("user.email", "t@t"), ("user.name", "t")):
+            subprocess.run(["git", "-C", cand41, "config", k, v],
+                           check=True)
+        open(os.path.join(cand41, "f.txt"), "w").write("candidate\n")
+        subprocess.run(["git", "-C", cand41, "add", "."], check=True)
+        subprocess.run(["git", "-C", cand41, "commit", "-q", "-m", "c1"],
+                       check=True)
+        head41 = subprocess.run(["git", "-C", cand41, "rev-parse", "HEAD"],
+                                capture_output=True, text=True,
+                                check=True).stdout.strip()
+        ident41 = framework.product_identity(cand41, expected_tag=head41)
+        check("H41 candidate-rev-attests",
+              ident41.get("product_commit") == head41
+              and ident41.get("product_tag") == head41)
+        open(os.path.join(cand41, "f.txt"), "a").write("drift\n")
+        subprocess.run(["git", "-C", cand41, "add", "."], check=True)
+        subprocess.run(["git", "-C", cand41, "commit", "-q", "-m", "c2"],
+                       check=True)
+        try:
+            framework.product_identity(cand41, expected_tag=head41)
+            check("H41b mismatched-rev-refused", False)
+        except framework.AdapterError as exc:
+            check("H41b mismatched-rev-refused",
+                  "refuse to attest" in str(exc))
+        seen41 = {}
+        prev_ident41 = framework.product_identity
+        framework.product_identity = (
+            lambda checkout, expected_tag="v0.3.1.0":
+                (seen41.update(tag=expected_tag) or {
+                    "product_tag": expected_tag, "product_commit": "x",
+                    "product_tree": "y"}))
+        try:
+            a41 = make_adapter(tmp, "ok-codex", checkout=cand41,
+                               home=os.path.join(tmp, "codex-home-h41"))
+            a41.product_expected_rev = "deadbeef-intended-rev"
+            a41.identity_fields("r-h41", "B0", "m", "t0", "t1")
+        finally:
+            framework.product_identity = prev_ident41
+        check("H41c adapter-passes-expected-rev",
+              seen41.get("tag") == "deadbeef-intended-rev")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     if failures:


### PR DESCRIPTION
The identity gate could attest only the immutable v0.3.1.0 product (hardcoded default), making the candidate-product phases of the release program (post-change B3, cluster/final comparisons) unreachable — caught live by the fail-closed gate at the first post-change mission.

- Base adapter gains `product_expected_rev` (default `v0.3.1.0` — all baseline behavior byte-identical; both subclasses inherit via `**kw`).
- `identity_fields` passes it to `product_identity`, which already accepted `expected_tag`.
- Campaign runners pass the campaign intent's candidate commit: the gate cross-checks checkout HEAD against the intended identity; mismatch still refuses (H41b). No self-attestation path exists.
- Tests: H41 candidate-rev-attests, H41b mismatched-rev-refused, H41c adapter-passes-expected-rev. All eval suites green (selftest 21 fixtures, hosts, adapters, adversarial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)