### PR TITLE
Rehearse scarce-resource launch identity (#84)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,7 @@ jobs:
           bash tests/handoff-packet-contract.test.sh
           bash tests/closure-surface-contract.test.sh
           bash tests/authorization-binding-contract.test.sh
+          bash tests/scarce-resource-rehearsal-contract.test.sh
           bash tests/convergence-mode-contract.test.sh
           bash tests/andon-escalation-judgment.test.sh
           bash tests/background-chain-contract.test.sh

--- a/fixtures/scarce-resource-rehearsal/cases.json
+++ b/fixtures/scarce-resource-rehearsal/cases.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "argv": [
+    "scripts/run-model.sh",
+    "--input",
+    "fixture.txt"
+  ],
+  "env_keys_present": [
+    "API_TOKEN",
+    "MODEL"
+  ],
+  "terminal_artifact_path": "evidence/rehearsal-terminal.json",
+  "stub_identity": "deterministic-producer-stub-v1"
+}

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -243,6 +243,8 @@ require_file tests/lesson-lift-contract.test.sh
 require_file tests/handoff-packet-contract.test.sh
 require_file tests/closure-surface-contract.test.sh
 require_file tests/authorization-binding-contract.test.sh
+require_file tests/scarce-resource-rehearsal-contract.test.sh
+require_file fixtures/scarce-resource-rehearsal/cases.json
 require_file tests/convergence-mode-contract.test.sh
 require_file tests/andon-escalation-judgment.test.sh
 require_file tests/background-chain-contract.test.sh
@@ -600,6 +602,7 @@ bash tests/lesson-lift-contract.test.sh
 bash tests/handoff-packet-contract.test.sh
 bash tests/closure-surface-contract.test.sh
 bash tests/authorization-binding-contract.test.sh
+bash tests/scarce-resource-rehearsal-contract.test.sh
 bash tests/convergence-mode-contract.test.sh
 bash tests/andon-escalation-judgment.test.sh
 bash tests/background-chain-contract.test.sh

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -235,6 +235,18 @@ operational specificity. The read-only handoff lane
 requirement where their contexts overlap. `validate-phase.sh` enforces the
 mechanical parts; cold review owns materiality judgments.
 
+**Rule P4-11 — Scarce-resource launch rehearsal (#84).**
+Before a scarce or irreversible resource is spent, rehearse the exact
+production wrapper, argv, sorted environment-key names, transport, and terminal
+artifact path with the producer stubbed and zero metered calls. Bind the result
+to a strict terminal receipt and canonical command hash; environment values are
+never captured. A failed rehearsal authorizes no launch. Interposed stubs make
+the result `PASS_WITH_SCOPE_GAP` and every extra component is named in
+`Residual risk:`. A passing run through a second apparatus is flagged for cold
+review with residual-risk rationale rather than mechanically promoted. After a
+failure, only manual repair and re-run may establish a new passing receipt; the
+governed action must not automatically retry.
+
 **Rule P4-12 — Paired controls on free-text acceptance.**
 Any acceptance criterion that matches free text ships with two named controls
 recorded beside it: one legitimate paraphrase that must PASS, and one

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -25,6 +25,167 @@ drift() {
   exit 1
 }
 
+# Scarce-resource preflight rehearsal (#84). This mode is deliberately
+# separate from the legacy authorization-record comparison below: it validates
+# inert artifacts and never launches the recorded argv or reads environment
+# values.
+if [ "${1:-}" = "--phase" ]; then
+  phase=""; rehearsal=""; launch=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --phase) [ "$#" -ge 2 ] || fail "--phase requires a file"; phase="$2"; shift 2;;
+      --rehearsal) [ "$#" -ge 2 ] || fail "--rehearsal requires a file"; rehearsal="$2"; shift 2;;
+      --launch) [ "$#" -ge 2 ] || fail "--launch requires a file"; launch="$2"; shift 2;;
+      *) fail "unknown rehearsal arg $1";;
+    esac
+  done
+  [ -f "$phase" ] || fail "phase file not found: $phase"
+  python - "$phase" "$rehearsal" "$launch" <<'PY'
+import datetime
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+def fail(message):
+    print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr)
+    raise SystemExit(1)
+
+phase_path, rehearsal_path, launch_path = sys.argv[1:]
+phase_text = pathlib.Path(phase_path).read_text(encoding="utf-8")
+budget_lines = re.findall(r"(?mi)^Scarce resource budget:[ \t]*(.*?)[ \t]*$", phase_text)
+if len(budget_lines) != 1:
+    fail("phase must contain exactly one Scarce resource budget field")
+budget = budget_lines[0]
+if budget == "none":
+    if rehearsal_path or launch_path:
+        fail("a none budget accepts no rehearsal or launch artifact")
+    print("check-authorization-binding: ok — scarce resource budget is none")
+    raise SystemExit(0)
+if not re.fullmatch(r"[1-9][0-9]* [^\s]+", budget):
+    fail("budget must be 'none' or 'N <resource>' with positive N")
+if not rehearsal_path or not launch_path:
+    fail("non-none budget requires --rehearsal and --launch")
+
+def load_object(path, label):
+    def reject_duplicate_members(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate object member {key!r}")
+            value[key] = item
+        return value
+    try:
+        value = json.loads(
+            pathlib.Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_members,
+        )
+    except (OSError, UnicodeError, ValueError) as exc:
+        fail(f"invalid {label} JSON: {exc}")
+    if type(value) is not dict:
+        fail(f"{label} must be one JSON object")
+    return value
+
+receipt = load_object(rehearsal_path, "REHEARSAL_TERMINAL")
+launch = load_object(launch_path, "launch record")
+receipt_keys = {
+    "rehearsed_command_hash", "stub_identity", "stubbed_components",
+    "env_keys_present", "terminal_artifact_path", "exit_code",
+    "disposition", "timestamp",
+}
+launch_keys = {
+    "argv", "env_keys_present", "terminal_artifact_path",
+    "launch_records", "metered_calls",
+}
+if set(receipt) != receipt_keys:
+    fail(f"REHEARSAL_TERMINAL fields must be exactly {sorted(receipt_keys)}")
+if set(launch) != launch_keys:
+    fail(f"launch record fields must be exactly {sorted(launch_keys)}")
+
+def nonempty_string(value, label):
+    if type(value) is not str or not value:
+        fail(f"{label} must be a nonempty string")
+
+def string_array(value, label, *, nonempty=True):
+    if type(value) is not list or (nonempty and not value):
+        fail(f"{label} must be a nonempty string array")
+    if any(type(item) is not str or not item for item in value):
+        fail(f"{label} contains an invalid string")
+
+def env_keys(value, label):
+    string_array(value, label)
+    if value != sorted(value) or len(value) != len(set(value)):
+        fail(f"{label} must be sorted and unique")
+    if any(not re.fullmatch(r"[A-Z_][A-Z0-9_]*", item) for item in value):
+        fail(f"{label} may contain environment key names only")
+
+nonempty_string(receipt["rehearsed_command_hash"], "rehearsed_command_hash")
+if not re.fullmatch(r"[0-9a-f]{64}", receipt["rehearsed_command_hash"]):
+    fail("rehearsed_command_hash must be lowercase SHA-256")
+nonempty_string(receipt["stub_identity"], "stub_identity")
+string_array(receipt["stubbed_components"], "stubbed_components")
+if len(receipt["stubbed_components"]) != len(set(receipt["stubbed_components"])):
+    fail("stubbed_components must be unique")
+env_keys(receipt["env_keys_present"], "receipt env_keys_present")
+nonempty_string(receipt["terminal_artifact_path"], "receipt terminal_artifact_path")
+if type(receipt["exit_code"]) is not int:
+    fail("exit_code must be an integer")
+if receipt["disposition"] not in {"PASS", "PASS_WITH_SCOPE_GAP", "FAIL"}:
+    fail("invalid disposition")
+nonempty_string(receipt["timestamp"], "timestamp")
+if not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", receipt["timestamp"]):
+    fail("timestamp must be UTC ISO-8601 ending Z")
+try:
+    datetime.datetime.fromisoformat(receipt["timestamp"].replace("Z", "+00:00"))
+except ValueError:
+    fail("timestamp is not a real UTC instant")
+
+string_array(launch["argv"], "argv")
+nonempty_string(launch["argv"][0], "production wrapper argv[0]")
+env_keys(launch["env_keys_present"], "launch env_keys_present")
+nonempty_string(launch["terminal_artifact_path"], "launch terminal_artifact_path")
+for key in ("launch_records", "metered_calls"):
+    if type(launch[key]) is not int or launch[key] < 0:
+        fail(f"{key} must be a nonnegative integer")
+if launch["metered_calls"] != 0:
+    fail("a rehearsal must consume zero metered calls")
+
+if receipt["env_keys_present"] != launch["env_keys_present"]:
+    fail("receipt and launch environment-key sets differ")
+if receipt["terminal_artifact_path"] != launch["terminal_artifact_path"]:
+    fail("receipt and launch terminal artifact paths differ")
+preimage = json.dumps(
+    {"argv": launch["argv"], "env_keys_present": sorted(launch["env_keys_present"])},
+    ensure_ascii=False,
+    separators=(",", ":"),
+).encode("utf-8")
+actual_hash = hashlib.sha256(preimage).hexdigest()
+if receipt["rehearsed_command_hash"] != actual_hash:
+    fail("rehearsed command hash does not match exact argv/environment-key identity")
+if receipt["exit_code"] != 0 or receipt["disposition"] == "FAIL":
+    fail("nonzero or FAIL rehearsal never authorizes launch")
+
+components = receipt["stubbed_components"]
+if "producer" not in components:
+    fail("producer must be stubbed")
+extras = [item for item in components if item != "producer"]
+if not extras:
+    if receipt["disposition"] != "PASS" or components != ["producer"]:
+        fail("PASS requires exactly the producer stub")
+else:
+    if receipt["disposition"] != "PASS_WITH_SCOPE_GAP":
+        fail("interposed stubs require PASS_WITH_SCOPE_GAP")
+    residuals = re.findall(r"(?mi)^Residual risk:[ \t]*(.*?)[ \t]*$", phase_text)
+    missing = [item for item in extras if not any(item in line for line in residuals)]
+    if missing:
+        fail(f"Residual risk must name every interposed stub: {missing}")
+
+print("check-authorization-binding: ok — rehearsal identity and terminal receipt are bound")
+PY
+  exit $?
+fi
+
 auth=""; inv=""
 while [ "$#" -gt 0 ]; do
   case "$1" in

--- a/skills/implementaudit/templates/phase-goal.txt
+++ b/skills/implementaudit/templates/phase-goal.txt
@@ -26,6 +26,7 @@ Auditing operation: {{WHAT_ydqyq-audit-action_THIS_PHASE_PERFORMS}}
 Terminal object state to prove: {{WHAT_MUST_BE_TRUE_WHEN_DONE}}
 Thinking ref: <run-root>/THINKING.md
 Mandatory commands: {{COMMANDS_CSV}}
+Scarce resource budget: {{N <resource> | none}}
 Acceptance criteria: {{CRIT_COUNT}}
 Evidence required: {{EVIDENCE_CSV}}
 Depends on phases: {{DEPS}}

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+checker="skills/implementaudit/scripts/check-authorization-binding.sh"
+policy="skills/implementaudit/references/phase-design.md"
+template="skills/implementaudit/templates/phase-goal.txt"
+fixture="fixtures/scarce-resource-rehearsal/cases.json"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fail() { printf 'scarce-resource-rehearsal-contract: %s\n' "$*" >&2; exit 1; }
+
+cat > "$tmp/phase-budget.md" <<'EOF'
+Scarce resource budget: 2 model-calls
+Residual risk: none
+EOF
+cat > "$tmp/phase-none.md" <<'EOF'
+Scarce resource budget: none
+Residual risk: none
+EOF
+cat > "$tmp/phase-gap.md" <<'EOF'
+Scarce resource budget: 2 model-calls
+Residual risk: terminal-writer is interposed during rehearsal
+EOF
+cat > "$tmp/phase-gap-missing.md" <<'EOF'
+Scarce resource budget: 2 model-calls
+Residual risk: none
+EOF
+
+python - "$fixture" "$tmp" <<'PY'
+import copy
+import hashlib
+import json
+import pathlib
+import sys
+
+fixture = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+out = pathlib.Path(sys.argv[2])
+
+def canonical_hash(argv, env_keys):
+    preimage = json.dumps(
+        {"argv": argv, "env_keys_present": sorted(env_keys)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(preimage).hexdigest()
+
+launch = {
+    "argv": fixture["argv"],
+    "env_keys_present": fixture["env_keys_present"],
+    "terminal_artifact_path": fixture["terminal_artifact_path"],
+    "launch_records": 1,
+    "metered_calls": 0,
+}
+receipt = {
+    "rehearsed_command_hash": canonical_hash(launch["argv"], launch["env_keys_present"]),
+    "stub_identity": fixture["stub_identity"],
+    "stubbed_components": ["producer"],
+    "env_keys_present": fixture["env_keys_present"],
+    "terminal_artifact_path": fixture["terminal_artifact_path"],
+    "exit_code": 0,
+    "disposition": "PASS",
+    "timestamp": "2026-08-06T12:00:00Z",
+}
+
+def write(name, value):
+    (out / name).write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+write("launch-good.json", launch)
+write("receipt-good.json", receipt)
+
+f1_launch = copy.deepcopy(launch)
+f1_launch.update(argv=[], launch_records=0, metered_calls=0)
+f1_receipt = copy.deepcopy(receipt)
+f1_receipt.update(exit_code=2, disposition="FAIL")
+write("launch-f1-zero.json", f1_launch)
+write("receipt-f1-fail.json", f1_receipt)
+
+path_mismatch = copy.deepcopy(receipt)
+path_mismatch["terminal_artifact_path"] = "evidence/other-terminal.json"
+write("receipt-path-mismatch.json", path_mismatch)
+
+drift_launch = copy.deepcopy(launch)
+drift_launch["env_keys_present"] = ["API_TOKEN", "MODEL", "REGION"]
+write("launch-drift.json", drift_launch)
+
+gap = copy.deepcopy(receipt)
+gap["stubbed_components"] = ["producer", "terminal-writer"]
+gap["disposition"] = "PASS_WITH_SCOPE_GAP"
+write("receipt-gap.json", gap)
+
+extra = copy.deepcopy(receipt)
+extra["unexpected"] = "not allowed"
+write("receipt-extra.json", extra)
+env_values = copy.deepcopy(receipt)
+env_values["env_values"] = {"API_TOKEN": "redacted-but-still-forbidden"}
+write("receipt-env-values.json", env_values)
+key_value = copy.deepcopy(receipt)
+key_value["env_keys_present"] = ["API_TOKEN=secret", "MODEL"]
+write("receipt-key-value.json", key_value)
+unsorted_keys = copy.deepcopy(receipt)
+unsorted_keys["env_keys_present"] = ["MODEL", "API_TOKEN"]
+write("receipt-unsorted.json", unsorted_keys)
+duplicate_keys = copy.deepcopy(receipt)
+duplicate_keys["env_keys_present"] = ["API_TOKEN", "API_TOKEN", "MODEL"]
+write("receipt-duplicate.json", duplicate_keys)
+bad_type = copy.deepcopy(receipt)
+bad_type["exit_code"] = True
+write("receipt-type-invalid.json", bad_type)
+
+# Raw JSON is intentional: ordinary dict serialization cannot preserve
+# duplicate object members. A strict untrusted-data parser must reject both
+# contradictions instead of silently retaining the final value.
+receipt_text = json.dumps(receipt, indent=2) + "\n"
+(out / "receipt-duplicate-member.json").write_text(
+    receipt_text.replace('"exit_code": 0', '"exit_code": 2,\n  "exit_code": 0', 1),
+    encoding="utf-8",
+)
+launch_text = json.dumps(launch, indent=2) + "\n"
+(out / "launch-duplicate-member.json").write_text(
+    launch_text.replace('"argv": [', '"argv": [],\n  "argv": [', 1),
+    encoding="utf-8",
+)
+PY
+
+must_pass() {
+  local label="$1"; shift
+  "$@" >/dev/null 2>&1 || fail "$label must pass"
+}
+must_fail() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then fail "$label must fail"; fi
+}
+rehearse() {
+  bash "$checker" --phase "$1" --rehearsal "$2" --launch "$3"
+}
+
+# F1: a failed malformed-argv rehearsal cannot authorize launch; the fixture
+# independently proves that neither a launch record nor a metered call occurred.
+must_fail F1 rehearse "$tmp/phase-budget.md" "$tmp/receipt-f1-fail.json" "$tmp/launch-f1-zero.json"
+python - "$tmp/launch-f1-zero.json" <<'PY' || fail "F1 counters must remain zero"
+import json, pathlib, sys
+d = json.loads(pathlib.Path(sys.argv[1]).read_text())
+raise SystemExit(0 if d["launch_records"] == 0 and d["metered_calls"] == 0 else 1)
+PY
+
+# F2/F3: transport/path incompatibility and post-rehearsal identity drift are
+# rejected before a real launch can occur.
+must_fail F2 rehearse "$tmp/phase-budget.md" "$tmp/receipt-path-mismatch.json" "$tmp/launch-good.json"
+must_fail F3 rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-drift.json"
+
+# F4: an explicit `none` budget has no receipt obligation.
+must_pass F4 bash "$checker" --phase "$tmp/phase-none.md"
+
+# F5: interposed stubbing is a scope gap and every extra component must be
+# named by the phase's residual-risk statement.
+must_fail F5-missing-residual rehearse "$tmp/phase-gap-missing.md" "$tmp/receipt-gap.json" "$tmp/launch-good.json"
+must_pass F5-matched-residual rehearse "$tmp/phase-gap.md" "$tmp/receipt-gap.json" "$tmp/launch-good.json"
+
+# F7: a repaired receipt may pass on a manual re-run. The policy itself must
+# keep that repair manual and forbid automatic retries.
+must_pass F7 rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-good.json"
+
+# F8: strict schemas reject extras, value-bearing fields/key-value strings,
+# ordering/uniqueness violations, and booleans masquerading as integers.
+for case in extra env-values key-value unsorted duplicate type-invalid; do
+  must_fail "F8-$case" rehearse "$tmp/phase-budget.md" "$tmp/receipt-$case.json" "$tmp/launch-good.json"
+done
+must_fail F8-duplicate-receipt-member rehearse "$tmp/phase-budget.md" "$tmp/receipt-duplicate-member.json" "$tmp/launch-good.json"
+must_fail F8-duplicate-launch-member rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-duplicate-member.json"
+
+# Policy/template owners: P4-11 occupies its ordered slot, requires exact
+# apparatus rehearsal and independent cold review of a second apparatus, and
+# exposes the budget field beside mandatory commands.
+p410="$(grep -n '^\*\*Rule P4-10 ' "$policy" | cut -d: -f1)"
+p411="$(grep -n '^\*\*Rule P4-11 ' "$policy" | cut -d: -f1)"
+p412="$(grep -n '^\*\*Rule P4-12 ' "$policy" | cut -d: -f1)"
+[ "$p410" -lt "$p411" ] && [ "$p411" -lt "$p412" ] || fail "P4-11 must sit between P4-10 and P4-12"
+p411_text="$(sed -n "${p411},$((p412 - 1))p" "$policy" | tr '\n' ' ')"
+printf '%s' "$p411_text" | grep -qi 'exact.*wrapper.*argv.*environment-key.*terminal' || fail "P4-11 missing exact apparatus identity"
+printf '%s' "$p411_text" | grep -qi 'second apparatus.*cold review' || fail "F6 second-apparatus judgment must remain cold review"
+printf '%s' "$p411_text" | grep -qi 'manual repair.*re-run' || fail "F7 manual repair/re-run rule missing"
+printf '%s' "$p411_text" | grep -qi 'no automatic retr\|must not automatically retr' || fail "F7 automatic retry prohibition missing"
+grep -q '^Scarce resource budget: {{N <resource> | none}}$' "$template" || fail "phase budget field missing"
+
+printf 'scarce-resource-rehearsal-contract: ok (F1-F8; zero metered calls)\n'


### PR DESCRIPTION
## Summary

- add P4-11 and an explicit scarce-resource phase budget
- bind exact wrapper argv, sorted environment-key names, terminal path, and strict receipt schema before spend
- reject duplicate JSON members, values/extras, identity drift, and unqualified interposed stubs without launching or consuming metered calls

## Evidence

- logical implementation commit: 5433e89b72eacd5b0427ff21111b699bec9f8ab5
- frozen final C head: 546f0ca76adf98644578db02048c4dc53485c1e9
- deterministic F1-F8 pass with zero metered calls and raw duplicate-member adversarials
- legacy authorization, phase 49/49, eval 29/no model calls, registry 66, syntax, and package forecast gates passed
- independent F6 and implementation review PASS after strict-loader repair
- package contribution: 158,420 -> 161,007 bytes; train-wide 162,000-byte calibration is already on main

## Stack

Base: #77 branch. This PR displays only #84 and will be retargeted after its parents merge. Exact C is the load-bearing local and hosted qualification target.

Issue: #84