### PR TITLE
Complete v0.3.3.0 release accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ claims.
   non-regression, the complete deterministic verifier, and package verification.
   Exact-head hosted qualification, tag/release/artifact/checksum readback, and
   post-publication Pages readback also completed; the release ledger records
-  the exact identities and remaining tracker-accounting boundary.
+  the exact identities and completed tracker accounting. The repo-generic
+  README/docs dogfood false pass remains open as nonblocking follow-up #155.
 - R28/#117 is owner-paused, open, optional, and nonblocking for v0.3.3.0. Its
   completion, qualification, closure, or later pause receipt is not a release
   prerequisite, and `/dashboard/` remains excluded from the package.

--- a/docs/audits/INDEX.md
+++ b/docs/audits/INDEX.md
@@ -112,10 +112,10 @@ Standing gate owners: `check-action-selection-contract.sh`,
 
 - `docs/audits/archive/v0.3.3.0-release-report.md` - exact package identity,
   nonblocking R28/#117 and out-of-scope #144 boundaries, release integration,
-  tag/assets/checksum readback, hosted validation, Pages deployment, and the
-  remaining live tracker-accounting field. It is the current published-release
-  ledger; publication fields are evidence-bound to the identities recorded
-  there rather than inferred from source text.
+  tag/assets/checksum readback, hosted validation, Pages deployment, and
+  completed #97/milestone-2 accounting. It is the current published-release
+  ledger; the generic README/docs dogfood defect remains separately open as
+  nonblocking issue #155 in milestone 3.
 
 ## Boundary
 

--- a/docs/audits/archive/v0.3.3.0-release-report.md
+++ b/docs/audits/archive/v0.3.3.0-release-report.md
@@ -1,6 +1,6 @@
 # v0.3.3.0 release report
 
-Status: published and independently read back; tracker accounting in progress
+Status: published, independently read back, and tracker-accounting complete
 
 This is the current release ledger for IMPLEMENTAUDIT v0.3.3.0. It records
 source/package identity and separate GitHub readbacks of the tag, release,
@@ -47,19 +47,35 @@ The following identities were read independently after publication:
   its named digest matches the downloaded release asset
 - Release-head hosted Ubuntu validation: run `31263128671`, success at the
   release commit
-- Post-publication main/tree at this ledger correction's ingress:
-  `5210675b1dc5e9df962e0c8df869a5b54b87d516` /
-  `3a3220023990a5c2afaeea9cf2eacfcb2051088b`
-- Post-publication hosted Ubuntu validation: run `31275547177`, success at that
+- Post-publication documentation correction: PR #154, reviewed head
+  `a66a6114487845b661f73c39ce1728ed8a024ade`, merged as
+  `b45745eca1af06ca791a93eed74cb41ebd199a01`; retained tree
+  `bf4daa11f6f03ab9448f1cfa7d3bd71e156639ac`
+- Fresh-context correction review: PASS on that exact head/tree
+- Correction-head hosted Ubuntu validation: run `31279313891`, success
+- Post-correction main hosted Ubuntu validation: run `31279804694`, success at
+  `b45745eca1af06ca791a93eed74cb41ebd199a01`
+- Post-correction Pages deployment: run `31279804707`, success at that exact
   main commit
-- Post-publication Pages deployment: run `31275547139`, success at that main
-  commit; the generated public routes were subsequently read back
+- Public Pages readback: 32/32 routes returned HTTP 200 and all 32 complete
+  documents matched a fresh build from that exact main after newline-only
+  normalisation
 
-The independent review and final-main identities will be rebound to the exact
-post-correction tree before tracker closure.
+## Tracker accounting
 
-## Remaining tracker field
+- #97 closure receipt: comment `5228392568`, independently read back with exact
+  normalised body equality
+- R1-R23 children: 23/23 closed (#74 through #96)
+- #97: closed as completed after receipt readback
+- Milestone 2 (`v0.3.3.0`): closed after independent readback at 0 open / 29
+  closed issues
+- #155/R29: open in milestone 3 as the nonblocking repo-generic skill
+  countermeasure for the README/docs dogfood false pass
+- #117: open, owner-paused, optional, and nonblocking
+- #144: open in milestone 3 and separately out of scope
 
-- #97 and milestone 2 disposition: pending
+The ledger-only commit that records these terminal tracker facts necessarily
+advances public main and its repository tree after `b45745e`; it does not change
+the published package, tag, release, assets, checksum, or tracker dispositions.
 
 Historical v0.3.2.0 ledgers remain unchanged and authoritative for that release.

--- a/docs/portal/pages/audit-trail.html
+++ b/docs/portal/pages/audit-trail.html
@@ -59,7 +59,7 @@
           <tr><td><code>docs/audits/archive/v0.2.9.0-andon-escalation-jidoka-repair.md</code></td><td>Andon/Jidoka repair, no arbitrary caps, sidecar recovery, package parity, and docs truthfulness.</td><td>Prior release audit ledger.</td></tr>
           <tr><td><code>docs/audits/archive/v0.3.0.0-local-package-dogfood-audit.md</code></td><td>Installed-package dogfood, release readiness, package self-sufficiency, and v0.3.0.0 release-gate evidence.</td><td>Historical release-gate ledger.</td></tr>
           <tr><td><code>docs/audits/archive/v0.3.2.0-correction-and-republish-report.md</code></td><td>Corrected same-version v0.3.2.0 publication and digest-pair readback.</td><td>Historical public-release ledger.</td></tr>
-          <tr><td><code>docs/audits/archive/v0.3.3.0-release-report.md</code></td><td>Current package identity, package gate, integration, publication, and terminal readback fields.</td><td>Current published-release ledger; live tracker accounting remains explicit.</td></tr>
+          <tr><td><code>docs/audits/archive/v0.3.3.0-release-report.md</code></td><td>Current package identity, package gate, integration, publication, terminal readback, and tracker closure.</td><td>Current published-release ledger; repo-generic dogfood follow-up #155 remains open and nonblocking.</td></tr>
         </tbody>
       </table>
 

--- a/docs/portal/site.json
+++ b/docs/portal/site.json
@@ -4,7 +4,7 @@
     "manifest_version": "0.3.3",
     "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0",
     "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md",
-    "status": "v0.3.3.0 is published and its tag, release assets, checksum, hosted validation, and Pages deployment were independently read back; these checks establish publication and artifact integrity, not signature, attestation, marketplace, or provenance claims",
+    "status": "v0.3.3.0 is published; its tag, release assets, checksum, hosted validation, Pages deployment, and tracker closure were independently read back. Repo-generic dogfood follow-up #155 remains open and nonblocking; these checks establish publication and artifact integrity, not signature, attestation, marketplace, or provenance claims",
     "last_release_gate_verified_public_release": {
       "milestone": "v0.3.3.0",
       "manifest_version": "0.3.3",


### PR DESCRIPTION
## Summary

- record the independently verified PR #154 documentation correction and hosted/Pages readback
- record completed #97 and milestone 2 accounting
- preserve #117, #144, and repo-generic follow-up #155 as open, nonblocking boundaries

## Scope

Repository-only release accounting. No packaged/runtime path changes.

## Verification

- `git diff --check`
- `bash tests/audit-retention.test.sh`
- `bash tests/docs-portal.test.sh` (35/35)
- `bash scripts/check-public-claim-boundaries.sh`
- `bash scripts/build-release-asset.sh`
- canonical package remains 215,126 bytes, SHA-256 `8ddf80e0c4545e0d66e5f81eff30a224943264a25e52a1fbb9ee0e3c3f4d778a`
- packaged payload diff against the published release asset: empty

The exact committed head/tree will receive independent cold review and hosted exact-head validation before merge.
