### PR TITLE
#89: Package and release identity gate

### DIFF
--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -22,7 +22,256 @@ fi
 asset_name="IMPLEMENTAUDIT.skill"
 cleanup_dir=""
 
+check_release_identity() {
+  local mode="${1:-}" previous_version="${2:-}" release_commit="${3:-}" check_root="${4:-$repo_root}"
+  local candidate_asset="${5:-$check_root/$asset_name}"
+  [ -n "$mode" ] && [ -n "$previous_version" ] && [ -n "$release_commit" ] \
+    || fail "--check-release-identity requires <forward|republish> <previous-version> <release-commit> [repo-root] [candidate-asset]"
+  "${py_cmd[@]}" - "$mode" "$previous_version" "$release_commit" "$check_root" "$candidate_asset" <<'PY'
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+mode, previous_version, release_commit, root_arg, candidate_arg = sys.argv[1:]
+root = Path(root_arg).resolve()
+if mode not in {"forward", "republish"}:
+    raise SystemExit("prospective release identity mode must be forward or republish")
+
+plugin_path = root / ".claude-plugin" / "plugin.json"
+skill_path = root / "skills" / "implementaudit" / "SKILL.md"
+changelog_path = root / "CHANGELOG.md"
+for path in (plugin_path, skill_path, changelog_path):
+    if not path.is_file():
+        raise SystemExit(f"release identity owner is missing: {path}")
+
+plugin_version = str(json.loads(plugin_path.read_text(encoding="utf-8")).get("version", "")).strip()
+skill_text = skill_path.read_text(encoding="utf-8")
+match = re.search(r'(?m)^\s+version:\s*["\']?([^"\'\n]+)["\']?\s*$', skill_text)
+if not match:
+    raise SystemExit("SKILL.md metadata.version is missing")
+skill_version = match.group(1).strip()
+if not plugin_version or plugin_version != skill_version:
+    raise SystemExit(
+        f"release identity version owners disagree: plugin={plugin_version!r} skill={skill_version!r}"
+    )
+if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", plugin_version):
+    raise SystemExit("release identity version must use three numeric components")
+
+
+def normalized_heading(value: str) -> str:
+    parts = value.split(".")
+    if len(parts) == 4 and parts[-1] == "0":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+headings = [
+    normalized_heading(value)
+    for value in re.findall(
+        r"(?m)^## \[v?([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)(?: [^\]]+)?\]",
+        changelog_path.read_text(encoding="utf-8"),
+    )
+]
+distinct_headings = list(dict.fromkeys(headings))
+if not distinct_headings:
+    raise SystemExit("CHANGELOG.md has no published version heading")
+if mode == "forward":
+    candidates = [value for value in distinct_headings if value != plugin_version]
+    authoritative_previous = candidates[0] if candidates else ""
+else:
+    authoritative_previous = distinct_headings[0]
+if previous_version != authoritative_previous:
+    raise SystemExit(
+        f"declared previous version {previous_version!r} != CHANGELOG authority {authoritative_previous!r}"
+    )
+
+resolved = subprocess.run(
+    ["git", "-C", str(root), "rev-parse", "--verify", f"{release_commit}^{{commit}}"],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+if resolved.returncode != 0:
+    raise SystemExit("release identity commit does not resolve")
+commit_sha = resolved.stdout.strip()
+commit_tree = subprocess.run(
+    ["git", "-C", str(root), "rev-parse", f"{commit_sha}^{{tree}}"],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+).stdout.strip()
+head_tree = subprocess.run(
+    ["git", "-C", str(root), "rev-parse", "HEAD^{tree}"],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+).stdout.strip()
+ancestor = subprocess.run(
+    ["git", "-C", str(root), "merge-base", "--is-ancestor", commit_sha, "HEAD"],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+if ancestor.returncode != 0:
+    raise SystemExit("release identity commit must be an ancestor of current HEAD")
+if commit_tree != head_tree:
+    raise SystemExit("release identity commit tree must equal current HEAD tree")
+
+if mode == "forward":
+    if plugin_version == previous_version:
+        raise SystemExit("forward release must change the prior published version")
+    print(f"build-release-asset: release identity forward {previous_version} -> {plugin_version} at {commit_sha}")
+    raise SystemExit(0)
+
+if plugin_version != previous_version:
+    raise SystemExit("same-version republication must retain the prior published version")
+
+candidate_path = Path(candidate_arg)
+if not candidate_path.is_absolute():
+    candidate_path = root / candidate_path
+if candidate_path.name != "IMPLEMENTAUDIT.skill":
+    raise SystemExit("same-version republication candidate must be named IMPLEMENTAUDIT.skill")
+if candidate_path.is_symlink() or not candidate_path.is_file():
+    raise SystemExit("same-version republication candidate must be a regular non-symlink file")
+candidate_digest = hashlib.sha256(candidate_path.read_bytes()).hexdigest()
+candidate_bytes = candidate_path.stat().st_size
+
+shown = subprocess.run(
+    ["git", "-C", str(root), "show", "--format=", "--unified=0", commit_sha, "--", "CHANGELOG.md"],
+    encoding="utf-8",
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+if shown.returncode != 0:
+    raise SystemExit("release identity CHANGELOG commit cannot be inspected")
+added = "\n".join(
+    line[1:]
+    for line in shown.stdout.splitlines()
+    if line.startswith("+") and not line.startswith("+++")
+)
+pairs = re.findall(
+    r"(?ims)^[ \t]*-\s+`IMPLEMENTAUDIT\.skill`:\s+superseded\s+"
+    r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
+    r"superseding\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$",
+    added,
+)
+if len(pairs) != 1:
+    raise SystemExit("same-version republication commit must add exactly one IMPLEMENTAUDIT.skill digest-and-byte pair")
+superseded_digest, _, superseding_digest, superseding_bytes_text = pairs[0]
+if superseded_digest == superseding_digest:
+    raise SystemExit("same-version republication digest pair must name distinct payloads")
+superseding_bytes = int(superseding_bytes_text.replace(",", ""))
+if superseding_digest != candidate_digest or superseding_bytes != candidate_bytes:
+    raise SystemExit(
+        "same-version republication record does not match the built IMPLEMENTAUDIT.skill digest and byte count"
+    )
+print(f"build-release-asset: release identity {mode} {plugin_version} at {commit_sha}")
+PY
+}
+
+check_historical_release_record() {
+  local check_root="${1:-$repo_root}"
+  "${py_cmd[@]}" - "$check_root" <<'PY'
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+changelog = root / "CHANGELOG.md"
+if not changelog.is_file():
+    raise SystemExit(f"historical release record owner is missing: {changelog}")
+
+marker = "This entry is the one retroactive application"
+text = changelog.read_text(encoding="utf-8")
+if text.count(marker) != 1:
+    raise SystemExit("historical #96 marker must occur exactly once")
+marker_commit = subprocess.run(
+    ["git", "-C", str(root), "log", "-1", "--format=%H", "-S", marker, "--", "CHANGELOG.md"],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+).stdout.strip()
+expected_commit = "4df5c0067d97fa20e86c98df5569a5314b6ec66c"
+if marker_commit != expected_commit:
+    raise SystemExit("historical #96 marker does not resolve to its pinned commit")
+shown = subprocess.run(
+    ["git", "-C", str(root), "show", f"{marker_commit}:CHANGELOG.md"],
+    check=True,
+    encoding="utf-8",
+    stdout=subprocess.PIPE,
+).stdout
+pair = re.search(
+    r"(?ims)^[ \t]*-\s+`IMPLEMENTAUDIT\.skill`:\s+superseded\s+"
+    r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
+    r"superseding\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)",
+    shown,
+)
+expected = (
+    "a04165198a208ecc231d769783400c4610c58dbd0ca338682be481d7515319f4",
+    "131,329",
+    "884ab409842b863b003e9d405972f33ba71d194f77572738002a42e73d1b6b14",
+    "132,117",
+)
+if pair is None or pair.groups() != expected:
+    raise SystemExit("historical #96 IMPLEMENTAUDIT.skill identity record does not match its pinned evidence")
+print(f"build-release-asset: nonqualifying historical #96 record ok at {marker_commit}")
+PY
+}
+
+check_stale_artifact() {
+  local surface="${1:-}" artifact="${2:-}" changelog="${3:-}"
+  [ -n "$surface" ] && [ -n "$artifact" ] && [ -n "$changelog" ] \
+    || fail "--check-stale-artifact requires <source|package|release> <artifact> <changelog>"
+  case "$surface" in
+    source) printf 'build-release-asset: source surface adds no stale package-artifact obligation\n'; return 0 ;;
+    package|release) : ;;
+    *) fail "stale artifact surface must be source, package, or release" ;;
+  esac
+  [ -e "$artifact" ] || return 0
+  [ -f "$artifact" ] && [ ! -L "$artifact" ] || fail "stale artifact target must be a regular non-symlink file"
+  [ -f "$changelog" ] && [ ! -L "$changelog" ] || fail "stale artifact CHANGELOG must be a regular non-symlink file"
+  "${py_cmd[@]}" - "$artifact" "$changelog" <<'PY'
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+artifact = Path(sys.argv[1])
+changelog = Path(sys.argv[2])
+digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+text = changelog.read_text(encoding="utf-8")
+superseded = set(re.findall(r"(?is)\bsuperseded\b\s+`?([0-9a-f]{64})`?", text))
+if digest in superseded:
+    raise SystemExit(
+        f"ignored build artifact matches withdrawn/superseded publication digest {digest}; remove, rename, or rebuild it"
+    )
+print(f"build-release-asset: ignored build artifact is not superseded ({digest})")
+PY
+}
+
+case "${1:-}" in
+  --check-release-identity)
+    shift
+    check_release_identity "$@"
+    exit $?
+    ;;
+  --check-historical-release-record)
+    shift
+    check_historical_release_record "$@"
+    exit $?
+    ;;
+  --check-stale-artifact)
+    shift
+    check_stale_artifact "$@"
+    exit $?
+    ;;
+esac
+
 if [ "${1:-}" = "--check" ]; then
+  check_stale_artifact package "$repo_root/dist/$asset_name" "$repo_root/CHANGELOG.md"
   out_dir="$(mktemp -d)"
   cleanup_dir="$out_dir"
 else

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -9,6 +9,21 @@ fail() {
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+release_identity_args=()
+release_identity_tmp=""
+trap 'if [ -n "${release_identity_tmp:-}" ]; then rm -rf "$release_identity_tmp"; fi' EXIT
+if [ "${1:-}" = "--release-identity" ]; then
+  [ "$#" -eq 4 ] \
+    || fail "--release-identity requires <forward|republish> <previous-version> <release-commit>"
+  case "$2" in
+    forward|republish) : ;;
+    *) fail "--release-identity mode must be forward or republish" ;;
+  esac
+  release_identity_args=("$2" "$3" "$4")
+  shift 4
+fi
+[ "$#" -eq 0 ] || fail "unknown argument: $1"
+
 require_file() {
   [ -f "$1" ] || fail "missing required file: $1"
 }
@@ -26,6 +41,12 @@ require_file .gitignore
 require_file .claude-plugin/plugin.json
 require_file .claude-plugin/marketplace.json
 require_file scripts/build-release-asset.sh
+if [ "${#release_identity_args[@]}" -gt 0 ]; then
+  release_identity_tmp="$(mktemp -d)"
+  bash scripts/build-release-asset.sh "$release_identity_tmp"
+  bash scripts/build-release-asset.sh --check-release-identity \
+    "${release_identity_args[@]}" "$repo_root" "$release_identity_tmp/IMPLEMENTAUDIT.skill"
+fi
 require_file scripts/check-public-claim-boundaries.sh
 require_file scripts/check-added-lines-clean.sh
 require_file scripts/check-audit-retention.sh

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -211,6 +211,52 @@ surface `source` is a negative control and adds no package-only obligation.
 Countermeasure non-target effects remain owned by #92; cross-reference them
 rather than duplicating that rule.
 
+## Package and publication identity (#89)
+
+A plain package build proves local bytes only; it is not publication proof.
+Before a release gate can claim a forward release or a same-version
+republication, run:
+
+```text
+scripts/verify-package.sh --release-identity <forward|republish> <previous-version> <release-commit>
+```
+
+`forward` requires the two canonical version owners to agree and differ from
+the previous published version. `republish` requires them to retain that
+version; both modes require the declared commit to be an ancestor of current
+`HEAD` and its tree to equal current `HEAD` tree, allowing metadata-only merge
+identity without permitting unrelated same-tree authority or byte drift.
+The previous version is derived from the ordered published-version headings in
+`CHANGELOG.md`, not trusted from the caller. `republish` also requires that
+commit's own `CHANGELOG.md` additions to contain distinct lowercase SHA-256 and
+byte-count values for `IMPLEMENTAUDIT.skill` labeled `superseded` and
+`superseding`. The superseding digest and byte count must equal the
+deterministically built candidate asset. A pair from another commit, another
+artifact, or fabricated bytes cannot discharge the gate.
+
+The completed #96 v0.3.2.0 correction remains inspectable with
+`scripts/build-release-asset.sh --check-historical-release-record`, but that
+command is a pinned, nonqualifying history check. It cannot qualify a current
+or prospective release and `retroactive` is not a release-identity mode.
+
+`build-release-asset.sh --check` also inspects an existing ignored
+`dist/IMPLEMENTAUDIT.skill`: if its digest is labeled `superseded` in
+`CHANGELOG.md`, package proof fails until the artifact is removed, renamed, or
+rebuilt. Source-only runs retain the #76 negative-control boundary and do not
+gain this package/release obligation.
+
+A publication closure claim carries both its evidence digest and a contained,
+hash-bound current-digest receipt:
+
+```text
+claim: <id> | surface: publication | status: verified|unverified | evidence-surface: publication | evidence-digest: <sha256>
+publication-identity: <id> | live-digest-file: <bare-file.sha256> | live-file-sha256: <sha256> | live-digest: <sha256> | disposition: verified|SUPERSEDED
+```
+
+Equal evidence/current digests use `verified`. Drift cannot remain verified;
+retain it as `status: unverified` with disposition `SUPERSEDED`, reusing #87's
+vocabulary rather than inventing another terminal state.
+
 ## Proving a file is dead
 
 Before archival or deletion, search by two independent methods:

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -218,7 +218,7 @@ Before a release gate can claim a forward release or a same-version
 republication, run:
 
 ```text
-scripts/verify-package.sh --release-identity <forward|republish> <previous-version> <release-commit>
+scripts/verify-package.sh --release-identity <forward|republish> <previous-version> <release-commit>  # source repo only
 ```
 
 `forward` requires the two canonical version owners to agree and differ from

--- a/skills/implementaudit/scripts/check-closure-surface.sh
+++ b/skills/implementaudit/scripts/check-closure-surface.sh
@@ -158,6 +158,115 @@ while IFS= read -r line; do
   fi
 done < "$file"
 
+# #89 publication identity is prospective and deterministic. A publication
+# claim is never kept verified merely because its label still resolves: the
+# evidence digest must equal a hash-bound current-digest receipt. Drift is
+# retained explicitly as SUPERSEDED.
+if grep -Eq '^claim:.*\|[[:space:]]*surface:[[:space:]]*publication([[:space:]]*\||$)|^publication-identity:' "$file"; then
+  ensure_python
+  publication_error=""
+  if ! publication_error="$("${py_cmd[@]}" - "$file" <<'PY'
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+record = Path(sys.argv[1]).resolve()
+base = record.parent
+sha_re = re.compile(r"[0-9a-f]{64}")
+
+
+def die(message: str) -> None:
+    print(message)
+    raise SystemExit(1)
+
+
+def fields(line: str, first_key: str) -> dict[str, str]:
+    parts = [part.strip() for part in line.split("|")]
+    values: dict[str, str] = {}
+    for index, part in enumerate(parts):
+        if ":" not in part:
+            die(f"publication identity malformed field: {part!r}")
+        key, value = part.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if index == 0 and key != first_key:
+            die(f"publication identity row must begin with {first_key}:")
+        if key in values:
+            die(f"publication identity duplicate field: {key}")
+        values[key] = value
+    return values
+
+
+claims: dict[str, dict[str, str]] = {}
+identities: dict[str, dict[str, str]] = {}
+for raw in record.read_text(encoding="utf-8").splitlines():
+    if raw.startswith("claim:"):
+        values = fields(raw, "claim")
+        if values.get("surface") == "publication":
+            claim_id = values.get("claim", "")
+            if not claim_id or claim_id in claims:
+                die("publication claim id is missing or duplicated")
+            claims[claim_id] = values
+    elif raw.startswith("publication-identity:"):
+        values = fields(raw, "publication-identity")
+        claim_id = values.get("publication-identity", "")
+        if not claim_id or claim_id in identities:
+            die("publication identity claim id is missing or duplicated")
+        identities[claim_id] = values
+
+if set(claims) != set(identities):
+    missing = sorted(set(claims) - set(identities))
+    dangling = sorted(set(identities) - set(claims))
+    die(f"publication identity rows must match publication claims; missing={missing} dangling={dangling}")
+
+required_identity = {
+    "publication-identity",
+    "live-digest-file",
+    "live-file-sha256",
+    "live-digest",
+    "disposition",
+}
+for claim_id, claim in claims.items():
+    identity = identities[claim_id]
+    if set(identity) != required_identity:
+        die(f"claim {claim_id}: publication identity fields must be exactly {sorted(required_identity)}")
+    evidence_digest = claim.get("evidence-digest", "")
+    if not sha_re.fullmatch(evidence_digest):
+        die(f"claim {claim_id}: publication evidence-digest must be lowercase SHA-256")
+    live_digest = identity["live-digest"]
+    file_digest = identity["live-file-sha256"]
+    if not sha_re.fullmatch(live_digest) or not sha_re.fullmatch(file_digest):
+        die(f"claim {claim_id}: live digest fields must be lowercase SHA-256")
+    name = identity["live-digest-file"]
+    if not name or Path(name).name != name or "/" in name or "\\" in name:
+        die(f"claim {claim_id}: live-digest-file must be a contained bare filename")
+    live_file = base / name
+    if not live_file.is_file() or live_file.is_symlink():
+        die(f"claim {claim_id}: live digest file is missing or not a regular contained file")
+    data = live_file.read_bytes()
+    if hashlib.sha256(data).hexdigest() != file_digest:
+        die(f"claim {claim_id}: live digest file SHA-256 mismatch")
+    try:
+        observed = data.decode("ascii").strip()
+    except UnicodeDecodeError:
+        die(f"claim {claim_id}: live digest file must contain ASCII SHA-256")
+    if not sha_re.fullmatch(observed) or observed != live_digest:
+        die(f"claim {claim_id}: live digest field does not match the bound file")
+    disposition = identity["disposition"]
+    status = claim.get("status", "")
+    if evidence_digest == live_digest:
+        if disposition != "verified":
+            die(f"claim {claim_id}: stable publication digest must use disposition verified")
+    else:
+        if status == "verified" or disposition != "SUPERSEDED":
+            die(f"claim {claim_id}: publication digest drift is SUPERSEDED and cannot remain verified")
+PY
+  )"; then
+    fail "$publication_error"
+  fi
+fi
+
 # #87 closure identity fields are prospective. Once any field is present, the
 # complete exact grammar is mandatory. Start/verify drift cannot close as
 # unchanged, and repeated equivalent draws require a declared sampling budget.

--- a/tests/closure-surface-contract.test.sh
+++ b/tests/closure-surface-contract.test.sh
@@ -13,6 +13,62 @@ scorer="skills/implementaudit/scripts/check-closure-surface.sh"
 fx="fixtures/closure-surface"
 fail() { printf 'closure-surface-contract: %s\n' "$*" >&2; exit 1; }
 
+publication_identity_controls() {
+  local work="$1" evidence_digest live_digest stable_file_hash drift_file_hash
+  evidence_digest='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  live_digest='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+  printf '%s\n' "$evidence_digest" > "$work/publication-stable.sha256"
+  stable_file_hash="$(sha256sum "$work/publication-stable.sha256" | awk '{print $1}')"
+  cat > "$work/publication-stable.md" <<EOF
+claim: pub-stable | surface: publication | status: verified | evidence-surface: publication | evidence-digest: $evidence_digest
+publication-identity: pub-stable | live-digest-file: publication-stable.sha256 | live-file-sha256: $stable_file_hash | live-digest: $evidence_digest | disposition: verified
+EOF
+  bash "$scorer" "$work/publication-stable.md" >/dev/null \
+    || fail 'stable publication digest identity was rejected'
+
+  printf '%s\n' "$live_digest" > "$work/publication-drift.sha256"
+  drift_file_hash="$(sha256sum "$work/publication-drift.sha256" | awk '{print $1}')"
+  cat > "$work/publication-drift-verified.md" <<EOF
+claim: pub-drift | surface: publication | status: verified | evidence-surface: publication | evidence-digest: $evidence_digest
+publication-identity: pub-drift | live-digest-file: publication-drift.sha256 | live-file-sha256: $drift_file_hash | live-digest: $live_digest | disposition: verified
+EOF
+  if bash "$scorer" "$work/publication-drift-verified.md" >/dev/null 2>&1; then
+    fail 'publication digest drift remained verified instead of SUPERSEDED'
+  fi
+
+  grep -v '^publication-identity:' "$work/publication-stable.md" \
+    > "$work/publication-missing-identity.md"
+  if bash "$scorer" "$work/publication-missing-identity.md" >/dev/null 2>&1; then
+    fail 'verified publication claim without a current-digest identity row was accepted'
+  fi
+
+  sed -e 's/status: verified/status: unverified/' \
+      -e 's/disposition: verified/disposition: SUPERSEDED/' \
+      "$work/publication-drift-verified.md" > "$work/publication-drift-superseded.md"
+  bash "$scorer" "$work/publication-drift-superseded.md" >/dev/null \
+    || fail 'publication digest drift with explicit SUPERSEDED disposition was rejected'
+
+  sed "s/live-file-sha256: $drift_file_hash/live-file-sha256: $evidence_digest/" \
+    "$work/publication-drift-superseded.md" > "$work/publication-drift-unbound.md"
+  if bash "$scorer" "$work/publication-drift-unbound.md" >/dev/null 2>&1; then
+    fail 'caller-supplied live digest was accepted without binding the live digest file'
+  fi
+
+  sed "s/live-digest: $live_digest/live-digest: $evidence_digest/" \
+    "$work/publication-drift-superseded.md" > "$work/publication-live-field-mismatch.md"
+  if bash "$scorer" "$work/publication-live-field-mismatch.md" >/dev/null 2>&1; then
+    fail 'live digest field was accepted when it contradicted the bound file'
+  fi
+}
+
+if [ "${1:-}" = "--publication-identity-only" ]; then
+  focused_tmp="$(mktemp -d)"
+  trap 'rm -rf "$focused_tmp"' EXIT
+  publication_identity_controls "$focused_tmp"
+  printf 'closure-surface-contract: publication-identity-only ok\n'
+  exit 0
+fi
+
 flat="$(tr '\n' ' ' < "$proto" | tr -s ' ')"
 printf '%s' "$flat" | grep -qi 'Closure-claims table' \
   || fail "PROTOCOL missing closure-claims table"
@@ -720,5 +776,8 @@ printf '%s\nAUDIT_START_ANCHOR: %s\nAUDIT_VERIFY_ANCHOR: %s\n%s\n%s\n%s\n%s\n' "
 if bash "$scorer" "$tmp/zero-pass-qualified.md" >/dev/null 2>&1; then
   fail "zero-pass terminal accepted as QUALIFIED"
 fi
+
+# #89 R16: publication verification is digest identity, not label identity.
+publication_identity_controls "$tmp"
 
 printf 'closure-surface-contract: ok (contract + quota, kill-authority, #88 external-state, and #78 deferral controls)\n'

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -8,6 +8,152 @@ tmp_parent="$(mktemp -d)"
 stray_file="skills/implementaudit/zz-package-parity-stray-test.txt"
 trap 'rm -rf "$tmp_parent"; rm -f "$stray_file"' EXIT
 
+if [ "${1:-}" = "--identity-only" ]; then
+  fail() { printf 'release-asset.test: %s\n' "$*" >&2; exit 1; }
+  grep -Fq -- '--check-release-identity' scripts/build-release-asset.sh \
+    || fail 'release-identity checker mode is missing'
+  grep -Fq -- '--check-stale-artifact' scripts/build-release-asset.sh \
+    || fail 'stale-artifact checker mode is missing'
+  a_digest='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  b_digest='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+  make_fixture() {
+    local root="$1" version="$2"
+    mkdir -p "$root/.claude-plugin" "$root/skills/implementaudit"
+    printf '{"version":"%s"}\n' "$version" > "$root/.claude-plugin/plugin.json"
+    printf '%s\n' '---' 'metadata:' "  version: \"$version\"" '---' > "$root/skills/implementaudit/SKILL.md"
+    printf '# Changelog\n\n## [v0.3.2.0] - 2026-07-18\n' > "$root/CHANGELOG.md"
+    printf 'original payload\n' > "$root/payload.txt"
+    printf 'original package\n' > "$root/IMPLEMENTAUDIT.skill"
+    git -C "$root" init -q
+    git -C "$root" config user.email t@example.invalid
+    git -C "$root" config user.name t
+    git -C "$root" add .
+    git -C "$root" -c user.email=t@example.invalid -c user.name=t commit -qm initial
+  }
+
+  no_record="$tmp_parent/republish-no-record"
+  make_fixture "$no_record" 0.3.2
+  printf 'changed payload\n' > "$no_record/payload.txt"
+  printf 'changed package\n' > "$no_record/IMPLEMENTAUDIT.skill"
+  git -C "$no_record" add payload.txt IMPLEMENTAUDIT.skill
+  git -C "$no_record" -c user.email=t@example.invalid -c user.name=t commit -qm republish
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.2 HEAD "$no_record" >/dev/null 2>&1; then
+    fail 'same-version republication without a digest pair was accepted'
+  fi
+
+  fabricated="$tmp_parent/republish-fabricated-pair"
+  make_fixture "$fabricated" 0.3.2
+  printf 'changed payload\n' > "$fabricated/payload.txt"
+  printf 'real package bytes\n' > "$fabricated/IMPLEMENTAUDIT.skill"
+  printf '\n## [v0.3.2.0 corrected re-release] - 2026-08-04\n- `IMPLEMENTAUDIT.skill`: superseded `%s` (1 byte) -> superseding `%s` (888 bytes).\n' \
+    "$a_digest" "$b_digest" >> "$fabricated/CHANGELOG.md"
+  git -C "$fabricated" add .
+  git -C "$fabricated" commit -qm republish
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.2 HEAD "$fabricated" >/dev/null 2>&1; then
+    fail 'fabricated package digest and byte count were accepted'
+  fi
+
+  preexisting="$tmp_parent/republish-preexisting-pair"
+  make_fixture "$preexisting" 0.3.2
+  printf '\n- `IMPLEMENTAUDIT.skill`: superseded `%s` (1 byte) -> superseding `%s` (2 bytes).\n' \
+    "$a_digest" "$b_digest" >> "$preexisting/CHANGELOG.md"
+  git -C "$preexisting" add CHANGELOG.md
+  git -C "$preexisting" -c user.email=t@example.invalid -c user.name=t commit -qm record
+  printf 'changed payload\n' > "$preexisting/payload.txt"
+  git -C "$preexisting" add payload.txt
+  git -C "$preexisting" -c user.email=t@example.invalid -c user.name=t commit -qm republish
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.2 HEAD "$preexisting" >/dev/null 2>&1; then
+    fail 'digest pair from an earlier commit was accepted for republication'
+  fi
+
+  with_pair="$tmp_parent/republish-with-pair"
+  make_fixture "$with_pair" 0.3.2
+  printf 'changed payload\n' > "$with_pair/payload.txt"
+  printf 'changed package\n' > "$with_pair/IMPLEMENTAUDIT.skill"
+  candidate_digest="$(sha256sum "$with_pair/IMPLEMENTAUDIT.skill" | awk '{print $1}')"
+  candidate_bytes="$(wc -c < "$with_pair/IMPLEMENTAUDIT.skill" | tr -d '[:space:]')"
+  printf '\n## [v0.3.2.0 corrected re-release] - 2026-08-04\n- `IMPLEMENTAUDIT.skill`: superseded `%s` (1 byte) -> superseding `%s` (%s bytes).\n' \
+    "$a_digest" "$candidate_digest" "$candidate_bytes" >> "$with_pair/CHANGELOG.md"
+  git -C "$with_pair" add payload.txt IMPLEMENTAUDIT.skill CHANGELOG.md
+  git -C "$with_pair" -c user.email=t@example.invalid -c user.name=t commit -qm republish
+  bash scripts/build-release-asset.sh --check-release-identity \
+    republish 0.3.2 HEAD "$with_pair" >/dev/null \
+    || fail 'same-version republication with a same-commit digest pair was rejected'
+
+  cross_artifact="$tmp_parent/republish-cross-artifact"
+  make_fixture "$cross_artifact" 0.3.2
+  printf 'changed package\n' > "$cross_artifact/IMPLEMENTAUDIT.skill"
+  cross_digest="$(sha256sum "$cross_artifact/IMPLEMENTAUDIT.skill" | awk '{print $1}')"
+  cross_bytes="$(wc -c < "$cross_artifact/IMPLEMENTAUDIT.skill" | tr -d '[:space:]')"
+  printf '\n## [v0.3.2.0 corrected re-release] - 2026-08-04\n- `CHECKSUMS.txt`: IMPLEMENTAUDIT.skill superseded `%s` (1 byte) -> superseding `%s` (%s bytes).\n' \
+    "$a_digest" "$cross_digest" "$cross_bytes" >> "$cross_artifact/CHANGELOG.md"
+  git -C "$cross_artifact" add .
+  git -C "$cross_artifact" commit -qm republish
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.2 HEAD "$cross_artifact" >/dev/null 2>&1; then
+    fail 'digest pair for another artifact was accepted as IMPLEMENTAUDIT.skill identity'
+  fi
+
+  same_tree="$(git -C "$with_pair" write-tree)"
+  orphan="$(printf 'unrelated same-tree record\n' | git -C "$with_pair" commit-tree "$same_tree")"
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.2 "$orphan" "$with_pair" >/dev/null 2>&1; then
+    fail 'unrelated same-tree commit was accepted as release authority'
+  fi
+
+  forward="$tmp_parent/normal-version-bump"
+  make_fixture "$forward" 0.3.2
+  printf '{"version":"0.3.3"}\n' > "$forward/.claude-plugin/plugin.json"
+  sed -i 's/version: "0.3.2"/version: "0.3.3"/' "$forward/skills/implementaudit/SKILL.md"
+  printf 'changed payload\n' > "$forward/payload.txt"
+  git -C "$forward" add .
+  git -C "$forward" -c user.email=t@example.invalid -c user.name=t commit -qm forward
+  bash scripts/build-release-asset.sh --check-release-identity \
+    forward 0.3.2 HEAD "$forward" >/dev/null \
+    || fail 'normal forward version bump gained a digest-pair obligation'
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      forward 0.2.0 HEAD "$forward" >/dev/null 2>&1; then
+    fail 'caller-supplied non-current previous version bypassed CHANGELOG authority'
+  fi
+
+  real_record_commit="$(git log -1 --format=%H -S 'This entry is the one retroactive application' -- CHANGELOG.md)"
+  [ -n "$real_record_commit" ] || fail 'real #96 retroactive digest-pair commit not found'
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      retroactive 0.3.2 "$real_record_commit" "$repo_root" >/dev/null 2>&1; then
+    fail 'historical retroactive record remained available for prospective qualification'
+  fi
+  bash scripts/build-release-asset.sh --check-historical-release-record "$repo_root" >/dev/null \
+    || fail 'separate nonqualifying historical #96 record check was rejected'
+  if grep -Fq 'retroactive' scripts/verify-package.sh; then
+    fail 'package verifier still exposes retroactive mode as prospective qualification'
+  fi
+
+  stale_root="$tmp_parent/stale-artifact"
+  mkdir -p "$stale_root/dist"
+  printf 'withdrawn bytes\n' > "$stale_root/dist/pkg.skill"
+  stale_digest="$(sha256sum "$stale_root/dist/pkg.skill" | awk '{print $1}')"
+  printf '# Changelog\n- asset: superseded `%s` -> superseding `%s`.\n' \
+    "$stale_digest" "$b_digest" > "$stale_root/CHANGELOG.md"
+  if bash scripts/build-release-asset.sh --check-stale-artifact \
+      package "$stale_root/dist/pkg.skill" "$stale_root/CHANGELOG.md" >/dev/null 2>&1; then
+    fail 'withdrawn ignored package artifact was accepted'
+  fi
+  bash scripts/build-release-asset.sh --check-stale-artifact \
+    source "$stale_root/dist/pkg.skill" "$stale_root/CHANGELOG.md" >/dev/null \
+    || fail 'source-only run was subjected to package/release stale-artifact policy'
+  printf 'current bytes\n' > "$stale_root/dist/pkg.skill"
+  bash scripts/build-release-asset.sh --check-stale-artifact \
+    package "$stale_root/dist/pkg.skill" "$stale_root/CHANGELOG.md" >/dev/null \
+    || fail 'non-superseded package artifact was rejected'
+
+  printf 'release-asset.test: identity-only ok\n'
+  exit 0
+fi
+
 # Package parity: a stray file under skills/implementaudit/ must fail the build, because it
 # would otherwise ship without a deliberate manifest update.
 printf 'stray payload parity probe\n' > "$stray_file"


### PR DESCRIPTION
## What changed

Lands #89 package/release identity semantics from original commit `125747e133e0c4dc01f6990b1dfdb99131bba7e5`, plus qualification-label repair `74560c32d8042bcab9f1837233571153dec1e2ae`. Propagated head/tree after inheriting the #87 review repair: `83116957958f484e66a6565ebc22c04dbc02aa27` / `cc164742fcd8d74d3286db5c97af9e2165573928`.

## Evidence and review

Focused package/publication identity controls and independent review: `phases/phase-7.md` and `reviews/phase-7-code-review.md`. The final safeguard gate required the `scripts/verify-package.sh --release-identity` example to say `source repo only`; RED/GREEN and affected release-asset proof are in `evidence/p12-propagation-receipt.md`.

## Package and boundaries

P6 is 196,181 bytes / 48 members; `SKILL.md` remains 448 lines / 21,910 bytes. This PR defines gates but performs no release, republication, tag, upload, publication, or deployment. Rollback is normal commit revert.

## Andon / Hansei

The repair is one truthful ownership label; authorization, ancestry, tree, and digest checks are unchanged.