### PR TITLE
Correct v0.3.3.0 publication owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 (nothing yet)
 
-## [v0.3.3.0 release candidate] - 2026-08-08
+## [v0.3.3.0] - 2026-08-08
 
-This source candidate establishes the v0.3.3.0 package identity for final
-prerelease qualification. It is not a tag, GitHub release, publication, or
-provenance record.
+This release establishes the v0.3.3.0 package identity. Tag, GitHub release,
+assets, checksum, hosted validation, Pages deployment, and public installation
+routes were independently read back. These checks establish publication and
+artifact integrity, not signature, attestation, marketplace, or provenance
+claims.
 
 ### Changed
 
@@ -34,12 +36,13 @@ provenance record.
 - Optional `/dashboard/` content remains a separately packaged projection and
   is excluded from `IMPLEMENTAUDIT.skill`.
 
-### Qualification boundary
+### Qualification and publication boundary
 
 - The exact candidate package passed installed-runtime dogfood, ordinary-run
   non-regression, the complete deterministic verifier, and package verification.
-  Public release still requires the fresh-context final review, exact-head
-  hosted qualification, and independent tag/release/artifact/checksum readback.
+  Exact-head hosted qualification, tag/release/artifact/checksum readback, and
+  post-publication Pages readback also completed; the release ledger records
+  the exact identities and remaining tracker-accounting boundary.
 - R28/#117 is owner-paused, open, optional, and nonblocking for v0.3.3.0. Its
   completion, qualification, closure, or later pause receipt is not a release
   prerequisite, and `/dashboard/` remains excluded from the package.

--- a/docs/audits/INDEX.md
+++ b/docs/audits/INDEX.md
@@ -110,11 +110,12 @@ Standing gate owners: `check-action-selection-contract.sh`,
 
 ## v0.3.3.0 release evidence (current ledger)
 
-- `docs/audits/archive/v0.3.3.0-release-report.md` - exact candidate package
-  identity, nonblocking R28/#117 and out-of-scope #144 boundaries, and the
-  pending-to-read-back integration, publication, Pages, and tracker fields.
-  Until those fields are completed from live readback, it is prerelease
-  accounting rather than a publication claim.
+- `docs/audits/archive/v0.3.3.0-release-report.md` - exact package identity,
+  nonblocking R28/#117 and out-of-scope #144 boundaries, release integration,
+  tag/assets/checksum readback, hosted validation, Pages deployment, and the
+  remaining live tracker-accounting field. It is the current published-release
+  ledger; publication fields are evidence-bound to the identities recorded
+  there rather than inferred from source text.
 
 ## Boundary
 

--- a/docs/audits/archive/v0.3.3.0-release-report.md
+++ b/docs/audits/archive/v0.3.3.0-release-report.md
@@ -1,11 +1,11 @@
 # v0.3.3.0 release report
 
-Status: prerelease qualification in progress
+Status: published and independently read back; tracker accounting in progress
 
 This is the current release ledger for IMPLEMENTAUDIT v0.3.3.0. It records
-source/package identity before publication and is completed only from separate
-GitHub readbacks after the tag, release, assets, hosted workflows, and Pages
-deployment exist. It is not provenance, a signature, or host-load proof.
+source/package identity and separate GitHub readbacks of the tag, release,
+assets, hosted workflows, and Pages deployment. It is not provenance, a
+signature, marketplace proof, or a general host-load claim.
 
 ## Qualified package identity
 
@@ -29,17 +29,37 @@ R28/#117 is owner-paused, open, optional, and nonblocking for v0.3.3.0. This
 release does not wait for, merge, qualify, or close it. Issue #144 is a separate
 post-release Graphify campaign and remains out of scope.
 
-## Publication fields
+## Publication readback
 
-These fields remain pending until independent readback:
+The following identities were read independently after publication:
 
-- Release commit/tree: pending
-- Hosted Ubuntu exact-head result: pending
-- Fresh-context final review: pending
-- Tag `v0.3.3.0` target: pending
-- GitHub release ID/URL: pending
-- Downloaded asset/checksum readback: pending
-- Post-publication final main/tree and Pages deployment: pending
+- Release commit/tree: `74917a9076f3eb0527be392009ac901b7aa9f5ce` /
+  `219e399715bb3da542fdadb873734945827dd219`
+- Tag `v0.3.3.0`: annotated tag object
+  `da59c096579f0a68177c15b6e2ea2a42f02c438c`, dereferencing to the release
+  commit above
+- GitHub release: ID `367231273`,
+  `https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0`
+- Release asset readback: `IMPLEMENTAUDIT.skill`, 215,126 bytes, SHA-256
+  `8ddf80e0c4545e0d66e5f81eff30a224943264a25e52a1fbb9ee0e3c3f4d778a`
+- Checksum readback: `CHECKSUMS.txt`, 96 bytes, SHA-256
+  `8feacb2e520f1c408f36c1e32625d71fc238721ecb8e6aa4666bd3a2c4dd64e2`;
+  its named digest matches the downloaded release asset
+- Release-head hosted Ubuntu validation: run `31263128671`, success at the
+  release commit
+- Post-publication main/tree at this ledger correction's ingress:
+  `5210675b1dc5e9df962e0c8df869a5b54b87d516` /
+  `3a3220023990a5c2afaeea9cf2eacfcb2051088b`
+- Post-publication hosted Ubuntu validation: run `31275547177`, success at that
+  main commit
+- Post-publication Pages deployment: run `31275547139`, success at that main
+  commit; the generated public routes were subsequently read back
+
+The independent review and final-main identities will be rebound to the exact
+post-correction tree before tracker closure.
+
+## Remaining tracker field
+
 - #97 and milestone 2 disposition: pending
 
 Historical v0.3.2.0 ledgers remain unchanged and authoritative for that release.

--- a/docs/portal/pages/audit-trail.html
+++ b/docs/portal/pages/audit-trail.html
@@ -7,7 +7,7 @@
       <p>Release evidence belongs in tracked audit ledgers, changelog entries, source files, and explicitly recorded live readbacks.<br>Generated portal metadata proves docs freshness only; it is not release, publication, or provenance evidence.</p>
 
       <h2 id="current-milestone">Current milestone</h2>
-      <p>The repository documents <code>v0.3.3.0</code> as the current source milestone. The last release-gate verified public release remains <code>v0.3.2.0</code> until v0.3.3.0 publication is independently read back.<br>Treat either pointer as evidence with its stated boundary, not permission to claim host-load, marketplace, issue-publication, or provenance state without rechecking it.</p>
+      <p>The repository documents <code>v0.3.3.0</code> as the current source milestone and independently verified public release.<br>Treat that pointer as publication and artifact-integrity evidence with its stated boundary, not permission to claim marketplace, general host-load, signature, attestation, or provenance state without separate proof.</p>
 
       <h2 id="evidence-to-recheck">Evidence to re-check</h2>
       <ul>
@@ -31,9 +31,9 @@
         <colgroup><col class="source-surface"><col><col></colgroup>
         <thead><tr><th>Surface</th><th>Current source-backed status</th><th>Boundary</th></tr></thead>
         <tbody>
-          <tr><td>Source milestone</td><td><code>v0.3.3.0</code></td><td>Source identity only until tag/release publication is independently read back.</td></tr>
+          <tr><td>Source milestone</td><td><code>v0.3.3.0</code></td><td>The matching tag and GitHub release were independently read back; source text alone would not establish publication.</td></tr>
           <tr><td>Manifest version</td><td><code>0.3.3</code></td><td>Derived from <code>.claude-plugin/plugin.json</code>.</td></tr>
-          <tr><td>Last verified public release</td><td><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.2.0">GitHub release <code>v0.3.2.0</code></a></td><td>Pointer to release evidence, not proof that a local host loaded it.</td></tr>
+          <tr><td>Last verified public release</td><td><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0">GitHub release <code>v0.3.3.0</code></a></td><td>Pointer to independently read-back publication evidence, not proof that every local host loaded it.</td></tr>
           <tr><td>Asset</td><td><code>IMPLEMENTAUDIT.skill</code></td><td>Asset names and digests must be re-read from the release before claiming live state.</td></tr>
           <tr><td>Checksum boundary</td><td>The release body records the <code>IMPLEMENTAUDIT.skill</code> SHA-256 digest.</td><td>A digest can support artifact-integrity readback, but it is not a signature, attestation, SBOM, license, marketplace check, install check, or host-load proof.</td></tr>
           <tr><td>Pages / deploy</td><td>Pages is current only after deploy success</td><td>Docs source alone does not prove public deployment.</td></tr>
@@ -58,8 +58,8 @@
           <tr><td><code>docs/audits/archive/v0.2.8.0-docs-portal-coherence-polish.md</code></td><td>Coherence and prose fixes after the v0.2.8 docs portal rewrite.</td><td>Terminology and readability precedent.</td></tr>
           <tr><td><code>docs/audits/archive/v0.2.9.0-andon-escalation-jidoka-repair.md</code></td><td>Andon/Jidoka repair, no arbitrary caps, sidecar recovery, package parity, and docs truthfulness.</td><td>Prior release audit ledger.</td></tr>
           <tr><td><code>docs/audits/archive/v0.3.0.0-local-package-dogfood-audit.md</code></td><td>Installed-package dogfood, release readiness, package self-sufficiency, and v0.3.0.0 release-gate evidence.</td><td>Historical release-gate ledger.</td></tr>
-          <tr><td><code>docs/audits/archive/v0.3.2.0-correction-and-republish-report.md</code></td><td>Corrected same-version v0.3.2.0 publication and digest-pair readback.</td><td>Last verified public-release ledger.</td></tr>
-          <tr><td><code>docs/audits/archive/v0.3.3.0-release-report.md</code></td><td>Current candidate identity, package gate, integration, publication, and terminal readback fields.</td><td>Current release ledger; prerelease until completed.</td></tr>
+          <tr><td><code>docs/audits/archive/v0.3.2.0-correction-and-republish-report.md</code></td><td>Corrected same-version v0.3.2.0 publication and digest-pair readback.</td><td>Historical public-release ledger.</td></tr>
+          <tr><td><code>docs/audits/archive/v0.3.3.0-release-report.md</code></td><td>Current package identity, package gate, integration, publication, and terminal readback fields.</td><td>Current published-release ledger; live tracker accounting remains explicit.</td></tr>
         </tbody>
       </table>
 

--- a/docs/portal/pages/overview.html
+++ b/docs/portal/pages/overview.html
@@ -1,5 +1,5 @@
 <section class="hero shell" id="top">
-  <div class="eyebrow">Claude Code + Codex skill - v0.3.3.0 source milestone</div>
+  <div class="eyebrow">Claude Code + Codex skill - v0.3.3.0 public release</div>
   <div class="hero-grid hero-grid-vis">
     <div class="hero-copy">
       <h1><span class="h1-brand">IMPLEMENTAUDIT</span><span class="h1-tagline">Implementation runs that close like audits.</span></h1>
@@ -17,9 +17,9 @@
         <a class="btn-secondary magnet-link" href="start-here/installation/">Install</a>
       </div>
       <div class="meta-row">
-        <div class="meta-cell"><em>Current</em><b><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md">v0.3.3.0</a></b></div>
+        <div class="meta-cell"><em>Current</em><b><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0">v0.3.3.0</a></b></div>
         <div class="meta-cell"><em>Host targets</em><b><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md#install-notes">Claude Code + Codex</a></b></div>
-        <div class="meta-cell"><em>Evidence</em><b><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/INDEX.md">audit evidence index</a></b></div>
+        <div class="meta-cell"><em>Evidence</em><b><a href="https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md">v0.3.3.0 release ledger</a></b></div>
       </div>
     </div>
     <div class="hero-visual">

--- a/docs/portal/site.json
+++ b/docs/portal/site.json
@@ -2,14 +2,14 @@
   "release": {
     "milestone": "v0.3.3.0",
     "manifest_version": "0.3.3",
-    "url": "",
-    "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/INDEX.md",
-    "status": "source checkout only; no tag; no release; no publication; no provenance. v0.3.3.0 core release-candidate identity is under final prerelease qualification; publication remains a separate release-gate action",
+    "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0",
+    "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md",
+    "status": "v0.3.3.0 is published and its tag, release assets, checksum, hosted validation, and Pages deployment were independently read back; these checks establish publication and artifact integrity, not signature, attestation, marketplace, or provenance claims",
     "last_release_gate_verified_public_release": {
-      "milestone": "v0.3.2.0",
-      "manifest_version": "0.3.2",
-      "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.2.0",
-      "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.2.0-correction-and-republish-report.md"
+      "milestone": "v0.3.3.0",
+      "manifest_version": "0.3.3",
+      "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0",
+      "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md"
     },
     "checksum_boundary": "release-body SHA-256 digest supports artifact-integrity readback and may support a separately authorized provenance gate"
   },

--- a/tests/docs-portal.test.sh
+++ b/tests/docs-portal.test.sh
@@ -358,7 +358,7 @@ from pathlib import Path
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
 text = text.replace(
-    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/INDEX.md",
+    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md",
     "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.2.9.0-andon-escalation-jidoka-repair.md",
 )
 path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary

- replace prerelease state in every authoritative current v0.3.3.0 publication owner with independently read-back release facts
- point portal release metadata, overview, and repo record at the published v0.3.3.0 release and ledger
- keep #97/milestone accounting and the exact post-correction review/main identities explicitly open
- update the portal stale-link negative control for the new authoritative ledger URL

## Why

The release and public assets were published and independently read back, but
the changelog, audit index/ledger, and generated portal owners still projected
prerelease state. Pages parity reproduced those stale sources and therefore did
not establish truthful public documentation closure.

The governing dogfood shortcoming is being routed separately as a repo-generic
follow-up issue. This PR contains only the release-specific repository-owner
correction.

## Impact and boundaries

Users now see the correct v0.3.3.0 public release identity and release-evidence
link across the portal. Historical v0.3.2.0 records remain unchanged. R28/#117
remains open, paused, optional, and nonblocking; #144 remains open and out of
scope.

No `.claude-plugin/` or `skills/implementaudit/` path changes. Rebuilding the
release package remains byte-identical at 215,126 bytes with SHA-256
`8ddf80e0c4545e0d66e5f81eff30a224943264a25e52a1fbb9ee0e3c3f4d778a`.

## Checks

- `git diff --check`
- `bash tests/audit-retention.test.sh`
- `bash tests/docs-portal.test.sh` (35/35)
- `bash scripts/check-public-claim-boundaries.sh`
- `bash scripts/build-release-asset.sh` plus exact byte/digest comparison
- independent cold review: PASS on commit
  `a66a6114487845b661f73c39ce1728ed8a024ade`, tree
  `bf4daa11f6f03ab9448f1cfa7d3bd71e156639ac`
