### PR TITLE
Enforce DONE phase evidence resolution

### DIFF
--- a/skills/implementaudit/scripts/validate-run-root.sh
+++ b/skills/implementaudit/scripts/validate-run-root.sh
@@ -8,6 +8,7 @@ err() {
   err_count=$((err_count + 1))
 }
 warn() { printf 'validate-run-root: WARNING: %s\n' "$*" >&2; }
+has_non_whitespace() { LC_ALL=C grep -q '[^[:space:]]' "$1" 2>/dev/null; }
 
 if [ "${1:-}" = "--graph-freshness" ]; then
   if [ "$#" -ne 3 ]; then
@@ -238,6 +239,84 @@ check_background_chains() {
   done
 }
 
+is_terminal_phase_status() {
+  case "$1" in
+    done|done\ *|verified|verified\ *|pass|pass\ *|'focused pass'|'focused pass '*|complete|complete\ *|complete\;*|completed|completed\ *|closed|closed\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_nonterminal_phase_status() {
+  case "$1" in
+    open|ready|ready_to_dispatch|in_phase|in\ progress|in\ progress\ *|in_progress|in_progress\ *|paused|blocked|interrupted|pending|dispatchable|finding_closure_pending|audit_handoff|handoff) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check_done_phase_captures() {
+  local phase="$1" status phase_n capture target repo_prefix
+  status="$(awk '
+    /^IMPLEMENTAUDIT_PHASE_DONE[[:space:]]*$/ { done=1; next }
+    done && /^Status:[[:space:]]*/ {
+      sub(/^Status:[[:space:]]*/, ""); print tolower($0); exit
+    }
+  ' "$phase")"
+  if is_terminal_phase_status "$status"; then
+    :
+  elif is_nonterminal_phase_status "$status"; then
+    return 0
+  elif [ -f "$run_root/ROADMAP.md" ]; then
+    phase_n="$(basename "$phase" | sed -n 's/^phase-\([0-9][0-9]*\)\.md$/\1/p')"
+    status="$(awk -F'|' -v n="$phase_n" '
+      function trim(v) { gsub(/^[ \t]+|[ \t]+$/, "", v); return v }
+      /^\|/ {
+        if (!phase_table) {
+          first=tolower(trim($2)); second=tolower(trim($3)); status_col=0
+          if (first == "phase" || (first == "#" && second == "phase")) {
+            for (i=2; i<NF; i++) if (tolower(trim($i)) == "status") status_col=i
+            if (status_col) phase_table=1
+          }
+          next
+        }
+        if (trim($2) == n) { print tolower(trim($status_col)); exit }
+        next
+      }
+      phase_table && NF && $0 !~ /^[ \t]*$/ { phase_table=0 }
+    ' "$run_root/ROADMAP.md")"
+    is_terminal_phase_status "$status" || return 0
+  else
+    return 0
+  fi
+  repo_prefix=""
+  case "$run_root" in
+    */.IMPLEMENTAUDIT/*) repo_prefix="${run_root%%/.IMPLEMENTAUDIT/*}" ;;
+    .IMPLEMENTAUDIT/*) repo_prefix="." ;;
+  esac
+  while IFS= read -r capture; do
+    capture="${capture#\`}"; capture="${capture%\`}"
+    case "$capture" in
+      '<run-root>') target="$run_root" ;;
+      '<run-root>/'*) target="$run_root/${capture#<run-root>/}" ;;
+      /*|[A-Za-z]:*) target="$capture" ;;
+      "$run_root"/*) target="$capture" ;;
+      *.IMPLEMENTAUDIT/*)
+        capture=".IMPLEMENTAUDIT/${capture#*.IMPLEMENTAUDIT/}"
+        target="${repo_prefix:+$repo_prefix/}$capture"
+        ;;
+      evidence/*) target="$run_root/$capture" ;;
+      ./evidence/*) target="$run_root/${capture#./}" ;;
+      *) continue ;;
+    esac
+    if [ ! -f "$target" ]; then
+      err "DONE phase $(basename "$phase") declared capture is missing: $capture"
+    elif ! has_non_whitespace "$target"; then
+      err "DONE phase $(basename "$phase") declared capture is blank: $capture"
+    fi
+  done < <(sed -n '/^## Mandatory commands/,/^## / {
+    s/.*;[[:space:]]*capture:[[:space:]]*\([^;]*\);.*/\1/p
+  }' "$phase")
+}
+
 mode=full
 if [ "${1:-}" = "--micro" ]; then
   mode=micro
@@ -295,12 +374,34 @@ fi
 if [ "$mode" = micro ]; then
   [ -f "$run_root/STATE.md" ] || err "missing required artifact: STATE.md"
 else
+  root_done=no
+  if grep -Eq '^\|[[:space:]]*Status[[:space:]]*\|[[:space:]]*DONE[[:space:]]*\|' \
+    "$run_root/STATE.md" 2>/dev/null; then
+    root_done=yes
+  fi
+  template_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../templates" && pwd)"
   for f in STATE.md PROTOCOL.md; do
-    [ -f "$run_root/$f" ] || err "missing required artifact: $f"
+    if [ ! -f "$run_root/$f" ]; then err "missing required artifact: $f"
+    elif ! has_non_whitespace "$run_root/$f"; then err "required artifact is blank: $f"; fi
   done
   for f in ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
-    [ -f "$run_root/$f" ] || err "missing planning artifact: $f (required for dispatched phase runs)"
+    artifact_status="$(awk -F'|' -v artifact="<run-root>/$f" '
+      function trim(v) { gsub(/^[ \t`]+|[ \t`]+$/, "", v); return v }
+      trim($2) == artifact { print tolower(trim($3)); exit }
+    ' "$run_root/STATE.md" 2>/dev/null)"
+    if [ ! -f "$run_root/$f" ]; then err "missing planning artifact: $f (required for dispatched phase runs)"
+    elif ! has_non_whitespace "$run_root/$f"; then err "planning artifact is blank: $f"; fi
+    if [ "$root_done" = yes ] && [ "$artifact_status" = complete ] &&
+       [ -f "$run_root/$f" ] &&
+       cmp -s "$run_root/$f" "$template_dir/$f"; then
+      err "planning artifact remains an unfilled template at DONE: $f"
+    fi
   done
+fi
+
+if [ "$mode" = full ] && [ -d "$run_root/phases" ]; then
+  while IFS= read -r phase; do check_done_phase_captures "$phase"; done \
+    < <(find "$run_root/phases" -type f -name 'phase-*.md' -print | sort)
 fi
 
 state="$run_root/STATE.md"

--- a/tests/run-root-validation.test.sh
+++ b/tests/run-root-validation.test.sh
@@ -42,6 +42,165 @@ grep -oE '^\| *[0-9]+ *\|' "$tmp/good/ROADMAP.md" | grep -oE '[0-9]+' | sort -un
 done
 bash "$helper" "$tmp/good"
 
+# 1b. #139 full-mode evidence resolution. Only a phase explicitly marked done
+# resolves current mandatory-command capture grammar; open phases remain cheap.
+write_capture_phase() {
+  local path="$1" status="$2" capture="$3"
+  cat > "$path" <<EOF
+IMPLEMENTAUDIT_PHASE_START
+## Mandatory commands
+- true > $capture 2>&1 — property: structural; scope: fixture; coverage: full; capture: $capture; expected: exit 0
+IMPLEMENTAUDIT_PHASE_VERIFY
+IMPLEMENTAUDIT_PHASE_DONE
+Status: $status
+EOF
+}
+
+mkdir -p "$tmp/done-capture-missing"
+cp -r "$tmp/good/." "$tmp/done-capture-missing/"
+write_capture_phase "$tmp/done-capture-missing/phases/phase-1.md" done \
+  '<run-root>/evidence/mandatory.log'
+if bash "$helper" "$tmp/done-capture-missing" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: DONE phase with missing capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/legacy-roadmap-done-missing"
+cp -r "$tmp/done-capture-missing/." "$tmp/legacy-roadmap-done-missing/"
+sed -i '/^Status: done$/d' "$tmp/legacy-roadmap-done-missing/phases/phase-1.md"
+sed -i 's/| 1 |  |  | - |  |  |  | open |/| 1 | legacy | owner | - | smoke | smoke | n\/a | focused PASS |/' \
+  "$tmp/legacy-roadmap-done-missing/ROADMAP.md"
+sed -i '1i| 1 | unrelated numbered row | open |' \
+  "$tmp/legacy-roadmap-done-missing/ROADMAP.md"
+if bash "$helper" "$tmp/legacy-roadmap-done-missing" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: legacy ROADMAP-terminal phase with missing capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/roadmap-complete-semicolon"
+cp -r "$tmp/legacy-roadmap-done-missing/." "$tmp/roadmap-complete-semicolon/"
+sed -i 's/focused PASS/complete; finalized/' \
+  "$tmp/roadmap-complete-semicolon/ROADMAP.md"
+if bash "$helper" "$tmp/roadmap-complete-semicolon" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: ROADMAP complete-semicolon phase with missing capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/historical-local-status"
+cp -r "$tmp/legacy-roadmap-done-missing/." "$tmp/historical-local-status/"
+printf 'Status: FINDINGS_CLOSED_PASS\n' \
+  >> "$tmp/historical-local-status/phases/phase-1.md"
+if bash "$helper" "$tmp/historical-local-status" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: unknown historical status must fall back to terminal ROADMAP\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/explicit-nonterminal-status"
+cp -r "$tmp/historical-local-status/." "$tmp/explicit-nonterminal-status/"
+sed -i 's/Status: FINDINGS_CLOSED_PASS/Status: open/' \
+  "$tmp/explicit-nonterminal-status/phases/phase-1.md"
+bash "$helper" "$tmp/explicit-nonterminal-status" >/dev/null || {
+  printf 'run-root-validation.test: explicit nonterminal status must suppress ROADMAP fallback\n' >&2
+  exit 1
+}
+
+mkdir -p "$tmp/done-capture-blank/evidence"
+cp -r "$tmp/good/." "$tmp/done-capture-blank/"
+write_capture_phase "$tmp/done-capture-blank/phases/phase-1.md" done \
+  '<run-root>/evidence/mandatory.log'
+: > "$tmp/done-capture-blank/evidence/mandatory.log"
+if bash "$helper" "$tmp/done-capture-blank" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: DONE phase with blank capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/done-capture-whitespace/evidence"
+cp -r "$tmp/good/." "$tmp/done-capture-whitespace/"
+write_capture_phase "$tmp/done-capture-whitespace/phases/phase-1.md" done \
+  '<run-root>/evidence/mandatory.log'
+printf ' \n\t\n' > "$tmp/done-capture-whitespace/evidence/mandatory.log"
+if bash "$helper" "$tmp/done-capture-whitespace" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: DONE phase with whitespace-only capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/done-capture-present/evidence"
+cp -r "$tmp/good/." "$tmp/done-capture-present/"
+write_capture_phase "$tmp/done-capture-present/phases/phase-1.md" done \
+  '<run-root>/evidence/mandatory.log'
+printf 'producer exit 0\n' > "$tmp/done-capture-present/evidence/mandatory.log"
+bash "$helper" "$tmp/done-capture-present" >/dev/null || {
+  printf 'run-root-validation.test: DONE phase with nonblank capture must pass\n' >&2
+  exit 1
+}
+
+mkdir -p "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example/evidence"
+cp -r "$tmp/good/." "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example/"
+write_capture_phase "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example/phases/phase-1.md" \
+  'PASS - focused gates' \
+  '../repo-relative/.IMPLEMENTAUDIT/runs/example/evidence/mandatory.log'
+printf 'producer exit 0\n' \
+  > "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example/evidence/mandatory.log"
+bash "$helper" "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example" >/dev/null || {
+  printf 'run-root-validation.test: repo-relative capture from absolute run root must pass\n' >&2
+  exit 1
+}
+rm "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example/evidence/mandatory.log"
+if bash "$helper" "$tmp/repo-relative/.IMPLEMENTAUDIT/runs/example" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: descriptive PASS status with missing capture must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/unresolved-variable"
+cp -r "$tmp/good/." "$tmp/unresolved-variable/"
+write_capture_phase "$tmp/unresolved-variable/phases/phase-1.md" done \
+  '$EVIDENCE_ROOT/legacy.log'
+bash "$helper" "$tmp/unresolved-variable" >/dev/null || {
+  printf 'run-root-validation.test: unresolved legacy capture variable must remain compatible\n' >&2
+  exit 1
+}
+
+mkdir -p "$tmp/open-capture-missing"
+cp -r "$tmp/good/." "$tmp/open-capture-missing/"
+write_capture_phase "$tmp/open-capture-missing/phases/phase-1.md" open \
+  '<run-root>/evidence/mandatory.log'
+bash "$helper" "$tmp/open-capture-missing" >/dev/null || {
+  printf 'run-root-validation.test: open phase capture must not resolve early\n' >&2
+  exit 1
+}
+
+mkdir -p "$tmp/blank-planning-artifact"
+cp -r "$tmp/good/." "$tmp/blank-planning-artifact/"
+: > "$tmp/blank-planning-artifact/tools.md"
+if bash "$helper" "$tmp/blank-planning-artifact" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: blank required planning artifact must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/whitespace-planning-artifact"
+cp -r "$tmp/good/." "$tmp/whitespace-planning-artifact/"
+printf ' \n\t\n' > "$tmp/whitespace-planning-artifact/tools.md"
+if bash "$helper" "$tmp/whitespace-planning-artifact" >/dev/null 2>&1; then
+  printf 'run-root-validation.test: whitespace-only planning artifact must fail\n' >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/template-only-done"
+cp -r "$tmp/good/." "$tmp/template-only-done/"
+sed -i 's/| Status | open |/| Status | DONE |/' \
+  "$tmp/template-only-done/STATE.md"
+sed -i 's#| `<run-root>/tools.md` | open |#| `<run-root>/tools.md` | complete |#' \
+  "$tmp/template-only-done/STATE.md"
+for f in ROADMAP.md THINKING.md sidecars.md context.md; do
+  printf '\nfixture populated\n' >> "$tmp/template-only-done/$f"
+done
+template_output="$(bash "$helper" "$tmp/template-only-done" 2>&1 || true)"
+if ! grep -Fq 'planning artifact remains an unfilled template at DONE: tools.md' \
+  <<<"$template_output"; then
+  printf 'run-root-validation.test: DONE root must reject an unfilled tools template\n' >&2
+  exit 1
+fi
+
 # 2. An invented Status token must fail.
 mkdir -p "$tmp/badstatus"
 cp -r "$tmp/good/." "$tmp/badstatus/"


### PR DESCRIPTION
Implements #139

Cumulative Stage C P4 over frozen #140 head `880e52e30f22ade1daddd78c77b3c4148a99f926`.

- full-mode DONE phases resolve mechanically declared mandatory captures
- missing, whitespace-only, and template-only terminal evidence fails closed
- recognized nonterminal phase status remains cheap; unknown historical status uses the scoped ROADMAP Phase/Status fallback
- micro mode and unresolved legacy capture variables remain compatible
- five-root observation census: 6 / 2 / 0 / 11 / 5 candidate errors, all assigned class
- mandatory independent review: `INDEPENDENT_REVIEW_PASS` after two P1 findings were reproduced and closed

Qualification:
- WSL focused run-root suite: PASS
- active N06 controller root: PASS
- syntax and diff checks: PASS
- package build/extraction: PASS
- asset: 209761 bytes, 20239 bytes below the 230000 outer bound

The 761-byte current-ceiling overage remains on the already-open final-P7 calibration Andon. This PR does not calibrate package policy and does not consume the final broad verifier.