### PR TITLE
#135: close validation registry exemption

### DIFF
--- a/scripts/check-validation-registry.sh
+++ b/scripts/check-validation-registry.sh
@@ -5,8 +5,7 @@ set -euo pipefail
 # suite registries: the internal run block in scripts/verify-package.sh and
 # the CI test list in .github/workflows/validate.yml. They drift
 # independently (proven at v0.2.9.0 in both directions). This gate asserts
-# every tests/*.test.sh on disk is invoked in BOTH registries, with an
-# explicit, reasoned exemption list.
+# every tests/*.test.sh on disk is invoked in BOTH registries.
 #
 # Usage: check-validation-registry.sh [--repo-root <dir>]
 
@@ -37,13 +36,6 @@ import re
 import sys
 from pathlib import Path
 
-# Exemptions from the verify-package registry only. Each entry needs a reason.
-VERIFY_PACKAGE_EXEMPT = {
-    # docs-portal.test.sh invokes verify-package.sh internally; nesting it
-    # inside verify-package.sh would recurse (documented in AGENTS.md).
-    "docs-portal.test.sh": "invokes verify-package.sh; must not nest",
-}
-
 tests = sorted(p.name for p in Path("tests").glob("*.test.sh"))
 if not tests:
     sys.stderr.write("no tests/*.test.sh found\n")
@@ -61,14 +53,10 @@ def invokes(text: str, ref: str) -> bool:
 failures = []
 for name in tests:
     ref = f"tests/{name}"
-    if not invokes(verify_pkg, ref) and name not in VERIFY_PACKAGE_EXEMPT:
+    if not invokes(verify_pkg, ref):
         failures.append(f"{ref} is not invoked by scripts/verify-package.sh")
     if not invokes(ci, ref):
         failures.append(f"{ref} is not invoked by .github/workflows/validate.yml")
-
-for name in VERIFY_PACKAGE_EXEMPT:
-    if not (Path("tests") / name).is_file():
-        failures.append(f"stale exemption for nonexistent test: {name}")
 
 if failures:
     sys.stderr.write("\n".join(failures) + "\n")

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -689,6 +689,7 @@ bash tests/summarize-repo.test.sh
 bash tests/shipped-scripts-smoke.test.sh
 bash tests/run-root-validation.test.sh
 bash tests/custody-append.test.sh
+bash tests/docs-portal.test.sh
 bash scripts/check-validation-registry.sh
 bash tests/validation-registry.test.sh
 bash scripts/build-release-asset.sh --check

--- a/tests/validation-registry.test.sh
+++ b/tests/validation-registry.test.sh
@@ -10,14 +10,12 @@ trap 'rm -rf "$tmp"' EXIT
 # 1. The live repo must pass.
 bash scripts/check-validation-registry.sh
 
-# 2. A test on disk missing from both registries must fail. The synthetic
-# tree models the exemption contract: docs-portal.test.sh exists and is wired
-# into CI only (exempt from verify-package), like the live repo.
+# 2. A test on disk missing from both registries must fail.
 mkdir -p "$tmp/drift/tests" "$tmp/drift/scripts" "$tmp/drift/.github/workflows"
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/drift/tests/covered.test.sh"
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/drift/tests/orphan.test.sh"
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/drift/tests/docs-portal.test.sh"
-printf 'bash tests/covered.test.sh\n' > "$tmp/drift/scripts/verify-package.sh"
+printf 'bash tests/covered.test.sh\nbash tests/docs-portal.test.sh\n' > "$tmp/drift/scripts/verify-package.sh"
 printf 'run: bash tests/covered.test.sh\nrun: bash tests/docs-portal.test.sh\n' > "$tmp/drift/.github/workflows/validate.yml"
 
 if bash scripts/check-validation-registry.sh --repo-root "$tmp/drift" >/dev/null 2>&1; then
@@ -30,7 +28,7 @@ mkdir -p "$tmp/require-only/tests" "$tmp/require-only/scripts" "$tmp/require-onl
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/require-only/tests/covered.test.sh"
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/require-only/tests/orphan.test.sh"
 printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/require-only/tests/docs-portal.test.sh"
-printf 'bash tests/covered.test.sh\nrequire_file tests/orphan.test.sh\n' > "$tmp/require-only/scripts/verify-package.sh"
+printf 'bash tests/covered.test.sh\nbash tests/docs-portal.test.sh\nrequire_file tests/orphan.test.sh\n' > "$tmp/require-only/scripts/verify-package.sh"
 printf 'run: bash tests/covered.test.sh\nrun: bash tests/orphan.test.sh\nrun: bash tests/docs-portal.test.sh\n' > "$tmp/require-only/.github/workflows/validate.yml"
 
 if bash scripts/check-validation-registry.sh --repo-root "$tmp/require-only" >/dev/null 2>&1; then
@@ -39,18 +37,19 @@ if bash scripts/check-validation-registry.sh --repo-root "$tmp/require-only" >/d
 fi
 
 # 4. Full parity in a synthetic tree must pass.
-printf 'bash tests/covered.test.sh\nbash tests/orphan.test.sh\n' > "$tmp/drift/scripts/verify-package.sh"
+printf 'bash tests/covered.test.sh\nbash tests/orphan.test.sh\nbash tests/docs-portal.test.sh\n' > "$tmp/drift/scripts/verify-package.sh"
 printf 'run: bash tests/covered.test.sh\nrun: bash tests/orphan.test.sh\nrun: bash tests/docs-portal.test.sh\n' > "$tmp/drift/.github/workflows/validate.yml"
 bash scripts/check-validation-registry.sh --repo-root "$tmp/drift"
 
-# 5. A stale exemption (exempted test absent from disk) must fail.
-mkdir -p "$tmp/stale/tests" "$tmp/stale/scripts" "$tmp/stale/.github/workflows"
-printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/stale/tests/covered.test.sh"
-printf 'bash tests/covered.test.sh\n' > "$tmp/stale/scripts/verify-package.sh"
-printf 'run: bash tests/covered.test.sh\n' > "$tmp/stale/.github/workflows/validate.yml"
+# 5. CI-only coverage must not exempt a test from package-registry parity.
+mkdir -p "$tmp/ci-only/tests" "$tmp/ci-only/scripts" "$tmp/ci-only/.github/workflows"
+printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/ci-only/tests/covered.test.sh"
+printf '#!/usr/bin/env bash\ntrue\n' > "$tmp/ci-only/tests/docs-portal.test.sh"
+printf 'bash tests/covered.test.sh\n' > "$tmp/ci-only/scripts/verify-package.sh"
+printf 'run: bash tests/covered.test.sh\nrun: bash tests/docs-portal.test.sh\n' > "$tmp/ci-only/.github/workflows/validate.yml"
 
-if bash scripts/check-validation-registry.sh --repo-root "$tmp/stale" >/dev/null 2>&1; then
-  printf 'validation-registry.test: expected stale exemption to fail\n' >&2
+if bash scripts/check-validation-registry.sh --repo-root "$tmp/ci-only" >/dev/null 2>&1; then
+  printf 'validation-registry.test: expected CI-only test to fail package parity\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
Implements #135

Summary:
- remove the false docs-portal package-registry exemption
- run docs-portal.test.sh in verify-package without recursion
- isolate registry negative controls while preserving derived archive-set membership

Receipt:
- cumulative parent/base: main at 1f43400193a341a5ae44a2375ebf7a42ac813e37
- logical implementation commit/head: 07438d3a12ee31ad57d982024533f34a4ffea2cd
- logical tree: 4ff888ddf253dffca390893726a3c1064805f179
- propagated head/tree: unchanged from logical head/tree
- clean WSL validation registry, qualification producer, and complete eval harness: PASS
- independent review: PASS after masked-negative countermeasure
- package: 206584 bytes; current-ceiling headroom: 2416 bytes
- hosted validate: run 31226760206, job 93022523058, SUCCESS
- rollback: revert commit 07438d3a12ee31ad57d982024533f34a4ffea2cd