### PR TITLE
docs: v0.3.2.0 publish + readback evidence [Opus-authored]

### DIFF
--- a/docs/audits/archive/v0.3.2.0-install-and-drift-report.md
+++ b/docs/audits/archive/v0.3.2.0-install-and-drift-report.md
@@ -12,38 +12,61 @@ tree).
 ## Build
 
 - Release asset: `dist/IMPLEMENTAUDIT.skill`
-- Build command: `bash scripts/build-release-asset.sh`
-- Asset sha256: [FILLED AT BUILD]
+- Build command: `bash scripts/build-release-asset.sh` (extraction-validated)
+- Asset sha256: `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+- Asset size: 131329 bytes
 - Checksums file: `dist/CHECKSUMS.txt`
 - Plugin manifest version in asset: `0.3.2` (extraction-validated)
 
 ## Tag and release
 
-- Annotated tag: `v0.3.2.0` -> [FILLED: tag target SHA]
-- Release URL: [FILLED]
-- Uploaded assets: `IMPLEMENTAUDIT.skill`, checksums -> [FILLED: names/sizes]
+- Annotated tag: `v0.3.2.0` → commit `dfa55020cd883e1c9b1b65f7e96921b383b72820`
+  (the merged release PR #70 commit on `main`; CI green before tagging)
+- Release URL: https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.2.0
+- Uploaded assets: `IMPLEMENTAUDIT.skill` (131329 bytes), `CHECKSUMS.txt`
 
 ## Readback (public == intended)
 
-- Downloaded asset sha256 == built asset sha256: [FILLED]
-- Tag target == merged release commit on main: [FILLED]
-- Release body records the asset digest: [FILLED]
-- No tag movement / no duplicate release: [FILLED]
-- README / docs portal show `v0.3.2.0` as the live release: [FILLED]
+- Downloaded published asset sha256 = `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+  — **identical** to the built asset. ✅
+- Annotated tag `v0.3.2.0` dereferences to commit `dfa5502` = the merged
+  release commit on `main`. ✅
+- Release body records the asset digest (via `CHECKSUMS.txt`). ✅
+- Exactly one `v0.3.2.0` release, marked Latest; no duplicate release, no
+  tag movement. ✅
+- README (`current release v0.3.2.0`) and docs portal (`site.json`
+  milestone/manifest, regenerated overview page) show `v0.3.2.0` as the
+  live release on `main`. ✅
 
 ## Active install update
 
-- Install target (real Codex/Claude home or declared install path): [FILLED]
-- Installed from the PUBLIC asset URL (not the working tree): [FILLED]
-- Installed payload sha256 == published asset payload: [FILLED]
+- Install target: real Codex home `C:\Users\theis\.codex\skills\implementaudit`
+  (was version 0.3.1).
+- Installed from the **verified public asset** via
+  `install-codex-from-release.sh --asset <downloaded public skill>
+  --checksum <public CHECKSUMS> --codex-home ~/.codex --version 0.3.2`.
+- Installer-reported sha256 `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+  (matches public asset). Active install now reports SKILL.md
+  `version: "0.3.2"`.
+- Note: this is an authorized active-install MAINTENANCE update, not a
+  dogfood-proof claim (per AGENTS.md, real-home installs are never
+  release-candidate dogfood proof).
 
 ## Post-release installed smoke
 
-- Smoke command + result: [FILLED]
-- If a live host is unavailable, record BLOCKED honestly (per AGENTS.md
-  Claude-Desktop install-proof rule) rather than claiming install proof.
+- Installed payload has the correct flat archive shape (`SKILL.md` at root;
+  `references/`, `scripts/`, `templates/`; no nested `skills/`).
+- `references/continuity.md` (the #35 context-epoch contract) is present in
+  the installed payload — the new behavior shipped and installs.
+- SKILL.md frontmatter version is `0.3.2`.
+- A full behavioral installed-skill run (model-in-the-loop against the
+  installed payload) is NOT claimed here; the structural + hash smoke above
+  is the post-release proof, and the behavioral evidence is the pre-release
+  evaluation program (issue #9).
 
 ## Drift statement
 
-[FILLED: any difference between source checkout, built asset, and public
-release — expected to be none; the source is the release commit.]
+No drift: the source checkout at the release commit `dfa5502`, the built
+asset, and the published release asset are one and the same (byte-identical
+payload hash across build → publish → download → install). The active
+install now matches the public release.

--- a/docs/audits/archive/v0.3.2.0-issue-closure-ledger.md
+++ b/docs/audits/archive/v0.3.2.0-issue-closure-ledger.md
@@ -17,16 +17,18 @@ release closure (R8). Milestone: v0.3.2.0 (#1).
 | #6 | Route-sufficient rule | PR #27 merged; review #43 (transferred/risk-accepted require refs); combined suite green | CLOSED (pre-session) |
 | #7 | Second-order recurrence | PR #28 merged; review #44 CONFIRMED report-only (6/6 checker mutations detected) | CLOSED (pre-session) |
 | #8 | Path hygiene | PR #16 (historical) | CLOSED (pre-program) |
-| #9 | Model-in-the-loop evaluation | 84/84 primary baseline; B3 five waves; cmp-fable-r2 comparison campaign (56/56, no regressions; r1 halted fail-closed at index 4 on a harness bug fixed in #71, re-run clean); evaluation report | [CLOSE AT R8] |
-| #10 | Evidence-integrity tracking | Full program ledger: reviews integrated, qualification chain, release published + readback | [CLOSE AT R8] |
+| #9 | Model-in-the-loop evaluation | 84/84 primary baseline; B3 five waves; cmp-fable-r2 comparison campaign (56/56, no regressions; r1 halted fail-closed at index 4 on a harness bug fixed in #71, re-run clean); evaluation report | CLOSED at R8 (Opus-authored; Fable re-check pending) |
+| #10 | Evidence-integrity tracking | Full program ledger: reviews integrated, qualification chain, release v0.3.2.0 published (`dfa5502`, asset `a0416519`) + readback + active-install update | CLOSED at R8 (Opus-authored; Fable re-check pending) |
 | #11 | Convergence mode | PR #33 merged; review #56 CONFIRMED (overclaim already retracted; adoption gate deliberately deferred to v0.3.3.0 backlog) | CLOSED (pre-session) |
 | #12 | Parameter-bound authorization | PR #32 merged; review #55 (bound-but-unsupplied drift, duplicate keys, final-line retention); authorization-binding test green | CLOSED (pre-session) |
 | #13 | Lesson lift | PR #29 merged; review #45 (five scorer gaps fixed); lesson-lift test green | CLOSED (pre-session) |
 | #14 | Closure surface | PR #31 merged; review #54 (unique Claim-IDs; near-miss rows fail); closure-surface test green | CLOSED (pre-session) |
 | #15 | Handoff inspection | PR #30 merged; review #46 (full-40-hex tree equality, duplicate keys, sha256 recomputation); handoff-packet test green | CLOSED (pre-session) |
 | #20 | Eval custody hardening | PR #21 merged; review #37 (reconcile ValueError, fail-closed parent-terminal gate, H40 chain) | CLOSED (pre-session) |
-| #35 | Context-epoch continuity | PRs #67/#68/#69 + seed 5ea24fa; deterministic criteria green; B3 disposition: improvement without regression (evaluation report §2); reopened 2026-07-18 after premature close, closes with release | [CLOSE AT R8] |
+| #35 | Context-epoch continuity | PRs #67/#68/#69/#71 + seed 5ea24fa; deterministic criteria green; B3 pre/post comparison: improvement without regression (evaluation report §2); continuity.md shipped + installs in the published asset | CLOSED at R8 (Opus-authored; Fable re-check pending) |
 | #47–#53 | IA-* remediation | PRs #60–#66 (owner-merged, independently qualified); closed by their own merges | CLOSED (owner) |
 
 Review PRs #37–#46, #54–#59: all sixteen MERGED (none stale). Working PRs
-#67–#69 MERGED. Release PR #70: [MERGED AT R7].
+#67, #68, #69, #71 MERGED. Release PR #70 MERGED (`dfa5502`). Milestone
+v0.3.2.0 (#1): closed at R8 after all its issues closed and the release
+published.

--- a/docs/audits/archive/v0.3.2.0-release-report.md
+++ b/docs/audits/archive/v0.3.2.0-release-report.md
@@ -129,6 +129,25 @@ double-check scheduled.
 
 ### Build / publish / readback evidence
 
-[FILLED AS EACH STEP EXECUTES — asset hash, tag SHA, release URL,
-readback record, active-install update, post-release installed smoke.
-Not pre-filled: no proof claim precedes the action.]
+Pre-publish adversarial gate (5 independent skeptics, PR-less workflow):
+release-gate integrity (independent ledger re-derivation — no regressions,
+56/56, no substitution), provenance honesty (Opus trailer + mixed labels
+confirmed), overclaim audit (verdict faithful, no superiority claim),
+version-owner completeness (all owners at 0.3.2), package/asset integrity
+(43/43 archive parity, version 0.3.2, continuity.md present) — **0
+blockers**; two non-blocking nits fixed (`a19a82c`) before publish.
+
+- Merge: PR #70 → `main` `dfa5502`; main CI green before tagging.
+- Asset: `IMPLEMENTAUDIT.skill` sha256
+  `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+  (131329 bytes), manifest `0.3.2`.
+- Tag: annotated `v0.3.2.0` → `dfa5502` (verified dereference).
+- Release: https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.2.0
+  — Latest, single release, no tag movement.
+- Readback: downloaded public asset sha256 == built asset ✅.
+- Active install: real Codex home updated from the public asset to `0.3.2`
+  (maintenance, not dogfood proof).
+- Post-release smoke: installed payload flat-shaped, `continuity.md`
+  present, version `0.3.2`.
+
+Full detail: `v0.3.2.0-install-and-drift-report.md`.


### PR DESCRIPTION
Post-release evidence for the published v0.3.2.0 (does not alter the released artifact — the tag is already cut at dfa5502). Records: asset hash a0416519 (public == built), tag dereference to dfa5502, single Latest release, active-install update from the public asset, post-release smoke (continuity.md ships + installs), and the pre-publish adversarial gate result (0 blockers). Closure ledger marks #9/#10/#35 CLOSED, Opus-authored with the genuine-Fable re-check pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)