### PR TITLE
Calibrate package budget for admitted W1 payload

### DIFF
--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -172,14 +172,33 @@ with zipfile.ZipFile(asset) as zf:
     # references/continuity.md plus PROTOCOL/STATE contract text grew the
     # deflated asset to ~131 KB — growth verified intentional and deflated.
     asset_bytes = asset.stat().st_size
-    MAX_ASSET_BYTES = 140_000
-    if asset_bytes > MAX_ASSET_BYTES:
+    # W1 integration ANDON calibration: baseline ceiling 140_000; full W1
+    # forecast size 144_730; new ceiling 145_000; remaining headroom 270.
+    # Reason: admitted milestone payload, not acceptance weakening.
+    MAX_ASSET_BYTES = 145_000
+    FULL_W1_FORECAST_BYTES = 144_730
+
+    def enforce_asset_budget(candidate_bytes):
+        if candidate_bytes <= MAX_ASSET_BYTES:
+            return
         raise SystemExit(
-            f"asset size {asset_bytes:,} bytes exceeds the {MAX_ASSET_BYTES:,}-byte "
+            f"asset size {candidate_bytes:,} bytes exceeds the {MAX_ASSET_BYTES:,}-byte "
             "threshold. Verify ZIP_DEFLATED compression is applied (the check above), "
             "then update MAX_ASSET_BYTES in tests/release-asset.test.sh if the payload "
             "growth is intentional."
         )
+
+    # The complete, deduplicated W1 forecast must be admitted, while the first
+    # byte above the calibrated ceiling must remain rejected.
+    enforce_asset_budget(FULL_W1_FORECAST_BYTES)
+    try:
+        enforce_asset_budget(MAX_ASSET_BYTES + 1)
+    except SystemExit:
+        pass
+    else:
+        raise SystemExit("asset above MAX_ASSET_BYTES was accepted")
+
+    enforce_asset_budget(asset_bytes)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         zf.extractall(temp_dir)


### PR DESCRIPTION
## What changed

- Raises the sole authoritative release-asset ceiling from 140,000 to 145,000 bytes.
- Adds one shared budget check with a positive control at the deduplicated full-W1 forecast (144,730 bytes) and a negative control at 145,001 bytes.
- Records the measurement basis beside the constant; no shipped payload changes.

## Why

The W1 integration ANDON was caused by budgeting isolated PRs rather than the full admitted tranche. A disposable, unpushed semantic-union forecast measured:

| Layer | Asset bytes | Delta |
|---|---:|---:|
| F0 live main after PR #106 | 139,981 | — |
| F1 + PR #108 | 140,977 | +996 |
| F2 + PR #109 | 143,393 | +2,416 |
| F3 + PR #107 | 144,817 | +1,424 |
| F3 after one genuine comment deduplication | 144,730 | -87 |

The smallest whole-1,000-byte ceiling strictly above 144,730 is 145,000, leaving 270 bytes of headroom. This admits milestone payload; it does not weaken acceptance.

## Evidence

- RED: the new measured-W1 positive control failed at the old 140,000-byte ceiling.
- GREEN: `tests/release-asset.test.sh` passed at 145,000 and rejects 145,001.
- Focused package/reproducibility/install-copy/shape gates passed.
- Calibration head asset: 139,981 bytes; 337,932 raw packaged bytes; 43 entries.
- Full registered suite: 60/60 passed, zero failures. `scripts/verify-package.sh`: `verify-package: ok`.

## Boundaries

No shipped skill file, checker acceptance predicate, required fixture, existing negative control, `SKILL.md` line/byte ceiling, tag, release, milestone, or child-issue implementation is changed. No issue is closed by this PR.

Linkage: W1 integration ANDON; PRs #106, #108, #109, #107.