### PR TITLE
Calibrate package budget for the N04 identity/integrity train

### DIFF
--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -175,16 +175,17 @@ with zipfile.ZipFile(asset) as zf:
     # references/continuity.md plus PROTOCOL/STATE contract text grew the
     # deflated asset to ~131 KB — growth verified intentional and deflated.
     asset_bytes = asset.stat().st_size
-    # Train-wide ANDON calibration: retain the admitted 144_730-byte W1 and
-    # 151_898-byte N02 probes; the deduplicated #75 -> #77 -> #84 cumulative
-    # tip is 161_007 bytes. The smallest whole-1,000-byte ceiling strictly
-    # above it is 162_000, leaving 993 bytes of measured headroom.
-    # Reason: admitted milestone payload, not acceptance weakening.
-    MAX_ASSET_BYTES = 162_000
+    # Train-wide ANDON calibration: retain each historical admitted probe. The
+    # reviewed, dedup-adjudicated N04 identity/integrity train is 202_593 bytes;
+    # its owner-authorized whole-1,000-byte ceiling is 203_000 (407 bytes of
+    # measured headroom). Reason: admitted milestone payload, not acceptance
+    # weakening or future-batch/release headroom.
+    MAX_ASSET_BYTES = 203_000
     FULL_W1_FORECAST_BYTES = 144_730
     N02_EVIDENCE_CENSUS_FORECAST_BYTES = 151_898
     ISSUE_75_77_84_TRAIN_FORECAST_BYTES = 161_007
-    FIRST_REJECTED_BYTES = 162_001
+    N04_IDENTITY_INTEGRITY_FORECAST_BYTES = 202_593
+    FIRST_REJECTED_BYTES = 203_001
 
     def enforce_asset_budget(candidate_bytes):
         if candidate_bytes <= MAX_ASSET_BYTES:
@@ -201,6 +202,8 @@ with zipfile.ZipFile(asset) as zf:
     enforce_asset_budget(FULL_W1_FORECAST_BYTES)
     enforce_asset_budget(N02_EVIDENCE_CENSUS_FORECAST_BYTES)
     enforce_asset_budget(ISSUE_75_77_84_TRAIN_FORECAST_BYTES)
+    enforce_asset_budget(N04_IDENTITY_INTEGRITY_FORECAST_BYTES)
+    enforce_asset_budget(MAX_ASSET_BYTES)
     try:
         enforce_asset_budget(FIRST_REJECTED_BYTES)
     except SystemExit:


### PR DESCRIPTION
## What changed

- Raises the authoritative packaged-asset ceiling from 162,000 to 203,000 bytes.
- Records the reviewed N04 final forecast at 202,593 bytes.
- Makes 203,000 an explicit accepted boundary and 203,001 the first rejected byte.

## Why

The bounded N04 deduplication review found no safe reduction sufficient to fit the final cumulative nine-issue train below the old ceiling. The owner authorized 203,000 as the smallest whole-1,000-byte ceiling above the measured 202,593-byte artifact.

## Evidence anchor

- Frozen P9 commit: `fc4283b952cdc7d1fbb8984402c4598d732e4494`
- Frozen P9 tree: `4e7456d8237b1c6ca9149b9bd762af41fcfc02e2`
- Run handoff: `.IMPLEMENTAUDIT/n04-runs/n04-close-88-78-76-87-86-89-98-92-80-J9sKAd/HANDOFF.md`
- Deduplication review: `.IMPLEMENTAUDIT/n04-runs/n04-close-88-78-76-87-86-89-98-92-80-J9sKAd/evidence/p11-package-deduplication-review.md`
- Final artifact measurement: 202,593 bytes

## Boundaries

Package-budget policy only. This PR changes no skill, package member, `SKILL.md`, Linux baseline, future tranche, or release headroom, and it performs no tag, release, publication, or deployment.

## Linkage

N04-R1 owner-authorized calibration for the cumulative train `#88 -> #78 -> #76 -> #87 -> #86 -> #89 -> #98 -> #92 -> #80`.