### PR TITLE
Mechanical second-order recurrence trigger (#91)

### DIFF
--- a/fixtures/run-root/direct-ledger-substrate/below-threshold.md
+++ b/fixtures/run-root/direct-ledger-substrate/below-threshold.md
@@ -1,0 +1,8 @@
+# Direct in-session ledger below the trigger
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | second failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |

--- a/fixtures/run-root/direct-ledger-substrate/decision-after-audit-complete.md
+++ b/fixtures/run-root/direct-ledger-substrate/decision-after-audit-complete.md
@@ -1,0 +1,13 @@
+# Direct ledger with a late decision
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | second failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | third failure | repair predicate; owner/source=eval/shared.py | rerun fixture | escalated (cites #1, #2) |
+
+AUDIT_COMPLETE
+
+Mechanism-replacement decision: continue (recorded too late)

--- a/fixtures/run-root/direct-ledger-substrate/duplicate-occ-below-threshold.md
+++ b/fixtures/run-root/direct-ledger-substrate/duplicate-occ-below-threshold.md
@@ -1,0 +1,9 @@
+# Direct ledger with duplicated rows for one occurrence
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first row | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o1 | direct | regression | duplicate row | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 3 | o2 | direct | regression | second occurrence | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |

--- a/fixtures/run-root/direct-ledger-substrate/invalid-empty-continue.md
+++ b/fixtures/run-root/direct-ledger-substrate/invalid-empty-continue.md
@@ -1,0 +1,11 @@
+# Direct in-session ledger with an empty decision
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | second failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | third failure | repair predicate; owner/source=eval/shared.py | rerun fixture | escalated (cites #1, #2) |
+
+Mechanism-replacement decision: continue ( )

--- a/fixtures/run-root/direct-ledger-substrate/trigger-no-decision.md
+++ b/fixtures/run-root/direct-ledger-substrate/trigger-no-decision.md
@@ -1,0 +1,9 @@
+# Direct in-session ledger at the trigger
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | second failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | third failure | repair predicate; owner/source=eval/shared.py | rerun fixture | escalated (cites #1, #2) |

--- a/fixtures/run-root/legacy-andon-shape/ledger.md
+++ b/fixtures/run-root/legacy-andon-shape/ledger.md
@@ -1,0 +1,9 @@
+# Legacy Andon ledger
+
+## Andon log
+
+| # | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|
+| 1 | direct | regression | first failure | repair eval/shared.py | rerun fixture | resolved |
+| 2 | direct | regression | second failure | repair eval/shared.py | rerun fixture | resolved |
+| 3 | direct | regression | third failure | repair eval/shared.py | rerun fixture | resolved |

--- a/fixtures/run-root/recurrence-3-different-classes/root/.claimed
+++ b/fixtures/run-root/recurrence-3-different-classes/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-different-classes/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-different-classes/root/STATE.md
@@ -1,0 +1,11 @@
+# Three different classes
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 2 | o2 | direct | evidence-mismatch | second failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+| 3 | o3 | direct | failed-criterion | third failure | repair predicate; owner/source=eval/shared.py | rerun fixture | resolved |
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/recurrence-3-different-files/root/.claimed
+++ b/fixtures/run-root/recurrence-3-different-files/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-different-files/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-different-files/root/STATE.md
@@ -1,0 +1,11 @@
+# Same class across different owner/source files
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | first failure | repair predicate; owner/source=eval/first.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | second failure | repair predicate; owner/source=eval/second.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | third failure | repair predicate; owner/source=eval/third.py | rerun fixture | resolved |
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/recurrence-3-same-class-same-file/root/.claimed
+++ b/fixtures/run-root/recurrence-3-same-class-same-file/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-same-class-same-file/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-same-class-same-file/root/STATE.md
@@ -1,0 +1,11 @@
+# Recurrence without mechanism decision
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | plural form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | negation form accepted | narrow predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | adjacent form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | escalated (cites #1, #2) |
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/recurrence-3-with-continue-decision/root/.claimed
+++ b/fixtures/run-root/recurrence-3-with-continue-decision/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-with-continue-decision/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-with-continue-decision/root/STATE.md
@@ -1,0 +1,13 @@
+# Recurrence with justified continuation
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | plural form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | negation form accepted | narrow predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | adjacent form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | escalated (cites #1, #2) |
+
+Mechanism-replacement decision: continue (the bounded predicate remains the correct owner)
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/recurrence-3-with-convergence-escalation/root/.claimed
+++ b/fixtures/run-root/recurrence-3-with-convergence-escalation/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-with-convergence-escalation/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-with-convergence-escalation/root/STATE.md
@@ -1,0 +1,13 @@
+# Recurrence escalated to convergence mode
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | plural form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | negation form accepted | narrow predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | adjacent form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | escalated (cites #1, #2) |
+
+Mechanism-replacement decision: escalate-to-convergence-mode (neighboring polarity states share an invariant)
+
+AUDIT_COMPLETE

--- a/fixtures/run-root/recurrence-3-with-replace-decision/root/.claimed
+++ b/fixtures/run-root/recurrence-3-with-replace-decision/root/.claimed
@@ -1,0 +1,3 @@
+claimed_at_utc=2026-08-05T00:00:00Z
+mode=micro
+templates=STATE.md

--- a/fixtures/run-root/recurrence-3-with-replace-decision/root/STATE.md
+++ b/fixtures/run-root/recurrence-3-with-replace-decision/root/STATE.md
@@ -1,0 +1,13 @@
+# Recurrence with mechanism replacement
+
+## Andon log
+
+| # | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | o1 | direct | regression | plural form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 2 | o2 | direct | regression | negation form accepted | narrow predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | resolved |
+| 3 | o3 | direct | regression | adjacent form rejected | widen predicate; owner/source=eval/candidate_matrix_acceptance.py | rerun fixture | escalated (cites #1, #2) |
+
+Mechanism-replacement decision: replace-mechanism (regex alternation to structured envelope)
+
+AUDIT_COMPLETE

--- a/skills/implementaudit/references/convergence-mode.md
+++ b/skills/implementaudit/references/convergence-mode.md
@@ -19,6 +19,10 @@ Consider this mode when EITHER holds:
 If only a single fault is in play (no shared under-specified space), DO NOT
 use this mode: an enumeration artifact there is over-process.
 
+A `Mechanism-replacement decision: escalate-to-convergence-mode (<shared
+invariant>)` record is a documented producer of real-world trigger evidence.
+It records the escalation judgment; it does not adopt this experimental mode.
+
 ## The mode
 
 When the trigger fires, escalate from the serial repair loop (narrow repair
@@ -57,4 +61,6 @@ machinery.
 Both adoption-gate fixtures live in the source repo only (under the
 project's fixtures tree), not in the installed payload. The gate is a
 model-in-the-loop evaluation (#9 harness); it has not yet been run, so this
-mode remains optional and non-core.
+mode remains optional and non-core. The gate may consume dated, class-labelled,
+owner/source-attributed mechanism-decision records as real-world trigger
+evidence, while the shared single-fault fixture remains the negative control.

--- a/skills/implementaudit/references/transcript-contract.md
+++ b/skills/implementaudit/references/transcript-contract.md
@@ -164,7 +164,9 @@ has no row limit.
 These markers and classes apply to any governed run, phased or not. When no
 run root exists (direct in-session governance), the Markdown findings ledger
 serves as the Andon log substrate: record the abnormality class on the ledger
-row and cite prior same-class rows on escalation.
+row and cite prior same-class rows on escalation. The source-repo checker
+applies the recurrence rule to that substrate with
+`validate-run-root.sh --ledger <markdown-ledger>`.
 
 - **ANDON_PROBE**: emitted on the first abnormality of any class above. It
   must record: the abnormality and its class; the failing criterion, command,
@@ -190,7 +192,13 @@ row and cite prior same-class rows on escalation.
   rerun evidence. On success, the phase resumes from
   IMPLEMENTAUDIT_PHASE_VERIFY. Escalation may repeat with new evidence;
   repeating it without new evidence or progress routes to the ANDON_HANDOFF
-  conditions.
+  conditions. When three distinct linked occurrences share one class and the
+  last two repairs name the same `owner/source=<path>` in their Countermeasure
+  cells, append a `Mechanism-replacement decision:` after the last triggering
+  row and before closure. The accepted decisions are `replace-mechanism
+  (<what>)`, `continue (<justification>)`, and
+  `escalate-to-convergence-mode (<shared invariant>)`; none stops another
+  bounded repair.
 
 - **ANDON_HANDOFF**: emitted only when closure is blocked by an owner
   decision, unsafe scope, missing authorization, an external dependency,

--- a/skills/implementaudit/scripts/validate-run-root.sh
+++ b/skills/implementaudit/scripts/validate-run-root.sh
@@ -9,6 +9,7 @@
 # contract.
 #
 # Usage: validate-run-root.sh [--micro] <run-root>
+#        validate-run-root.sh --ledger <markdown-ledger>
 # Exit 0: conformant. Exit 1: violations listed on stderr. Exit 2: usage.
 
 set -uo pipefail
@@ -19,20 +20,101 @@ err() {
   err_count=$((err_count + 1))
 }
 
+# Count distinct Occ ids per Class in a new-format Andon table. The existing
+# Countermeasure cell carries owner/source=<path>; normalize separators before
+# comparing the last two distinct repair occurrences for a class. Keep this
+# normalization shape aligned with #80's separate host-note signature counter;
+# the substrates and scripts remain intentionally distinct.
+check_recurrence_decision() {
+  local ledger="$1" findings invalid_lines missing_classes
+  findings="$(awk -F'|' '
+    function trim(v) { gsub(/^[ \t]+|[ \t]+$/, "", v); return v }
+    function owner_source(v) {
+      if (v !~ /owner\/source[ \t]*=/) return ""
+      sub(/^.*owner\/source[ \t]*=[ \t]*/, "", v)
+      sub(/[ \t;,)]+.*$/, "", v)
+      gsub(/\\/, "/", v)
+      while (v ~ /^\.\//) sub(/^\.\//, "", v)
+      return v
+    }
+    /^Mechanism-replacement decision:/ {
+      if ($0 ~ /^Mechanism-replacement decision:[ \t]*(replace-mechanism|continue|escalate-to-convergence-mode)[ \t]*\([^()]*[[:alnum:]][^()]*\)[ \t]*$/) {
+        valid_decision[NR]=1
+      } else {
+        print "invalid\t" NR
+      }
+    }
+    /^[ \t]*AUDIT_COMPLETE[ \t]*$/ {
+      if (audit_complete_line == 0) audit_complete_line=NR
+    }
+    /^## Andon log/ { in_andon=1; new_format=0; next }
+    in_andon && /^## / { in_andon=0; new_format=0 }
+    in_andon && tolower($0) ~ /\|[ \t]*occ[ \t]*\|[ \t]*phase[ \t]*\|[ \t]*class[ \t]*\|/ {
+      new_format=1; next
+    }
+    in_andon && new_format && /^\|[[:space:]]*[0-9]+[[:space:]]*\|/ {
+      occ=trim($3); cls=trim($5)
+      if (occ == "" || cls == "") next
+      key=cls SUBSEP occ
+      if (!(key in seen)) {
+        seen[key]=1
+        count[cls]++
+        previous_owner[cls]=last_owner[cls]
+        last_owner[cls]=owner_source($7)
+        last_line[cls]=NR
+      }
+    }
+    END {
+      for (cls in count) {
+        if (count[cls] < 3 || last_owner[cls] == "" || previous_owner[cls] != last_owner[cls]) continue
+        found=0
+        for (line in valid_decision) {
+          if ((line + 0) > last_line[cls] &&
+              (audit_complete_line == 0 || (line + 0) < audit_complete_line)) found=1
+        }
+        if (!found) print "missing\t" cls
+      }
+    }' "$ledger")"
+
+  invalid_lines="$(printf '%s\n' "$findings" | awk -F'\t' '$1 == "invalid" { print $2 }' | tr '\n' ' ')"
+  if [ -n "$invalid_lines" ]; then
+    err "invalid Mechanism-replacement decision: line(s) $invalid_lines (allowed: replace-mechanism (<what>) / continue (<justification>) / escalate-to-convergence-mode (<shared invariant>))"
+  fi
+  missing_classes="$(printf '%s\n' "$findings" | awk -F'\t' '$1 == "missing" { print $2 }' | tr '\n' ' ')"
+  if [ -n "$missing_classes" ]; then
+    err "Andon class(es) $missing_classes reached 3 distinct linked occurrences with the last 2 repairs on one owner/source; add a following Mechanism-replacement decision:"
+  fi
+}
+
 mode=full
 if [ "${1:-}" = "--micro" ]; then
   mode=micro
+  shift
+elif [ "${1:-}" = "--ledger" ]; then
+  mode=ledger
   shift
 fi
 run_root="${1:-}"
 if [ -z "$run_root" ]; then
   if [ "$mode" = micro ]; then
     printf 'usage: validate-run-root.sh --micro <run-root>\n' >&2
+  elif [ "$mode" = ledger ]; then
+    printf 'usage: validate-run-root.sh --ledger <markdown-ledger>\n' >&2
   else
     printf 'usage: validate-run-root.sh <run-root>\n' >&2
   fi
   exit 2
 fi
+[ "$mode" != ledger ] || {
+  [ -f "$run_root" ] || { printf 'validate-run-root: not a file: %s\n' "$run_root" >&2; exit 2; }
+  check_recurrence_decision "$run_root"
+  if [ "$err_count" -gt 0 ]; then
+    printf 'validate-run-root: %d error(s)\n' "$err_count" >&2
+    exit 1
+  fi
+  printf 'validate-run-root: ok\n'
+  exit 0
+}
 [ -d "$run_root" ] || { printf 'validate-run-root: not a directory: %s\n' "$run_root" >&2; exit 2; }
 
 claim="$run_root/.claimed"
@@ -123,6 +205,7 @@ if [ -f "$state" ]; then
   elif ! grep -qi '| Class | Abnormality | Countermeasure | Rerun evidence | Outcome |' "$state"; then
     err "STATE.md Andon log table is missing the contract columns (# | Occ | Phase | Class | Abnormality | Countermeasure | Rerun evidence | Outcome; legacy shape without Occ also accepted)"
   fi
+  check_recurrence_decision "$state"
 
   if [ "$mode" = micro ]; then
     terminal_line="$(awk 'NF { last=$0 } END { print last }' "$state")"

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -671,6 +671,16 @@ Steps:
    route rule repairs through poka-yoke and AGENTS_UPDATE_DECISION.
    Rejecting governing-rule suspicion REQUIRES a recorded reason; a bare
    "no" fails the contract.
+   Deterministic firing condition: when the `## Andon log` contains at least
+   three distinct linked `Occ` ids sharing one `Class`, and the last two repair
+   rows for that class name the same normalized owner/source file in their
+   Countermeasure cells as `owner/source=<path>`, record a following
+   `Mechanism-replacement decision:` before `AUDIT_COMPLETE`. Values are
+   `replace-mechanism (<what is being replaced>)`,
+   `continue (<justification>)`, or
+   `escalate-to-convergence-mode (<shared invariant>)`. This is the existing
+   second-order judgment with a mechanical firing condition. It caps nothing
+   and forbids no further repair.
 3. Choose and record one path: split the phase, reframe the criterion,
    rollback, request an owner decision, or write a bounded fix-spec
    `<run-root>/phases/phase-N.fix.md`:

--- a/tests/andon-escalation-judgment.test.sh
+++ b/tests/andon-escalation-judgment.test.sh
@@ -27,6 +27,12 @@ printf '%s' "$flat" | grep -qi 'Rejecting governing-rule suspicion REQUIRES a re
   || fail "reasoned-rejection rule missing"
 printf '%s' "$flat" | grep -qi 'governing-rule suspicion' \
   || fail "Hansei governing-rule-suspicion field missing"
+printf '%s' "$flat" | grep -qi 'Mechanism-replacement decision:' \
+  || fail "mechanism-replacement decision field missing"
+printf '%s' "$flat" | grep -qi 'replace-mechanism.*continue.*escalate-to-convergence-mode' \
+  || fail "mechanism-replacement decision vocabulary missing"
+printf '%s' "$flat" | grep -qi 'caps nothing.*forbids no further repair' \
+  || fail "non-cap boundary missing"
 
 # --- five scored transcript fixtures (the judgment token per situation) ----
 dir="fixtures/andon-escalation"

--- a/tests/convergence-mode-contract.test.sh
+++ b/tests/convergence-mode-contract.test.sh
@@ -25,6 +25,10 @@ printf '%s' "$flat" | grep -qi 'exactly one outer qualification' || fail "single
 printf '%s' "$flat" | grep -qi 'Adoption gate' || fail "adoption gate missing"
 printf '%s' "$flat" | grep -qi 'single-fault fixture .* must NOT trigger\|must NOT trigger' \
   || fail "negative-control (must-not-trigger) missing"
+printf '%s' "$flat" | grep -qi 'escalate-to-convergence-mode' \
+  || fail "mechanism-replacement evidence producer missing"
+printf '%s' "$flat" | grep -qi 'real-world trigger evidence' \
+  || fail "adoption-gate evidence linkage missing"
 
 # Progressive disclosure: the reference must NOT be inlined into the
 # bootloader path. SKILL.md may POINT to it, but not carry its body — guard

--- a/tests/run-root-validation.test.sh
+++ b/tests/run-root-validation.test.sh
@@ -285,4 +285,63 @@ if bash "$helper" --micro "$fixture_root/terminal-marker-transcript-only/root" >
   exit 1
 fi
 
+# 8. Mechanical second-order recurrence trigger (#91).
+if recurrence_output="$(bash "$helper" --micro "$fixture_root/recurrence-3-same-class-same-file/root" 2>&1)"; then
+  printf 'run-root-validation.test: recurring class on one owner/source must require a decision\n' >&2
+  exit 1
+fi
+printf '%s\n' "$recurrence_output" | grep -Fq 'Mechanism-replacement decision:' || {
+  printf 'run-root-validation.test: recurrence failure did not name the required decision\n' >&2
+  exit 1
+}
+
+for decision_fixture in \
+  recurrence-3-with-replace-decision \
+  recurrence-3-with-continue-decision \
+  recurrence-3-with-convergence-escalation; do
+  bash "$helper" --micro "$fixture_root/$decision_fixture/root" >/dev/null || {
+    printf 'run-root-validation.test: %s expected PASS\n' "$decision_fixture" >&2
+    exit 1
+  }
+done
+
+bash "$helper" --micro "$fixture_root/recurrence-3-different-files/root" >/dev/null || {
+  printf 'run-root-validation.test: different-files control expected PASS\n' >&2
+  exit 1
+}
+bash "$helper" --micro "$fixture_root/recurrence-3-different-classes/root" >/dev/null || {
+  printf 'run-root-validation.test: different-classes control expected PASS\n' >&2
+  exit 1
+}
+
+# The convergence-mode single-fault control is reused, not duplicated.
+bash "$helper" --ledger fixtures/convergence-mode/single-fault-control.md >/dev/null || {
+  printf 'run-root-validation.test: shared single-fault control expected PASS\n' >&2
+  exit 1
+}
+bash "$helper" --ledger "$fixture_root/legacy-andon-shape/ledger.md" >/dev/null || {
+  printf 'run-root-validation.test: legacy Andon ledger expected PASS\n' >&2
+  exit 1
+}
+bash "$helper" --ledger "$fixture_root/direct-ledger-substrate/below-threshold.md" >/dev/null || {
+  printf 'run-root-validation.test: direct ledger below threshold expected PASS\n' >&2
+  exit 1
+}
+bash "$helper" --ledger "$fixture_root/direct-ledger-substrate/duplicate-occ-below-threshold.md" >/dev/null || {
+  printf 'run-root-validation.test: duplicate Occ rows must count once\n' >&2
+  exit 1
+}
+if bash "$helper" --ledger "$fixture_root/direct-ledger-substrate/trigger-no-decision.md" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: direct ledger trigger without decision must fail\n' >&2
+  exit 1
+fi
+if bash "$helper" --ledger "$fixture_root/direct-ledger-substrate/invalid-empty-continue.md" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: continue without justification must fail\n' >&2
+  exit 1
+fi
+if bash "$helper" --ledger "$fixture_root/direct-ledger-substrate/decision-after-audit-complete.md" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: decision after AUDIT_COMPLETE must fail\n' >&2
+  exit 1
+fi
+
 printf 'run-root-validation.test: ok\n'


### PR DESCRIPTION
## Purpose

Closes #91.

This makes second-order recurrence a mechanical invariant: when three distinct linked Andon occurrences share one class and the last two repairs name the same normalized `owner/source=<path>`, the ledger must record a following mechanism-replacement decision before closure. The trigger caps nothing and does not forbid another bounded repair.

## What changed

- Added the recurrence check to `validate-run-root.sh` for both run-root `STATE.md` and direct Markdown ledgers via `--ledger`.
- Counted distinct `Occ` identifiers per exact class, normalized path separators, and accepted only the three amended decision forms: `replace-mechanism`, justified `continue`, or `escalate-to-convergence-mode`.
- Linked convergence escalation to real-world trigger evidence without adopting the experimental mode.
- Updated the protocol and transcript references and added positive, negative, direct-ledger, duplicate-occurrence, and legacy fixtures.

## Legacy migration

No migration is required. Old run roots remain valid. Pre-`Occ` Andon tables are accepted as legacy and do not fire the new counter. New-format ledgers pay no additional decision cost unless the exact three-occurrence/same-class/same-owner-source condition holds.

## Fixtures and negative controls

- Green decisions: replace mechanism, justified continuation, and convergence escalation.
- Green controls: different owner/source files, different classes, below-threshold ledgers, duplicate rows for one `Occ`, the existing shared single-fault convergence fixture, and legacy Andon shape.
- Rejected controls: threshold reached with no decision, empty continuation justification, and a decision placed after `AUDIT_COMPLETE`.

## Validation

- All 59 `tests/*.test.sh` entries passed, with both validation registries reporting 59/59 parity. Platform-specific symlink/POSIX cases retained their supported skips.
- `bash scripts/verify-package.sh` passed with exit 0.
- `bash tests/run-root-validation.test.sh` passed.
- `bash tests/andon-escalation-judgment.test.sh` passed.
- `bash tests/convergence-mode-contract.test.sh` passed.
- `bash skills/implementaudit/scripts/validate-run-root.sh fixtures/run-root-example` passed.
- Historical full-run fixtures retained their prior findings counts: 2, 8, 7, 7, and 8.
- `git diff --check` passed before commit; the staged diff check also passed.

## Spine budget

`skills/implementaudit/SKILL.md` is unchanged at 448 lines and 21,807 bytes, within the 450-line / 22,000-byte budget.

## Stack and coordination

This PR is stacked on draft PR #102 and intentionally targets `impl/issue-90-run-root-micro`. Do not merge it before #102.

Per the amendment, future #80 and this issue do not share a script or hunk: #80 counts host-note signatures in `check-lesson-lift.sh`; this PR counts Andon occurrences in `validate-run-root.sh`. They coordinate only the normalization/counting shape.

## Rollback

Single revert of commit `ef8265177304cfa6f65216bc2ac8ebb1786a974c`.
