### PR TITLE
Continuity: surface post-boundary reconciliation in the bootloader Runtime Loop (#35 repair)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ schema evidence proved four-component plugin manifest versions are accepted.
   (mismatch still refuses; never self-attestation). Tests
   H41/H41b/H41c.
 
+- Context-epoch continuity, bootloader surfacing (#35, B3-driven
+  repair): the post-change B3 wave (b3-post-fable-r1) showed the
+  reference-only placement does not reach a resuming executor — all four
+  candidate missions failed the scored behaviors. The post-boundary
+  reconciliation is now Runtime Loop step 0 in `SKILL.md` itself
+  (provenance enum, live-state-wins reread, epoch-row recording,
+  satisfied-one-shot refusal with terminal evidence, continue-from-
+  current), pinned by `tests/continuity-contract.test.sh`.
+
 - Context-epoch continuity contract (#35): a compacted/reconstructed
   summary is an observation of history, not current-state authority. New
   packaged reference `references/continuity.md`; PROTOCOL template

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -315,6 +315,18 @@ second `/goal` inside an existing `/goal` run.
 
 ## Runtime Loop
 
+0. Continuity boundary (when resuming): after any `host-reported-compaction`
+   / `new-session` / `handoff-resume` / `manual-resume` /
+   `inferred-context-gap` — never a fabricated compaction — FIRST reread
+   the live run-root STATE.md and ROADMAP.md from disk: a compacted or
+   reconstructed summary is an observation of history, and live state wins.
+   Record the boundary provenance as a STATE epoch row, classify each
+   remembered steer by lifecycle, and refuse to re-execute a satisfied
+   one-shot (e.g. an already-resolved ANDON), citing its terminal evidence:
+   "Target already satisfied at <evidence>; no duplicate action taken."
+   Standing constraints/authorizations survive the boundary. Then continue
+   from the current next authorized action — never restart. Details:
+   `references/continuity.md`. An uninterrupted turn skips this step.
 1. Safety read: `AGENTS.md`, README/CONTRIBUTING/docs/workflows, existing audit
    docs, generator/source ownership, and authorization chain.
 2. Input gate: stop on empty, malformed, unsafe, unsupported, or non-audit

--- a/tests/continuity-contract.test.sh
+++ b/tests/continuity-contract.test.sh
@@ -52,6 +52,17 @@ grep -qi "never a fabricated compaction" "$state_t" || fail "STATE template miss
 grep -qi "Context epochs and instruction applicability" "$state_t" || fail "STATE template missing epoch section"
 grep -qi "NO new marker" "$tc" || fail "transcript contract missing no-new-marker rule"
 grep -q "references/continuity.md" skills/implementaudit/SKILL.md || fail "SKILL.md load map missing continuity reference"
+# The bootloader itself must carry the load-bearing runtime instruction —
+# the B3 post-change r1 wave proved reference-only placement does not
+# reach a resuming executor (all four candidate missions failed).
+skill="skills/implementaudit/SKILL.md"
+for tok in host-reported-compaction new-session handoff-resume \
+           manual-resume inferred-context-gap; do
+  grep -q "$tok" "$skill" || fail "SKILL.md runtime loop missing provenance token: $tok"
+done
+grep -qi "live state wins" "$skill" || fail "SKILL.md runtime loop missing live-state-wins rule"
+grep -qi "Target already satisfied at" "$skill" || fail "SKILL.md runtime loop missing refusal sentence"
+grep -qi "epoch row" "$skill" || fail "SKILL.md runtime loop missing epoch-row recording"
 
 # 2. Template-built root (empty epoch tables) passes; a stripped legacy
 # root (no epoch section at all) also passes — old roots stay resumable.


### PR DESCRIPTION
Bounded repair from the adverse b3-post-fable-r1 wave (pre-registered rule verdict: non-improvement). The five scored B3 behaviors and their vocabulary lived only in `references/continuity.md` + templates — three hops from the bootloader a resuming executor actually reads, and legacy run roots seed a stale pre-#35 PROTOCOL copy. The reconciliation contract is now **Runtime Loop step 0** in `SKILL.md` (provenance enum, live-state-wins reread, epoch-row recording, satisfied-one-shot refusal citing terminal evidence, continue-from-current, uninterrupted-turn skip), pinned by `tests/continuity-contract.test.sh`. Budget 431/450 lines. Focused gates green. Rerun: fresh campaign `b3-post-fable-r2` after merge; the r1 adverse ledger is preserved evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)