### PR TITLE
Run-root self-enforcement & micro-run mode (#90)

### DIFF
--- a/fixtures/run-root/claimed-then-drifted/root/.claimed
+++ b/fixtures/run-root/claimed-then-drifted/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=full
+templates=STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md

--- a/fixtures/run-root/claimed-then-drifted/root/PROTOCOL.md
+++ b/fixtures/run-root/claimed-then-drifted/root/PROTOCOL.md
@@ -1,0 +1,1 @@
+# Fixture protocol

--- a/fixtures/run-root/claimed-then-drifted/root/STATE.md
+++ b/fixtures/run-root/claimed-then-drifted/root/STATE.md
@@ -1,0 +1,10 @@
+# Full run state
+
+| Status | open |
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/claimed-then-drifted/root/THINKING.md
+++ b/fixtures/run-root/claimed-then-drifted/root/THINKING.md
@@ -1,0 +1,1 @@
+# Fixture thinking

--- a/fixtures/run-root/claimed-then-drifted/root/context.md
+++ b/fixtures/run-root/claimed-then-drifted/root/context.md
@@ -1,0 +1,1 @@
+# Fixture context

--- a/fixtures/run-root/claimed-then-drifted/root/sidecars.md
+++ b/fixtures/run-root/claimed-then-drifted/root/sidecars.md
@@ -1,0 +1,1 @@
+# Fixture sidecars

--- a/fixtures/run-root/claimed-then-drifted/root/tools.md
+++ b/fixtures/run-root/claimed-then-drifted/root/tools.md
@@ -1,0 +1,1 @@
+# Fixture tools

--- a/fixtures/run-root/micro-conformant/root/.claimed
+++ b/fixtures/run-root/micro-conformant/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/micro-conformant/root/STATE.md
+++ b/fixtures/run-root/micro-conformant/root/STATE.md
@@ -1,0 +1,9 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | failed-criterion | fixture defect | repair fixture | rerun fixture | resolved |
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/micro-no-sentinel/root/STATE.md
+++ b/fixtures/run-root/micro-no-sentinel/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state without claim metadata
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/micro-with-phase-specs/root/.claimed
+++ b/fixtures/run-root/micro-with-phase-specs/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/micro-with-phase-specs/root/STATE.md
+++ b/fixtures/run-root/micro-with-phase-specs/root/STATE.md
@@ -1,0 +1,9 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | failed-criterion | fixture defect | repair fixture | rerun fixture | resolved |
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/micro-with-phase-specs/root/phases/phase-1.md
+++ b/fixtures/run-root/micro-with-phase-specs/root/phases/phase-1.md
@@ -1,0 +1,1 @@
+# Ineligible phase specification

--- a/fixtures/run-root/micro-with-roadmap-phase-table/root/.claimed
+++ b/fixtures/run-root/micro-with-roadmap-phase-table/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/micro-with-roadmap-phase-table/root/ROADMAP.md
+++ b/fixtures/run-root/micro-with-roadmap-phase-table/root/ROADMAP.md
@@ -1,0 +1,5 @@
+# Ineligible roadmap
+
+| Phase | Status |
+|---|---|
+| 1 | open |

--- a/fixtures/run-root/micro-with-roadmap-phase-table/root/STATE.md
+++ b/fixtures/run-root/micro-with-roadmap-phase-table/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/micro-with-stage62-disposition/root/.claimed
+++ b/fixtures/run-root/micro-with-stage62-disposition/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/micro-with-stage62-disposition/root/STATE.md
+++ b/fixtures/run-root/micro-with-stage62-disposition/root/STATE.md
@@ -1,0 +1,10 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+Independent cold-review disposition: PASS
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/no-sentinel-legacy/root/PROTOCOL.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/PROTOCOL.md
@@ -1,0 +1,1 @@
+# Fixture protocol

--- a/fixtures/run-root/no-sentinel-legacy/root/ROADMAP.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/ROADMAP.md
@@ -1,0 +1,1 @@
+# Fixture roadmap

--- a/fixtures/run-root/no-sentinel-legacy/root/STATE.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/STATE.md
@@ -1,0 +1,8 @@
+# Legacy full run state
+
+| Status | open |
+
+## Andon log
+
+| # | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|

--- a/fixtures/run-root/no-sentinel-legacy/root/THINKING.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/THINKING.md
@@ -1,0 +1,1 @@
+# Fixture thinking

--- a/fixtures/run-root/no-sentinel-legacy/root/context.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/context.md
@@ -1,0 +1,1 @@
+# Fixture context

--- a/fixtures/run-root/no-sentinel-legacy/root/sidecars.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/sidecars.md
@@ -1,0 +1,1 @@
+# Fixture sidecars

--- a/fixtures/run-root/no-sentinel-legacy/root/tools.md
+++ b/fixtures/run-root/no-sentinel-legacy/root/tools.md
@@ -1,0 +1,1 @@
+# Fixture tools

--- a/fixtures/run-root/sibling-declared-parallel/old-root/STATE.md
+++ b/fixtures/run-root/sibling-declared-parallel/old-root/STATE.md
@@ -1,0 +1,3 @@
+# Parallel sibling
+
+PARALLEL: independent objective authorized by owner

--- a/fixtures/run-root/sibling-declared-parallel/root/.claimed
+++ b/fixtures/run-root/sibling-declared-parallel/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:01Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/sibling-declared-parallel/root/STATE.md
+++ b/fixtures/run-root/sibling-declared-parallel/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/sibling-dispositioned/old-root/STATE.md
+++ b/fixtures/run-root/sibling-dispositioned/old-root/STATE.md
@@ -1,0 +1,3 @@
+# Superseded sibling
+
+SUPERSEDED_BY: ../root

--- a/fixtures/run-root/sibling-dispositioned/root/.claimed
+++ b/fixtures/run-root/sibling-dispositioned/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:01Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/sibling-dispositioned/root/STATE.md
+++ b/fixtures/run-root/sibling-dispositioned/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/sibling-unmarked/old-root/STATE.md
+++ b/fixtures/run-root/sibling-unmarked/old-root/STATE.md
@@ -1,0 +1,1 @@
+# Open sibling without disposition

--- a/fixtures/run-root/sibling-unmarked/root/.claimed
+++ b/fixtures/run-root/sibling-unmarked/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:01Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/sibling-unmarked/root/STATE.md
+++ b/fixtures/run-root/sibling-unmarked/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/terminal-marker-transcript-only/root/.claimed
+++ b/fixtures/run-root/terminal-marker-transcript-only/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/terminal-marker-transcript-only/root/STATE.md
+++ b/fixtures/run-root/terminal-marker-transcript-only/root/STATE.md
@@ -1,0 +1,8 @@
+# Micro run state
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+
+Transcript says closure, but disk has no marker.

--- a/skills/implementaudit/references/plan-lifecycle.md
+++ b/skills/implementaudit/references/plan-lifecycle.md
@@ -293,6 +293,26 @@ Reconciliation must handle every closing-the-loop state explicitly:
 
 ## Run-Root Plan Index Adaptation
 
+### Micro-run mode
+
+Use `claim-run.sh --micro` only for a single-defect repair with no phase
+decomposition, child-agent dispatch, executor handoff, or Stage 6.2 artifact.
+The reduced root contains `.claimed` plus an append-only `STATE.md`: the Andon
+log row or rows, followed by the emitted terminal marker as the final nonblank
+line. It does not carry ROADMAP, THINKING, PROTOCOL, sidecars, tools, context,
+or phase specs. Validate this declared narrowing with
+`validate-run-root.sh --micro <run-root>`; the same root must fail full
+validation.
+
+`claim-run.sh` records the mode and promised template set in `.claimed`.
+Missing promised artifacts are sentinel/artifact drift, not an unauthored
+legacy root. Roots without `.claimed` retain the legacy full-validation
+contract. A new claim lists sibling roots that lack an on-disk completion,
+handoff, supersession, or explicit `PARALLEL: <reason>` line, and validation
+rejects the new root until each sibling is dispositioned. `SUPERSEDED_BY:` is
+the run-root header; `SUPERSEDED_BY_CONCURRENT_MUTATION` is a separate residual
+disposition value and must not be parsed as that header.
+
 The legacy root `plans/README.md` backlog/index shape is behaviorally adapted
 into the namespaced run root instead of copied as a root planning surface.
 `ROADMAP.md` carries execution order, dependencies, plan rows, rejected rows,

--- a/skills/implementaudit/scripts/claim-run.sh
+++ b/skills/implementaudit/scripts/claim-run.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 # claim-run.sh - atomically claim a native IMPLEMENTAUDIT run root.
 #
-# The helper is intentionally small and side-effect bounded: it creates only the
-# run-root directory under IMPLEMENTAUDIT_BASE, then prints that path. It does
-# not write roadmap/state/protocol files, inspect source files, install tools,
-# index sidecars, or start execution.
+# The helper is intentionally small and side-effect bounded: it creates the
+# run-root directory and its claim metadata under IMPLEMENTAUDIT_BASE, then
+# prints that path. It does not write roadmap/state/protocol files, inspect
+# source files, install tools, index sidecars, or start execution.
 
 set -u
 
 base="${IMPLEMENTAUDIT_BASE:-.IMPLEMENTAUDIT/runs}"
+
+mode=full
+if [ "${1:-}" = "--micro" ]; then
+  mode=micro
+  shift
+fi
+
+case "$mode" in
+  full) template_set="STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md" ;;
+  micro) template_set="STATE.md" ;;
+esac
 
 slug="$(printf '%s' "${1:-}" \
   | tr '[:upper:]' '[:lower:]' \
@@ -27,6 +38,27 @@ run_root="$(mktemp -d "$base/${slug}-XXXXXX" 2>/dev/null)" || {
   printf "claim-run.sh: mktemp failed to claim a run dir under '%s'\n" "$base" >&2
   exit 1
 }
+
+claimed_at_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+if ! printf 'claimed_at_utc=%s\nmode=%s\ntemplates=%s\n' \
+  "$claimed_at_utc" "$mode" "$template_set" > "$run_root/.claimed"; then
+  printf "claim-run.sh: cannot write claim sentinel '%s/.claimed'\n" "$run_root" >&2
+  rmdir "$run_root" 2>/dev/null || true
+  exit 1
+fi
+
+# Claiming remains non-blocking so explicitly parallel work can declare itself.
+# List siblings that need COMPLETE, HANDOFF, SUPERSEDED_BY, or PARALLEL state.
+for sibling in "$base"/*; do
+  [ -d "$sibling" ] || continue
+  [ "$sibling" = "$run_root" ] && continue
+  sibling_state="$sibling/STATE.md"
+  if [ ! -f "$sibling_state" ] || ! grep -Eq \
+    '^(AUDIT_COMPLETE|IMPLEMENTAUDIT_RUN_COMPLETE|AUDIT_HANDOFF|ANDON_HANDOFF|COMPLETE|HANDOFF|SUPERSEDED_BY:[[:space:]].+|PARALLEL:[[:space:]].+)$' \
+    "$sibling_state"; then
+    printf 'claim-run: undispositioned sibling root: %s\n' "$sibling" >&2
+  fi
+done
 
 # Advisory only (this helper never mutates repo config): in target repos that
 # do not ignore the run-root base, run artifacts would appear as untracked

--- a/skills/implementaudit/scripts/validate-run-root.sh
+++ b/skills/implementaudit/scripts/validate-run-root.sh
@@ -8,7 +8,7 @@
 # never judges run content, only that the substrate is shaped like the
 # contract.
 #
-# Usage: validate-run-root.sh <run-root>
+# Usage: validate-run-root.sh [--micro] <run-root>
 # Exit 0: conformant. Exit 1: violations listed on stderr. Exit 2: usage.
 
 set -uo pipefail
@@ -19,33 +19,72 @@ err() {
   err_count=$((err_count + 1))
 }
 
+mode=full
+if [ "${1:-}" = "--micro" ]; then
+  mode=micro
+  shift
+fi
 run_root="${1:-}"
 if [ -z "$run_root" ]; then
-  printf 'usage: validate-run-root.sh <run-root>\n' >&2
+  if [ "$mode" = micro ]; then
+    printf 'usage: validate-run-root.sh --micro <run-root>\n' >&2
+  else
+    printf 'usage: validate-run-root.sh <run-root>\n' >&2
+  fi
   exit 2
 fi
 [ -d "$run_root" ] || { printf 'validate-run-root: not a directory: %s\n' "$run_root" >&2; exit 2; }
 
-# Required artifacts for a dispatched run root.
-for f in STATE.md PROTOCOL.md; do
-  [ -f "$run_root/$f" ] || err "missing required artifact: $f"
-done
-for f in ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
-  [ -f "$run_root/$f" ] || err "missing planning artifact: $f (required for dispatched phase runs)"
-done
+claim="$run_root/.claimed"
+claim_mode=""
+if [ "$mode" = micro ] && [ ! -f "$claim" ]; then
+  err "micro root is missing .claimed metadata"
+fi
+if [ -f "$claim" ]; then
+  claim_mode="$(awk -F= '$1 == "mode" { print substr($0, index($0, "=") + 1); exit }' "$claim")"
+  case "$claim_mode" in
+    full|micro) : ;;
+    *) err ".claimed has invalid mode '$claim_mode' (expected full or micro)" ;;
+  esac
+  if [ "$claim_mode" = micro ] && [ "$mode" != micro ]; then
+    err ".claimed records mode=micro; validate this declared narrowing with --micro"
+  elif [ "$claim_mode" = full ] && [ "$mode" = micro ]; then
+    err ".claimed records mode=full; --micro cannot narrow a full claim"
+  fi
+
+  claimed_templates="$(awk -F= '$1 == "templates" { print substr($0, index($0, "=") + 1); exit }' "$claim")"
+  for f in $claimed_templates; do
+    [ -f "$run_root/$f" ] || err "claimed $f is missing — sentinel/artifact drift"
+  done
+fi
+
+if [ "$mode" = micro ]; then
+  [ -f "$run_root/STATE.md" ] || err "missing required artifact: STATE.md"
+else
+  # Required artifacts for a dispatched run root. Absent .claimed preserves
+  # the v0.3.2 legacy behavior exactly.
+  for f in STATE.md PROTOCOL.md; do
+    [ -f "$run_root/$f" ] || err "missing required artifact: $f"
+  done
+  for f in ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
+    [ -f "$run_root/$f" ] || err "missing planning artifact: $f (required for dispatched phase runs)"
+  done
+fi
 
 state="$run_root/STATE.md"
 if [ -f "$state" ]; then
-  # Status must be one of the exact contract tokens.
-  status_line="$(grep -E '^\| Status \|' "$state" | head -1 || true)"
-  if [ -z "$status_line" ]; then
-    err "STATE.md has no '| Status |' row in the Current phase table"
-  else
-    status_value="$(printf '%s' "$status_line" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3}')"
-    case "$status_value" in
-      open|READY_TO_DISPATCH|IN_PHASE|PAUSED|BLOCKED|INTERRUPTED|DONE) : ;;
-      *) err "STATE.md Status '$status_value' is not a contract token (open / READY_TO_DISPATCH / IN_PHASE / PAUSED / BLOCKED / INTERRUPTED / DONE)" ;;
-    esac
+  if [ "$mode" = full ]; then
+    # Status must be one of the exact contract tokens.
+    status_line="$(grep -E '^\| Status \|' "$state" | head -1 || true)"
+    if [ -z "$status_line" ]; then
+      err "STATE.md has no '| Status |' row in the Current phase table"
+    else
+      status_value="$(printf '%s' "$status_line" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3}')"
+      case "$status_value" in
+        open|READY_TO_DISPATCH|IN_PHASE|PAUSED|BLOCKED|INTERRUPTED|DONE) : ;;
+        *) err "STATE.md Status '$status_value' is not a contract token (open / READY_TO_DISPATCH / IN_PHASE / PAUSED / BLOCKED / INTERRUPTED / DONE)" ;;
+      esac
+    fi
   fi
 
   # Andon log substrate must exist with the contract columns. Two valid
@@ -84,6 +123,47 @@ if [ -f "$state" ]; then
   elif ! grep -qi '| Class | Abnormality | Countermeasure | Rerun evidence | Outcome |' "$state"; then
     err "STATE.md Andon log table is missing the contract columns (# | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome; legacy shape without Occ also accepted)"
   fi
+
+  if [ "$mode" = micro ]; then
+    terminal_line="$(awk 'NF { last=$0 } END { print last }' "$state")"
+    case "$terminal_line" in
+      AUDIT_COMPLETE|AUDIT_HANDOFF|ANDON_HANDOFF) : ;;
+      IMPLEMENTAUDIT_RUN_COMPLETE)
+        grep -qx 'AUDIT_COMPLETE' "$state" || err "STATE.md ends with IMPLEMENTAUDIT_RUN_COMPLETE but has no preceding AUDIT_COMPLETE"
+        ;;
+      *) err "micro STATE.md final nonblank line is not a terminal marker (AUDIT_COMPLETE / IMPLEMENTAUDIT_RUN_COMPLETE / AUDIT_HANDOFF / ANDON_HANDOFF)" ;;
+    esac
+
+    if find "$run_root/phases" -type f -name 'phase-*.md' -print -quit 2>/dev/null | grep -q .; then
+      err "micro root contains phase specs; phased dispatch requires a full run root"
+    fi
+    if [ -f "$run_root/ROADMAP.md" ] && grep -Eq '^\|[[:space:]]*[0-9]+[[:space:]]*\|' "$run_root/ROADMAP.md"; then
+      err "micro root contains a ROADMAP phase table; phased dispatch requires a full run root"
+    fi
+    if grep -R -E -q '^(Stage 6\.2|Independent cold-review disposition|Review disposition):' "$run_root" \
+      --exclude='.claimed' 2>/dev/null; then
+      err "micro root contains a Stage 6.2 disposition; executor-facing review requires a full run root"
+    fi
+  fi
+fi
+
+
+# A .claimed root is new-format. It cannot validate while an older sibling is
+# undispositioned. SUPERSEDED_BY: is a root header; the distinct
+# SUPERSEDED_BY_CONCURRENT_MUTATION token is a residual-table value, not a
+# value of that header.
+if [ -f "$claim" ]; then
+  run_base="$(dirname "$run_root")"
+  for sibling in "$run_base"/*; do
+    [ -d "$sibling" ] || continue
+    [ "$sibling" = "$run_root" ] && continue
+    sibling_state="$sibling/STATE.md"
+    if [ ! -f "$sibling_state" ] || ! grep -Eq \
+      '^(AUDIT_COMPLETE|IMPLEMENTAUDIT_RUN_COMPLETE|AUDIT_HANDOFF|ANDON_HANDOFF|COMPLETE|HANDOFF|SUPERSEDED_BY:[[:space:]].+|PARALLEL:[[:space:]].+)$' \
+      "$sibling_state"; then
+      err "newly claimed root has undispositioned sibling: $(basename "$sibling")"
+    fi
+  done
 fi
 
 # Occurrence resolution + residual dispositions (#6): new-format roots

--- a/skills/implementaudit/templates/STATE.md
+++ b/skills/implementaudit/templates/STATE.md
@@ -169,3 +169,7 @@ Commit authorized: no
 Push authorized: no
 
 Tag/release/publication/provenance authorized: no
+
+## Run terminal disposition
+
+Append the emitted terminal marker as the final nonblank line of this file.

--- a/tests/claim-run.test.sh
+++ b/tests/claim-run.test.sh
@@ -32,6 +32,19 @@ second="$(bash "$helper" "Audit release asset boundary" 2>/dev/null)"
   exit 1
 }
 
+grep -qx 'mode=full' "$first/.claimed" || {
+  printf 'claim-run.test: full claim sentinel missing mode=full\n' >&2
+  exit 1
+}
+grep -qx 'templates=STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md' "$first/.claimed" || {
+  printf 'claim-run.test: full claim sentinel missing canonical template set\n' >&2
+  exit 1
+}
+grep -Eq '^claimed_at_utc=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$first/.claimed" || {
+  printf 'claim-run.test: full claim sentinel missing UTC timestamp\n' >&2
+  exit 1
+}
+
 case "$first" in
   .IMPLEMENTAUDIT/runs/audit-release-asset-boundary-*) ;;
   *)
@@ -53,6 +66,25 @@ case "$(basename "$custom")" in
     exit 1
     ;;
 esac
+
+micro_base="$tmp/micro base"
+micro="$(IMPLEMENTAUDIT_BASE="$micro_base" bash "$helper" --micro 'Tiny repair' 2>/dev/null)"
+grep -qx 'mode=micro' "$micro/.claimed" || {
+  printf 'claim-run.test: micro claim sentinel missing mode=micro\n' >&2
+  exit 1
+}
+grep -qx 'templates=STATE.md' "$micro/.claimed" || {
+  printf 'claim-run.test: micro claim sentinel names the wrong template set\n' >&2
+  exit 1
+}
+
+mkdir -p "$micro_base/unmarked-sibling"
+printf '# state without disposition\n' > "$micro_base/unmarked-sibling/STATE.md"
+warning="$(IMPLEMENTAUDIT_BASE="$micro_base" bash "$helper" --micro 'Sibling warning' 2>&1 >/dev/null)"
+printf '%s\n' "$warning" | grep -Fq 'unmarked-sibling' || {
+  printf 'claim-run.test: claim did not list undispositioned sibling root\n' >&2
+  exit 1
+}
 
 parallel_dir="$tmp/parallel"
 mkdir -p "$parallel_dir"

--- a/tests/run-root-validation.test.sh
+++ b/tests/run-root-validation.test.sh
@@ -212,4 +212,77 @@ res_case res_nopolicy "partially-resolved" \
 res_case res_axes "unresolved" \
 "| open cause | yes | deferred | owner backlog | ledger |" pass
 
+# 7. Run-root self-enforcement and micro-run mode (#90).
+fixture_root="fixtures/run-root"
+
+# 7a. A declared micro root passes only under --micro.
+bash "$helper" --micro "$fixture_root/micro-conformant/root" >/dev/null || {
+  printf 'run-root-validation.test: micro-conformant expected PASS under --micro\n' >&2
+  exit 1
+}
+if bash "$helper" "$fixture_root/micro-conformant/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro-conformant must fail full validation\n' >&2
+  exit 1
+fi
+if bash "$helper" --micro "$fixture_root/micro-no-sentinel/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro root without .claimed must fail\n' >&2
+  exit 1
+fi
+
+# 7b. A micro root cannot carry phased-dispatch artifacts.
+if bash "$helper" --micro "$fixture_root/micro-with-phase-specs/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro root with phase specs must fail\n' >&2
+  exit 1
+fi
+if bash "$helper" --micro "$fixture_root/micro-with-roadmap-phase-table/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro root with ROADMAP phase table must fail\n' >&2
+  exit 1
+fi
+if bash "$helper" --micro "$fixture_root/micro-with-stage62-disposition/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro root with Stage 6.2 disposition must fail\n' >&2
+  exit 1
+fi
+
+# 7c. A sentinel-vs-artifact mismatch is diagnosed as drift.
+if drift_output="$(bash "$helper" "$fixture_root/claimed-then-drifted/root" 2>&1)"; then
+  printf 'run-root-validation.test: claimed-then-drifted must fail\n' >&2
+  exit 1
+fi
+printf '%s\n' "$drift_output" | grep -qi 'drift' || {
+  printf 'run-root-validation.test: drift failure did not name drift\n' >&2
+  exit 1
+}
+
+# 7d. Legacy roots without .claimed preserve v0.3.2 behavior.
+bash "$helper" "$fixture_root/no-sentinel-legacy/root" >/dev/null || {
+  printf 'run-root-validation.test: no-sentinel legacy root must stay valid\n' >&2
+  exit 1
+}
+
+# 7e. Newly claimed roots refuse undeclared sibling concurrency.
+if sibling_output="$(bash "$helper" --micro "$fixture_root/sibling-unmarked/root" 2>&1)"; then
+  printf 'run-root-validation.test: undispositioned sibling must fail\n' >&2
+  exit 1
+fi
+printf '%s\n' "$sibling_output" | grep -Fq 'old-root' || {
+  printf 'run-root-validation.test: sibling failure did not list old-root\n' >&2
+  exit 1
+}
+
+# 7f. Superseded and explicitly parallel siblings are valid controls.
+bash "$helper" --micro "$fixture_root/sibling-dispositioned/root" >/dev/null || {
+  printf 'run-root-validation.test: dispositioned sibling expected PASS\n' >&2
+  exit 1
+}
+bash "$helper" --micro "$fixture_root/sibling-declared-parallel/root" >/dev/null || {
+  printf 'run-root-validation.test: declared-parallel sibling expected PASS\n' >&2
+  exit 1
+}
+
+# 7g. Transcript-only closure is not on-disk terminal evidence.
+if bash "$helper" --micro "$fixture_root/terminal-marker-transcript-only/root" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: micro root without terminal marker must fail\n' >&2
+  exit 1
+fi
+
 printf 'run-root-validation.test: ok\n'


### PR DESCRIPTION
## Purpose

Closes #90.

Issue-linked invariant: a claimed run root records its mode and promised artifact set, micro-run validation is a declared narrowing for single-defect work, and a newly claimed root cannot validate while an older sibling lacks an on-disk disposition.

## What changed

- `claim-run.sh` now accepts `--micro`, writes `.claimed` with UTC timestamp, mode, and promised template set, and lists undispositioned sibling roots.
- `validate-run-root.sh --micro` validates the reduced `.claimed` plus `STATE.md` shape, terminal marker, and eligibility guards. Full mode reports sentinel/artifact drift and checks sibling disposition only for newly claimed roots.
- `plan-lifecycle.md` defines micro-run eligibility and distinguishes the `SUPERSEDED_BY:` root header from the `SUPERSEDED_BY_CONCURRENT_MUTATION` residual value.
- `STATE.md` gains the trailing on-disk terminal-disposition slot.

## Legacy migration

No migration is required. Roots without `.claimed` retain the v0.3.2 full-validation path and legacy Andon-table tolerances. The no-sentinel legacy fixture remains green. Existing roots stay valid under the validator behavior that applied when they were created.

## Fixtures and negative controls

- Positive: conformant micro root under `--micro`; dispositioned sibling; declared-parallel sibling; legacy full root without `.claimed`.
- Negative: micro root under full validation; micro root without `.claimed`; phase spec, ROADMAP phase table, or Stage 6.2 disposition in micro mode; claimed artifact drift; undispositioned sibling; transcript-only terminal state.
- Historical regression sweep retained the five expected error counts: 2, 8, 7, 7, and 8.

## Validation

- Registry parity: 59 `tests/*.test.sh` files present in both registries, exit 0.
- Full Git Bash sweep: all 59 registered tests, exit 0.
- `bash scripts/verify-package.sh`, exit 0 (`verify-package: ok`).
- `bash tests/claim-run.test.sh`, exit 0.
- `bash tests/run-root-validation.test.sh`, exit 0.
- `bash skills/implementaudit/scripts/validate-run-root.sh fixtures/run-root-example`, exit 0.
- `git diff --check`, exit 0.

Supported-platform skips reported by the existing eval harness were limited to unsupported symlink and POSIX-only cases; the gate exited 0.

## Spine budget

Post-change `skills/implementaudit/SKILL.md`: 448 lines, 21,807 bytes. Budget: 450 lines, 22,000 bytes. This PR changes zero spine bytes.

## Dependency and scope

This is the required substrate for #91 and also precedes #95. The #80 relationship is affordability only because its host-notes file is outside the run root. No #80 files or other issue surfaces are changed.

## Rollback

Single revert of `baceba24d5d27e74f4725c3949db01aef8872ad5`. Existing full roots remain valid. `.claimed` becomes inert metadata under the reverted validator, and micro roots honestly fail full validation under v0.3.2 behavior.
