### PR TITLE
docs(release): close corrected v0.3.2.0 re-release record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 (nothing yet)
 
+## [v0.3.2.0 corrected re-release] - 2026-08-04
+
+The owner-authorized same-version correction replaced the withdrawn
+2026-07-18 publication after its B3 qualification claim was found
+unreconstructible. The release object was deleted and recreated, and the tag
+was transparently replaced once as part of that correction.
+
+### Changed
+
+- Tag target: `dfa55020cd883e1c9b1b65f7e96921b383b72820` →
+  `0adb10d79a192b576c4378f483d02bbcad161495`.
+- Release ID: `356138470` → `365082973`.
+- `IMPLEMENTAUDIT.skill`: superseded
+  `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+  (131,329 bytes) → superseding
+  `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`
+  (132,117 bytes).
+- `CHECKSUMS.txt`: superseded
+  `67f3bc93c815cecc6b35a0c69bf95a6c2b502981b6a1725ec62e08e18a33e98d`
+  → superseding
+  `b25b81ce0755c51c81888e33038ef5c410772f56a319f291f153fc4ebb71214e`.
+- The corrected payload includes commit `21e12b3`, which added the always-read
+  runtime rule that final audit markers are emitted exactly once per run.
+
+### Evidence boundaries
+
+- Candidate qualification recorded Luna 14/14 matrix plus 6/6 B3-v4 and Opus
+  14/14 matrix plus 6/6 B3-v4 at exact commit `0adb10d`.
+- The amended unchanged-repeat and untouched holdout/perturbation legs have no
+  findable completion record and were owner-waived at republication. They are
+  not claimed as executed.
+- Exact-tag GitHub Actions run `30933683268` failed during Ubuntu fixture
+  cleanup. Retained release evidence separately records passing Windows Git
+  Bash package verification, byte-identical builds, public readback, and a
+  disposable Codex-home install.
+- This entry is the one retroactive application of the superseded →
+  superseding digest-pair rule tracked by issue #89.
+
 ## [v0.3.2.0] - 2026-07-18
 
 Evidence-integrity and failure-origin hardening program (#10) release:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ release-critical eval custody hardening (#20), context-epoch continuity
 (#35), the native audit-action remediation set (#47–#53), the sixteen
 genuine-Fable review corrections, and the model-in-the-loop evaluation
 program (#9: 84-mission immutable baseline, B3 supplementary waves, and the
-candidate/control comparison campaign).
+candidate/control comparison campaign). The owner-authorized corrected
+same-version re-release published on 2026-08-04 at tag target `0adb10d`; it
+supersedes the withdrawn 2026-07-18 asset. The digest pair and qualification
+boundaries are recorded in the changelog and archived correction report.
 
 The current bootloader architecture keeps weak-executor safeguards in
 progressive references/templates: final reports, optional Graphify-assisted
@@ -882,7 +885,8 @@ asset-to-Codex-install path into a temporary Codex home. It does not claim passi
 
 **Release/contract alignment:** the current release-gate verified live public
 release is `v0.3.2.0` (verified against the live GitHub release at the
-v0.3.2.0 readback gate, 2026-07-18).
+corrected v0.3.2.0 readback gate, 2026-08-05; corrected publication
+`2026-08-04T18:48:56Z`, tag target `0adb10d`).
 This source checkout may contain post-release repairs after that tag; installing
 from a checkout or local asset uses local source, not a public release claim.
 Re-verify this paragraph at every release gate.

--- a/docs/audits/archive/v0.3.2.0-correction-and-republish-report.md
+++ b/docs/audits/archive/v0.3.2.0-correction-and-republish-report.md
@@ -2,8 +2,9 @@
 
 ## Status and provenance
 
-**Status:** CORRECTION IN PROGRESS — the first publication facts are frozen
-below; corrected tag/release fields remain pending.
+**Status:** CORRECTION COMPLETE. The first-publication facts remain frozen
+below; section 10 records the superseding publication and final evidence
+boundaries.
 **Correction author/runtime identity:** Sol.
 **Owner decision:** the owner explicitly classified the B3 contradiction as
 release-blocking `evidence-mismatch` and `false-closure`, authorized withdrawal,
@@ -600,7 +601,92 @@ and public/install transaction begin.
 
 ## 10. Corrected tag, asset, public readback, and installed smoke
 
-Pending. The final section will disclose original and corrected tag targets,
-original and corrected asset hashes, correction PR/merge commit, CI, package
-qualification, public asset readback, install parity/smoke, issue/milestone
-closure, and the exact Fable/Opus/Sol/owner provenance split.
+The owner-authorized correction replaced the withdrawn publication under the
+same version. The release object was deleted and recreated, not edited. Its ID
+therefore changed, and the old release ID is not a durable identifier for the
+live `v0.3.2.0` publication.
+
+| Field | Withdrawn publication | Corrected publication |
+|---|---|---|
+| Peeled tag target | `dfa55020cd883e1c9b1b65f7e96921b383b72820` | `0adb10d79a192b576c4378f483d02bbcad161495` |
+| Release ID | `356138470` | `365082973` |
+| Published | `2026-07-18T16:01:36Z` | `2026-08-04T18:48:56Z` |
+| `IMPLEMENTAUDIT.skill` | `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`, 131,329 bytes | `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`, 132,117 bytes |
+| `CHECKSUMS.txt` SHA-256 | `67f3bc93c815cecc6b35a0c69bf95a6c2b502981b6a1725ec62e08e18a33e98d` | `b25b81ce0755c51c81888e33038ef5c410772f56a319f291f153fc4ebb71214e` |
+| Runtime-contract delta | Marker-replay rule absent by withdrawn-asset extraction | Commit `21e12b3486fefa9a8826563cfc6f56e2ebdf947e` adds the always-read marker-replay rule |
+
+PR #73, `fix(release): correct and republish v0.3.2.0 B3 evidence [Sol]`,
+merged the accepted evaluator foundation to `main` as
+`3e89c7976ee6c5e03e048bd3b2ce1e8ae74f950d` on 2026-07-22. The correction
+continued through later evaluator and qualification commits. The final
+corrected tag target is `0adb10d79a192b576c4378f483d02bbcad161495`, not the
+PR #73 merge commit.
+
+### Qualification and CI boundary
+
+- PR #73's GitHub Actions `package` check passed in run `29886319415` before
+  merge.
+- At the final tag target, retained release evidence records two fresh Windows
+  Git Bash builds as byte-identical, package verification as passing, and the
+  retained asset as SHA-256 `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14e`.
+- GitHub Actions `validate` run `30933683268` for exact commit `0adb10d` did
+  **not** pass. Its package job reached `eval/test_candidate_matrix_freeze.py`
+  after the preceding package checks, then failed during Ubuntu fixture cleanup
+  with `NotADirectoryError` on `support-junction`. The corrected publication is
+  therefore not described here as exact-tag CI-green.
+
+The release-candidate qualification evidence is split across these sealed
+locations:
+
+- `CANDIDATE_MATRIX_LUNA_FREEZE_0ADB10D_V52`: Luna matrix, 14/14 at
+  `0adb10d`.
+- `B3V4_LUNA_FREEZE_0ADB10D_V70`: Luna B3-v4, 6/6 at `0adb10d`.
+- `opus-cross-model-0adb10d-20260804T141735Z/RELEASE_TERMINAL.json`: Opus
+  matrix 14/14 plus B3-v4 6/6, sealed `2026-08-04T16:29:24Z`, with a complete
+  fresh T7 tranche, zero retry within the tranche, and zero substitution.
+
+The Opus terminal's `custody_caveat` is, verbatim:
+
+> owner-lane evidence: real ClaudeAdapter host custody, packet review, and independent rederivation were not used; graders were the pinned official engines; raw streams retained for executor adjudication
+
+The amended section 9 gate also required a second, unchanged 28/28 run and the
+untouched holdout/perturbation suite. No completion record for either leg is
+findable in the repository, the private custody root, or the campaign
+terminals. The owner, acting as the gate authority, nevertheless executed the
+corrected republication on 2026-08-04. **Determination:** both legs were
+owner-waived at republication. They are not recorded as run, PASS, or inferred
+from the completed 14/14 plus 14/14 matrix evidence. This is an authority
+disposition, not manufactured qualification evidence.
+
+### Public readback, install, and tracker closure
+
+Live readback on 2026-08-05 returned release ID `365082973`, peeled tag target
+`0adb10d79a192b576c4378f483d02bbcad161495`, and the two corrected assets above.
+The public asset was downloaded again and installed with its checksum into a
+disposable Codex home on 2026-08-05. The installer reported the corrected asset
+digest, the installed runtime files matched `skills/implementaudit/`, and the
+448-line, 21,807-byte `SKILL.md` contained the marker-replay rule. The fresh
+details and the unrecoverable historical active-install date are recorded in
+`v0.3.2.0-install-and-drift-report-corrected.md`.
+
+Issues #35, #9, and #10 were closed with evidence-traced dispositions on
+2026-08-05. Milestone `v0.3.2.0` was then closed at 17 closed issues and zero
+open issues. Those tracker actions predate this record closeout and were not
+repeated.
+
+### Final provenance split
+
+- **Fable:** original review, implementation, and evaluation through the
+  recorded original-program boundary, plus the 2026-08-05 evidence-traced
+  tracker adjudication.
+- **Opus:** first release finalization and the separately labeled cross-model
+  qualification lane whose custody limitation is quoted above.
+- **Sol:** independent contradiction discovery, correction design and
+  implementation record, evaluator hardening lineage, and this durable
+  correction closeout.
+- **Owner:** release-blocking classification, withdrawal and same-version tag
+  replacement authorization, corrected republication, tracker dispositions,
+  and the republication-time waiver of the two unrecorded amended gate legs.
+
+No tag, release, asset, issue, or milestone was changed by this record
+closeout.

--- a/docs/audits/archive/v0.3.2.0-install-and-drift-report-corrected.md
+++ b/docs/audits/archive/v0.3.2.0-install-and-drift-report-corrected.md
@@ -1,0 +1,91 @@
+# v0.3.2.0 corrected re-release install and drift report
+
+**Status:** COMPLETE.
+**Evidence date:** 2026-08-05.
+
+This report supersedes the live-state claims in
+`v0.3.2.0-install-and-drift-report.md`. The older report remains preserved as
+the record of the withdrawn 2026-07-18 publication.
+
+## Live release identity
+
+- Release ID: `365082973`.
+- Published: `2026-08-04T18:48:56Z`.
+- Annotated tag `v0.3.2.0` peels to
+  `0adb10d79a192b576c4378f483d02bbcad161495`.
+- `IMPLEMENTAUDIT.skill`: 132,117 bytes, SHA-256
+  `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`.
+- `CHECKSUMS.txt`: 96 bytes, SHA-256
+  `b25b81ce0755c51c81888e33038ef5c410772f56a319f291f153fc4ebb71214e`.
+- The checksum manifest records
+  `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`
+  for `IMPLEMENTAUDIT.skill`.
+
+The first publication used release ID `356138470`, tag target
+`dfa55020cd883e1c9b1b65f7e96921b383b72820`, asset SHA-256
+`a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
+at 131,329 bytes, and checksum-manifest SHA-256
+`67f3bc93c815cecc6b35a0c69bf95a6c2b502981b6a1725ec62e08e18a33e98d`.
+The release object was deleted and recreated, not edited.
+
+## Fresh public download and disposable install
+
+On 2026-08-05, both live assets were downloaded again from GitHub release
+`v0.3.2.0`. Their local sizes and SHA-256 digests matched the live release API
+values above. The checksum manifest validated the downloaded skill asset.
+
+`scripts/install-codex-from-release.sh` then installed that downloaded asset,
+with the downloaded checksum manifest, into a disposable Codex home. The
+installer reported SHA-256
+`884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`.
+The installed payload had the expected flat runtime shape:
+`SKILL.md`, `references/`, `scripts/`, and `templates/`.
+
+The disposable install contained a 448-line, 21,807-byte `SKILL.md`. It
+contained the `Emit each final audit marker exactly once per run.` rule.
+SHA-256 comparison of every installed runtime file against
+`skills/implementaudit/` found no differences. Git history also showed no
+`skills/implementaudit/` changes between release commit `0adb10d` and the
+source checkout used for this report.
+
+This is structural install and drift evidence. No model-in-the-loop execution
+is claimed.
+
+## Active install and timestamp boundary
+
+The active Codex install at
+`C:\Users\theis\.codex\skills\implementaudit` also contained a 448-line,
+21,807-byte `SKILL.md` with the marker-replay rule. Its runtime files matched
+the source tree. Its two package-only metadata files were
+`.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+
+All 43 active-install files have the normalized archive timestamp
+`1980-01-01 00:00:00`. Those zeroed timestamps do not preserve the historical
+reinstall time. The date on which the active install first became the corrected
+payload is therefore unrecoverable from filesystem metadata. The dated fresh
+disposable install above proves the live asset installs now, but does not
+reconstruct that earlier active-install date.
+
+## Ignored `dist/` hygiene action
+
+The withdrawn local artifacts were retained for reproducibility but removed
+from live-looking names in the primary checkout's gitignored `dist/` directory
+on 2026-08-05:
+
+- `dist/IMPLEMENTAUDIT.skill` was renamed to
+  `dist/withdrawn-20260718-a0416519.skill`. Its SHA-256 remains
+  `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`.
+- `dist/CHECKSUMS.txt` was renamed to
+  `dist/withdrawn-20260718-a0416519-CHECKSUMS.txt`. Its SHA-256 remains
+  `67f3bc93c815cecc6b35a0c69bf95a6c2b502981b6a1725ec62e08e18a33e98d`.
+
+The rename is reversible, preserves the withdrawn bytes for audit, and ensures
+that no file named `dist/IMPLEMENTAUDIT.skill` presents the withdrawn payload
+as a current build artifact.
+
+## Drift determination
+
+The live public asset, fresh disposable install, active runtime payload, and
+release-tag source runtime files agree for the installable skill. The old
+report's tag, release ID, asset digest, and no-tag-movement claims are
+historical only and carry dated superseding annotations.

--- a/docs/audits/archive/v0.3.2.0-install-and-drift-report.md
+++ b/docs/audits/archive/v0.3.2.0-install-and-drift-report.md
@@ -4,6 +4,12 @@ Provenance: authored under **Claude Opus 4.8** during the owner-authorized
 release finalization (2026-07-18); genuine-Fable re-verification scheduled.
 See the release report §Provenance.
 
+> **Superseded 2026-08-04:** this report describes the withdrawn first
+> publication. The live corrected publication and fresh 2026-08-05 install
+> readback are recorded in
+> `v0.3.2.0-install-and-drift-report-corrected.md`. Historical statements below
+> are preserved and annotated rather than silently rewritten.
+
 This report records the published-release readback and the active-install
 update — the evidence that what is public matches what was built, and that
 the local install was refreshed from the public asset (not from the working
@@ -29,11 +35,18 @@ tree).
 
 - Downloaded published asset sha256 = `a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4`
   — **identical** to the built asset. ✅
+  > **Superseding note (2026-08-05):** this was true only for the withdrawn
+  > publication. The live asset is `884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14`.
 - Annotated tag `v0.3.2.0` dereferences to commit `dfa5502` = the merged
   release commit on `main`. ✅
+  > **Superseding note (2026-08-05):** the owner-authorized corrected tag now
+  > dereferences to `0adb10d79a192b576c4378f483d02bbcad161495`.
 - Release body records the asset digest (via `CHECKSUMS.txt`). ✅
 - Exactly one `v0.3.2.0` release, marked Latest; no duplicate release, no
   tag movement. ✅
+  > **Superseding note (2026-08-05):** the original release object was deleted
+  > and recreated as release ID `365082973`, and the tag moved from `dfa5502`
+  > to `0adb10d`. See the corrected report for the full identity pair.
 - README (`current release v0.3.2.0`) and docs portal (`site.json`
   milestone/manifest, regenerated overview page) show `v0.3.2.0` as the
   live release on `main`. ✅
@@ -70,3 +83,7 @@ No drift: the source checkout at the release commit `dfa5502`, the built
 asset, and the published release asset are one and the same (byte-identical
 payload hash across build → publish → download → install). The active
 install now matches the public release.
+
+> **Superseding note (2026-08-05):** this no-drift statement is scoped to the
+> withdrawn publication. The corrected report establishes the live asset and
+> current installed-payload comparison.


### PR DESCRIPTION
## Summary

- completes section 10 of the v0.3.2.0 correction report with the withdrawn and corrected tag, release, asset, checksum, qualification, CI, install, tracker, and provenance record
- adds the retroactive same-version re-release entry to `CHANGELOG.md`, annotates the withdrawn install report, adds a fresh live-asset install/drift report, and refreshes the README release identity
- records the recoverable rename of the withdrawn gitignored `dist/` asset and checksum without touching the skill payload

## Determinations and evidence boundaries

- The original release object `356138470` was deleted and recreated as `365082973`; the tag target changed from `dfa5502` to `0adb10d`.
- The asset digest changed from `a0416519...` at 131,329 bytes to `884ab409...` at 132,117 bytes. The `CHECKSUMS.txt` digest changed from `67f3bc93...` to `b25b81ce...`.
- Luna qualification is cited at `CANDIDATE_MATRIX_LUNA_FREEZE_0ADB10D_V52` (14/14) and `B3V4_LUNA_FREEZE_0ADB10D_V70` (6/6). The Opus cross-model terminal records 14/14 plus 6/6 and its `custody_caveat` is quoted verbatim.
- No completion record exists for the amended unchanged-repeat or untouched holdout/perturbation legs. The report records both as owner-waived at republication, not as executed or passed.
- Exact-tag GitHub Actions run `30933683268` failed during Ubuntu fixture cleanup. The report keeps that separate from the retained passing Windows package, reproducibility, public-readback, and disposable-install evidence.

## Validation

- issue-specific Smoke B: PASS
- serial cold review: PASS, including byte-preserved correction-report sections 1-5 and verbatim custody caveat
- `bash scripts/verify-package.sh`: exit 0, 59 tests registered, `phase-validation.test: ok (41/41)`, `verify-package: ok`
- `bash scripts/build-release-asset.sh --check`: exit 0, extraction validation ok
- `bash tests/docs-portal.test.sh`: exit 0, 33/33
- `git diff --check`: exit 0
- post-commit verification: PASS at `4df5c0067d97fa20e86c98df5569a5314b6ec66c`

The repo-documented direct invocation of `validate-phase.sh` against the blank `phase-goal.txt` skeleton remains a pre-existing expected red. The validator's two filled canonical examples and its registered 41/41 suite are green. No skill payload file changes in this PR.

## Boundaries

- draft PR only; no merge, tag, release, asset publication, issue mutation, or milestone mutation
- no file under `skills/implementaudit/`
- the optional 102-subject eval-defect taxonomy is not included because it is not needed for the durable falsehood closeout
- issue #96 should merge before issue #89's changelog rule implementation

Closes #96
