### PR TITLE
feat: enforce shipped helper reachability (#157)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,3 +122,4 @@ jobs:
           bash tests/docs-portal.test.sh
           bash tests/eval-harness.test.sh
           bash tests/payload-path-hygiene.test.sh
+          bash tests/helper-reachability.test.sh

--- a/fixtures/helper-reachability/README.md
+++ b/fixtures/helper-reachability/README.md
@@ -1,0 +1,18 @@
+# Helper reachability fixture map
+
+The focused test creates disposable candidate copies from these deterministic case definitions:
+
+| Case | Expected result |
+|---|---|
+| live 18-helper package manifest and closed declarations | PASS 18/18 |
+| one shipped helper lacks a declaration | FAIL |
+| a helper cites only itself as its owner | FAIL |
+| a required-procedural owner does not contain the exact helper route | FAIL |
+| a declaration uses a non-contract class such as `unit-tested` | FAIL |
+| an automatic helper names a missing caller | FAIL |
+| an advisory helper claims a mandatory closure effect | FAIL |
+| a nineteenth packaged helper is added without a declaration | FAIL 18/19, proving a derived denominator |
+| a declaration names a helper absent from the package | FAIL |
+
+Package presence, a self-usage comment, direct unit tests, and wildcard discovery are deliberately insufficient dispatch evidence.
+The live positive also requires one audit object and a cheap no-event path.

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ "${1:-}" = "--repo-root" ]; then
+  [ "$#" -eq 2 ] || { printf 'check-helper-reachability: usage: [--repo-root <dir>]\n' >&2; exit 2; }
+  repo_root="$(cd "$2" && pwd)"
+elif [ "$#" -ne 0 ]; then
+  printf 'check-helper-reachability: usage: [--repo-root <dir>]\n' >&2
+  exit 2
+fi
+
+if command -v python >/dev/null 2>&1; then
+  py_cmd=(python)
+elif command -v python3 >/dev/null 2>&1; then
+  py_cmd=(python3)
+elif command -v py >/dev/null 2>&1; then
+  py_cmd=(py -3)
+else
+  printf 'check-helper-reachability: python, python3, or py -3 is required\n' >&2
+  exit 2
+fi
+
+"${py_cmd[@]}" - "$repo_root" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+builder = root / "scripts" / "build-release-asset.sh"
+skill_root = root / "skills" / "implementaudit"
+contract = skill_root / "references" / "repo-state-comparison.md"
+for path in (builder, skill_root, contract):
+    if not path.exists():
+        raise SystemExit(f"check-helper-reachability: missing owner: {path}")
+
+builder_text = builder.read_text(encoding="utf-8")
+match = re.search(r"(?ms)^required_archive\s*=\s*\[(.*?)^\]", builder_text)
+if not match:
+    raise SystemExit("check-helper-reachability: required_archive manifest is unreadable")
+
+archive_entries = re.findall(r'"([^"]+)"', match.group(1))
+helpers = sorted(
+    entry.removeprefix("scripts/")
+    for entry in archive_entries
+    if re.fullmatch(r"scripts/[^/]+\.sh", entry)
+)
+if len(helpers) != len(set(helpers)):
+    raise SystemExit("check-helper-reachability: duplicate helper in required_archive")
+
+contract_text = contract.read_text(encoding="utf-8")
+rows = {}
+for line_number, line in enumerate(contract_text.splitlines(), 1):
+    if not line.startswith("helper-route: "):
+        continue
+    parts = [part.strip() for part in line.split("|")]
+    if len(parts) != 7:
+        raise SystemExit(
+            f"check-helper-reachability: malformed helper route at line {line_number}"
+        )
+    helper = parts[0].removeprefix("helper-route: ")
+    if helper in rows:
+        raise SystemExit(f"check-helper-reachability: duplicate applicability row: {helper}")
+    rows[helper] = {
+        "class": parts[1], "trigger": parts[2], "owner": parts[3],
+        "caller": parts[4], "arguments": parts[5], "boundary": parts[6],
+    }
+
+missing = sorted(set(helpers) - set(rows))
+extra = sorted(set(rows) - set(helpers))
+if missing:
+    suffix = f" (population={len(helpers)} examined={len(rows)})" if len(helpers) != len(rows) else ""
+    raise SystemExit(
+        "check-helper-reachability: missing applicability rows: "
+        + ", ".join(missing) + suffix
+    )
+if extra:
+    raise SystemExit(
+        "check-helper-reachability: applicability rows not in package: "
+        + ", ".join(extra)
+    )
+
+class_names = {
+    "A": "automatic", "R": "required-procedural", "O": "optional-advisory",
+    "S": "standalone-diagnostic", "I": "internal-library",
+}
+owner_aliases = {
+    "P": "templates/PROTOCOL.md",
+    "R": "references/repo-state-comparison.md",
+    "C": "references/child-agents.md",
+    "S": "SKILL.md",
+    "V": "scripts/validate-run-root.sh",
+}
+mandatory_re = re.compile(
+    r"(?i)(?:^|[-_ ])(?:must|mandatory|required|block|gate)(?:$|[-_ .,;:`])"
+)
+def field_is_anchored(value, content):
+    for part in value.lower().replace("artefact", "artifact").split("/"):
+        words = [w for w in re.split(r"[^a-z0-9]+", part)
+                 if len(w) >= 3 and w not in {"none", "only", "never", "automatic"}]
+        if words and all(word in content for word in words):
+            return True
+    return False
+
+def arguments_are_anchored(value, helper, content):
+    token_re = re.compile(r"--[a-z0-9][a-z0-9-]*|<[^>]+>|\.\.\.|[a-z0-9][a-z0-9-]*")
+    expected = [] if value.lower() == "none" else token_re.findall(value.lower())
+    candidates = re.findall(r"`([^`]*" + re.escape(helper) + r"[^`]*)`",
+                            content, re.I | re.S)
+    candidates.extend(
+        line.split("#", 1)[0] for line in content.splitlines()
+        if helper in line and "`" not in line and
+        re.match(r"\s*(?:bash|source|exec)\b", line, re.I)
+    )
+    for candidate in candidates:
+        match = re.search(re.escape(helper), candidate, re.I)
+        actual = token_re.findall(candidate[match.end():].lower()) if match else []
+        if actual == expected:
+            return True
+    return False
+
+def shell_code(content):
+    cleaned = []
+    for line in content.splitlines():
+        quote = None
+        escaped = False
+        kept = []
+        for index, char in enumerate(line):
+            if escaped:
+                kept.append(char)
+                escaped = False
+                continue
+            if char == "\\" and quote != "'":
+                kept.append(char)
+                escaped = True
+                continue
+            if char in {"'", '"'}:
+                if quote == char:
+                    quote = None
+                elif quote is None:
+                    quote = char
+                kept.append(char)
+                continue
+            if char == "#" and quote is None and (index == 0 or line[index - 1].isspace()):
+                break
+            kept.append(char)
+        cleaned.append("".join(kept))
+    return "\n".join(cleaned)
+
+def caller_invokes(helper, content):
+    content = shell_code(content)
+    def command_uses(target, path_prefix=False):
+        prefix = r'''(?:[^\s"']*/)?''' if path_prefix else ""
+        operand = rf'''["']?{prefix}{target}["']?(?=\s|$)'''
+        direct = rf"(?m)^\s*(?:(?:if|while|until|!)\s+)?(?:bash|source|exec)\s+{operand}"
+        substitution = rf'''(?mx)^\s*[a-z_][a-z0-9_]*\s*=\s*["']?\$\(\s*(?:bash|source|exec)\s+{operand}'''
+        return bool(re.search(direct, content, re.I) or
+                    re.search(substitution, content, re.I))
+
+    if command_uses(re.escape(helper), path_prefix=True):
+        return True
+    assignment = None
+    for line in content.splitlines():
+        candidate = re.match(r"^\s*([a-z_][a-z0-9_]*)\s*=\s*(.+?)\s*$", line, re.I)
+        if not candidate:
+            continue
+        value = candidate.group(2)
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        if re.search(rf"(?:^|/){re.escape(helper)}$", value):
+            assignment = candidate
+            break
+    if not assignment:
+        return False
+    variable = re.escape(assignment.group(1))
+    return command_uses(rf"\${{?{variable}}}?")
+
+def packaged_path(raw, helper, role):
+    rel = Path(raw)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise SystemExit(f"check-helper-reachability: invalid {role}: {helper}: {raw}")
+    if rel.as_posix() not in archive_entries:
+        raise SystemExit(f"check-helper-reachability: unshipped {role}: {helper}: {raw}")
+    path = skill_root / rel
+    try:
+        path.resolve().relative_to(skill_root.resolve())
+    except (OSError, ValueError):
+        raise SystemExit(f"check-helper-reachability: invalid {role}: {helper}: {raw}")
+    if not path.is_file():
+        raise SystemExit(f"check-helper-reachability: missing {role}: {helper}: {raw}")
+    return path
+
+for helper in helpers:
+    row = rows[helper]
+    class_code = row["class"]
+    if class_code not in class_names:
+        raise SystemExit(
+            f"check-helper-reachability: invalid applicability class {class_code} for {helper}"
+        )
+    applicability = class_names[class_code]
+    for field in ("trigger", "arguments", "boundary"):
+        if not row[field] or row[field] == "-":
+            raise SystemExit(f"check-helper-reachability: empty {field} for {helper}")
+
+    owner_text = owner_aliases.get(row["owner"], row["owner"])
+    owner_rel = Path(owner_text)
+    own_rel = Path("scripts") / helper
+    if owner_rel == own_rel:
+        raise SystemExit(
+            f"check-helper-reachability: dispatch owner cannot be the helper itself: {helper}"
+        )
+    owner = packaged_path(owner_text, helper, "dispatch owner")
+    owner_lines = owner.read_text(encoding="utf-8").splitlines()
+    non_route_lines = [line for line in owner_lines if not line.startswith("helper-route: ")]
+    owner_content = "\n".join(non_route_lines)
+    helper_lines = [index for index, line in enumerate(non_route_lines) if helper in line]
+    if not helper_lines:
+        raise SystemExit(
+            f"check-helper-reachability: dispatch owner does not name helper {helper}: {owner_text}"
+        )
+    if applicability == "required-procedural":
+        action = r"(?:bash|run|supply|dispatch(?:es)?|invoke|enforce|requires?|claim(?: it)? with)"
+        contexts = ["\n".join(non_route_lines[max(0, i - 4):i + 5])
+                    for i in helper_lines]
+        procedural = [context for context in contexts if re.search(
+            rf"(?:{action}.{{0,120}}{re.escape(helper)}|{re.escape(helper)}.{{0,120}}{action})",
+            context, re.I | re.S
+        )]
+        if not procedural:
+            raise SystemExit(
+                f"check-helper-reachability: procedural route absent: {helper}"
+            )
+        field_contexts = [context.lower().replace("artefact", "artifact")
+                          .replace(helper.lower(), "") for context in procedural]
+        for field in ("trigger", "boundary"):
+            if not any(field_is_anchored(row[field], context) for context in field_contexts):
+                raise SystemExit(
+                    f"check-helper-reachability: unanchored {field}: {helper}: {row[field]}"
+                )
+        if not any(arguments_are_anchored(row["arguments"], helper, context)
+                   for context in procedural):
+            raise SystemExit(
+                f"check-helper-reachability: unanchored arguments: {helper}: {row['arguments']}"
+            )
+        if not any(
+            field_is_anchored(row["trigger"], context.lower().replace("artefact", "artifact")
+                              .replace(helper.lower(), ""))
+            and field_is_anchored(row["boundary"], context.lower().replace("artefact", "artifact")
+                                  .replace(helper.lower(), ""))
+            and arguments_are_anchored(row["arguments"], helper, context)
+            for context in procedural
+        ):
+            raise SystemExit(
+                f"check-helper-reachability: route fields do not co-occur: {helper}"
+            )
+    if applicability in {"optional-advisory", "standalone-diagnostic"}:
+        advisory_text = " ".join(
+            (row["trigger"], row["arguments"], row["boundary"])
+        )
+        if mandatory_re.search(advisory_text):
+            raise SystemExit(
+                f"check-helper-reachability: advisory/standalone row implies mandatory enforcement: {helper}"
+            )
+        if any(mandatory_re.search(" ".join(non_route_lines[max(0, i - 1):i + 2]))
+               for i in helper_lines):
+            raise SystemExit(
+                f"check-helper-reachability: advisory owner overclaim: {helper}"
+            )
+
+    caller_rel = owner_aliases.get(row["caller"], row["caller"])
+    if applicability in {"automatic", "internal-library"}:
+        if caller_rel == "-":
+            raise SystemExit(
+                f"check-helper-reachability: {applicability} helper lacks caller: {helper}"
+            )
+        caller_path = packaged_path(caller_rel, helper, "caller")
+        if not (Path(caller_rel).as_posix().startswith("scripts/") and
+                Path(caller_rel).suffix == ".sh"):
+            raise SystemExit(
+                f"check-helper-reachability: caller is not a shipped script: {helper}: {caller_rel}"
+            )
+        caller_content = caller_path.read_text(encoding="utf-8")
+        if not caller_invokes(helper, caller_content):
+            raise SystemExit(
+                f"check-helper-reachability: caller does not invoke {helper}: {caller_rel}"
+            )
+    elif caller_rel != "-":
+        raise SystemExit(
+            f"check-helper-reachability: nonautomatic helper declares caller: {helper}"
+        )
+
+print(
+    "HELPER_REACHABILITY=PASS "
+    f"population={len(helpers)} examined={len(rows)} "
+    "enumeration=build-release-asset.required_archive"
+)
+PY

--- a/scripts/check-planner-stages.sh
+++ b/scripts/check-planner-stages.sh
@@ -76,7 +76,7 @@ require_in_file skills/implementaudit/SKILL.md "Stage 6 assumptions"
 require_in_file skills/implementaudit/SKILL.md "0-2 true-gap questions"
 require_in_file skills/implementaudit/SKILL.md "at most four material questions"
 require_in_file skills/implementaudit/SKILL.md "canonical runtime templates"
-require_in_file skills/implementaudit/SKILL.md '`scripts/validate-run-root.sh` after authoring'
+require_in_file skills/implementaudit/SKILL.md '`scripts/validate-run-root.sh <root>` after authoring'
 require_in_file skills/implementaudit/SKILL.md '`scripts/validate-run-root.sh` immediately before'
 require_in_file skills/implementaudit/SKILL.md "safe containment with unresolved causality"
 require_in_file skills/implementaudit/SKILL.md "distinct supported candidate causes"

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -220,6 +220,8 @@ require_file eval/test_qualification_evidence_producer.py
 require_file eval/historical_readjudicate.py
 require_file eval/test_historical_readjudicate.py
 require_file tests/payload-path-hygiene.test.sh
+require_file scripts/check-helper-reachability.sh
+require_file tests/helper-reachability.test.sh
 require_file fixtures/casual-build/accepted-intent.md
 require_file fixtures/casual-build/rejected-intent.md
 require_file fixtures/phase-design/polish-harden.md
@@ -685,6 +687,7 @@ bash tests/claim-boundary-proof-levels.test.sh
 bash tests/no-terminal-cap.test.sh
 bash tests/eval-harness.test.sh
 bash tests/payload-path-hygiene.test.sh
+bash tests/helper-reachability.test.sh
 bash tests/summarize-repo.test.sh
 bash tests/shipped-scripts-smoke.test.sh
 bash tests/run-root-validation.test.sh

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -186,9 +186,8 @@ Load references only when the current gate needs them:
 - `references/continuity.md`: context-epoch continuity — post-boundary
   reconciliation before mutation, instruction lifecycle/applicability,
   satisfied one-shot replay refusal, capsule binding, single-writer epochs.
-- `references/repo-state-comparison.md`: complete working-tree
-  comparison, baseline refs, final audit deliverable checks, and local commit
-  granularity.
+- `references/repo-state-comparison.md`: state/baseline/final checks and
+  shipped-helper dispatch.
 - `references/sidecars.md`: optional Graphify/ActiveGraph Gemba, first-run
   tooling onboarding, and no silent install/index/export boundaries.
 - `references/lean-operating-discipline.md`: PDCA, Gemba, Kaizen,
@@ -277,10 +276,9 @@ Phases with 3+ independent units declare `unit_independence` and
 
 When a run root is needed, write `ROADMAP.md`, `STATE.md`, `THINKING.md`,
 `PROTOCOL.md`, `context.md`, `tools.md`, `sidecars.md`, and phase specs under
-`.IMPLEMENTAUDIT/runs/<task-slug>-<id>/`. Claim the run root with
-`scripts/claim-run.sh`. Initialize from the canonical runtime templates, then
-run `scripts/validate-run-root.sh` after authoring; an invalid root is Andon,
-not a dispatchable plan.
+`.IMPLEMENTAUDIT/runs/<task-slug>-<id>/`. Claim it with
+`scripts/claim-run.sh <task>`, initialize from canonical runtime templates, then run
+`scripts/validate-run-root.sh <root>` after authoring; an invalid root is Andon, not dispatchable.
 
 When safe containment with unresolved causality is available, contain first,
 then route to the STATE residual procedure: preserve distinct supported candidate causes

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -28,7 +28,7 @@ owner/source.
 
 ## Helper
 
-Use the native helper instead of hand-typing the git incantation:
+Smoke/final: use the read-only helper:
 
 ```bash
 bash "${IMPLEMENTAUDIT_SKILL_DIR:-skills/implementaudit}"/scripts/repo-state.sh deliverable <baseline> <path>
@@ -224,6 +224,39 @@ Path and anchor aliases cannot count one physical file twice; symlink parents
 are refused. This preserves both `WINDOW_SECONDS = 30` and the prose that
 justifies it. The manifest admits intended duplication; it does not excuse
 divergence.
+
+When `.IMPLEMENTAUDIT/duplication-sets.txt` exists, dispatch
+`check-duplication-parity.sh <manifest>`; divergence blocks its phase. No set means no
+whole-repo sweep.
+
+## Helper dispatch (#157)
+
+Gate derives source repo `scripts/*.sh`; presence/tests/self-use/wildcards are
+not dispatch. `H|C|T|O|K|A|N`: helper/class/trigger/owner/caller/args/no-event.
+`A/R/O/S/I`: automatic/required/optional/standalone/internal. `P/R/C/S/V`:
+PROTOCOL/this/child-agents/SKILL/validate-run-root. R runs
+`bash <skill-dir>/scripts/<H> <A>` and blocks T; A/I need K; O/S never gate.
+One audit object; no event, no sweep. Phased Stage 0 runs `detect-env.sh`; run
+`validate-audit-spec.sh <spec>` for a spec and `detect-stack.sh` only for standalone diagnosis.
+
+helper-route: check-authorization-binding.sh|R|auth|P|-|--auth <a> --invocation <i> --state <s>|no-param
+helper-route: check-closure-surface.sh|R|final|P|-|<closure-record> --superseded-plan <each-replaced-plan> --steer-dir <run-root> --plan-cycle-record <each-cycle-accounted-plan>|inputs
+helper-route: check-duplication-parity.sh|R|duplication-set|R|-|<manifest>|no-set
+helper-route: check-evidence-anchor.sh|R|scope|P|-|--artifact ... --tree ...|disjoint
+helper-route: check-handoff-packet.sh|R|handoff-packet|P|-|<p> --repo-root <r>|same-session
+helper-route: check-lesson-lift.sh|R|final-record|P|-|<c> --repo-root <r>|closure
+helper-route: check-respec-impact-set.sh|A|impact-set|V|V|impact-set|no-impact
+helper-route: claim-run.sh|R|run-root|S|-|<task>|initialize
+helper-route: custody-append.sh|O|authorised-mirror|P|-|<store> <run> <event> <type> <json>|absent
+helper-route: detect-env.sh|R|Stage-0|R|-|none|phased
+helper-route: detect-stack.sh|S|stack-diagnosis|R|-|none|not-auto
+helper-route: lane-survivor-inventory.sh|O|interrupted-lane|C|-|<root> --expect <path>|unrelated
+helper-route: map-pin-chain.sh|R|artefact-edit|R|-|<path> [--expect-hops N]|no-completeness
+helper-route: repo-state.sh|R|Smoke/final|R|-|changed-files <baseline>|read-only
+helper-route: summarize-repo.sh|S|repo/owner-diagnosis|R|-|[--generated-owner <path>]|targeted-default
+helper-route: validate-audit-spec.sh|R|audit-spec|R|-|<spec>|no-spec
+helper-route: validate-phase.sh|R|phase|P|-|<phase>|exit-code
+helper-route: validate-run-root.sh|R|run-root|S|-|<root>|invalid
 
 ## Pin-chain map (#76)
 

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -114,7 +114,7 @@ block is present. If the file is missing or the marker is absent, stop and
 report Andon with the missing artifact path.
 
 **Step 3 — Validate phase spec.**
-Run `bash "${IMPLEMENTAUDIT_SKILL_DIR:-skills/implementaudit}"/scripts/validate-phase.sh <run-root>/phases/phase-N.md`.
+Run `bash "${IMPLEMENTAUDIT_SKILL_DIR:-skills/implementaudit}"/scripts/validate-phase.sh <phase>`.
 Exit code must be 0. If not, stop and report the validation error before
 proceeding. Do not execute a phase against an invalid spec.
 
@@ -193,10 +193,9 @@ current one — re-gather instead (stale-evidence substitution is an
 ANDON_PROBE, class `evidence-mismatch`). Legacy rows recorded before this
 contract carry no anchor and stay valid as historical evidence.
 
-An evidence-scope declaration may supply a nonempty `bound_surfaces` manifest
-of repo-relative paths/globs to `check-evidence-anchor.sh --artifact ... --tree
-... --bound-surfaces <manifest>`. Anchor-to-current changes disjoint from that
-set do not invalidate the artifact; an intersection does. The artifact binds
+An evidence scope may supply `--bound-surfaces <manifest>` to
+`check-evidence-anchor.sh --artifact ... --tree ...`. Disjoint anchor-to-current
+changes do not invalidate the artifact; an intersection does. The artifact binds
 the manifest bytes with exactly one `Bound-Surfaces-SHA256: <digest>` line, so
 the caller cannot substitute a narrower set. Without the manifest, exact
 whole-tree equality remains mandatory.
@@ -313,9 +312,9 @@ When resuming after interruption:
 
 ### Receiving-side handoff inspection
 
-When resuming from a HANDOFF PACKET produced by another run/session (not a
-same-session pause), the receiver verifies the packet against live state
-BEFORE accepting any work-in-process. This gate is not a full re-audit.
+For a non-same-session HANDOFF PACKET, run
+`check-handoff-packet.sh <p> --repo-root <r>` against live state before
+acceptance; not a full re-audit.
 
 Packet identity (required before any claim comparison): packet ID; packet
 version; packet content hash; claimed subject identity (repository +
@@ -512,8 +511,9 @@ and request an owner decision. Source-code or tool defaults are NEVER
 implicitly adopted for a governed parameter. Ordinary small authorizations
 stay one line — a parameter table is required only when consequential
 parameters exist to bind (a docs-only commit authorization needs none).
-Existing authorizations remain valid for work already running; new
-authorizations carry the enumeration when applicable.
+At this auth boundary run `check-authorization-binding.sh --auth <a>
+--invocation <i> --state <s>`. Running authorisations remain valid; new ones
+carry the enumeration when applicable.
 
 **Automatic-effect closure.** Before an authorized push or merge, inspect the
 configured workflow triggers against the exact event and target ref. Record
@@ -999,8 +999,8 @@ keeps the ordinary residual contract; this adds no disposition value.
 
 ### AUDIT_COMPLETE and IMPLEMENTAUDIT_RUN_COMPLETE
 
-Before final closure, invoke the shipped checker with every applicable plan
-and steer input. The canonical command shape is:
+For the final record run `check-lesson-lift.sh <c> --repo-root <r>`, then the
+shipped closure checker with all applicable inputs:
 
 ```text
 bash <skill-dir>/scripts/check-closure-surface.sh <closure-record> --superseded-plan <each-replaced-plan> --steer-dir <run-root> --plan-cycle-record <each-cycle-accounted-plan>  # installed skill; source repo only uses the same shipped helper

--- a/tests/closure-surface-contract.test.sh
+++ b/tests/closure-surface-contract.test.sh
@@ -985,8 +985,10 @@ sed -e 's/REANCHOR_DISPOSITION: unchanged/REANCHOR_DISPOSITION: per-finding/' \
     "$tmp/reanchor-unreconciled.md" > "$tmp/reanchor-superseded.md"
 printf 'residual: identity | consequential: yes | disposition: SUPERSEDED_BY_CONCURRENT_MUTATION | evidence-file: finding-r7.md | evidence-sha256: %s\n' \
   "$finding_hash" >> "$tmp/reanchor-superseded.md"
-reanchor_check "$tmp/reanchor-superseded.md" >/dev/null 2>&1 \
-  || fail "hash-bound per-finding concurrent-mutation supersession rejected"
+reanchor_output=""
+if ! reanchor_output="$(reanchor_check "$tmp/reanchor-superseded.md" 2>&1)"; then
+  fail "hash-bound per-finding concurrent-mutation supersession rejected: ${reanchor_output:-no scorer diagnostic}"
+fi
 sed '/^residual: identity /d' "$tmp/reanchor-superseded.md" > "$tmp/reanchor-missing-finding.md"
 if reanchor_check "$tmp/reanchor-missing-finding.md" >/dev/null 2>&1; then
   fail "moved closure anchor accepted without one structured row per claim"

--- a/tests/helper-reachability.test.sh
+++ b/tests/helper-reachability.test.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+checker="$repo_root/scripts/check-helper-reachability.sh"
+
+if [ ! -f "$checker" ]; then
+  printf 'helper-reachability.test: missing checker: %s\n' "$checker" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+
+make_candidate() {
+  local name="$1"
+  local candidate="$tmp/$name"
+  mkdir -p "$candidate/scripts"
+  cp -R "$repo_root/skills" "$candidate/skills"
+  cp "$repo_root/scripts/build-release-asset.sh" "$candidate/scripts/build-release-asset.sh"
+  printf '%s\n' "$candidate"
+}
+
+expect_fail() {
+  local label="$1" pattern="$2" candidate="$3" output
+  if output="$(bash "$checker" --repo-root "$candidate" 2>&1)"; then
+    printf 'helper-reachability.test: %s unexpectedly passed\n' "$label" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "$pattern" <<<"$output"; then
+    printf 'helper-reachability.test: %s failed for the wrong reason\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+}
+
+mutate_route() {
+  local candidate="$1" helper="$2" column="$3" value="$4"
+  python - \
+    "$candidate/skills/implementaudit/references/repo-state-comparison.md" \
+    "$helper" "$column" "$value" <<'PY'
+import sys
+from pathlib import Path
+
+path, helper, column_text, value = sys.argv[1:]
+column = int(column_text)
+lines = Path(path).read_text(encoding="utf-8").splitlines()
+prefix = f"helper-route: {helper}|"
+matches = [index for index, line in enumerate(lines) if line.startswith(prefix)]
+if len(matches) != 1:
+    raise SystemExit(f"expected one route row for {helper}, got {len(matches)}")
+parts = lines[matches[0]].split("|")
+parts[column] = value
+lines[matches[0]] = "|".join(parts)
+Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+}
+
+delete_route() {
+  local candidate="$1" helper="$2"
+  python - \
+    "$candidate/skills/implementaudit/references/repo-state-comparison.md" \
+    "$helper" <<'PY'
+import sys
+from pathlib import Path
+
+path, helper = sys.argv[1:]
+lines = Path(path).read_text(encoding="utf-8").splitlines()
+prefix = f"helper-route: {helper}|"
+kept = [line for line in lines if not line.startswith(prefix)]
+if len(kept) != len(lines) - 1:
+    raise SystemExit(f"expected one route row for {helper}")
+Path(path).write_text("\n".join(kept) + "\n", encoding="utf-8")
+PY
+}
+
+positive_output="$(bash "$checker" --repo-root "$repo_root")"
+grep -Fq 'HELPER_REACHABILITY=PASS population=18 examined=18 enumeration=build-release-asset.required_archive' \
+  <<<"$positive_output" || {
+    printf 'helper-reachability.test: live positive census did not prove 18/18\n%s\n' "$positive_output" >&2
+    exit 1
+  }
+grep -Fq 'One audit object; no event, no sweep.' \
+  "$repo_root/skills/implementaudit/references/repo-state-comparison.md" || {
+    printf 'helper-reachability.test: same-object/no-event contract is missing\n' >&2
+    exit 1
+  }
+
+missing_row="$(make_candidate missing-row)"
+delete_route "$missing_row" check-authorization-binding.sh
+expect_fail R30-F1 'missing applicability rows: check-authorization-binding.sh' "$missing_row"
+
+self_reference="$(make_candidate self-reference)"
+mutate_route "$self_reference" check-authorization-binding.sh 3 scripts/check-authorization-binding.sh
+expect_fail R30-F2 'dispatch owner cannot be the helper itself: check-authorization-binding.sh' "$self_reference"
+
+missing_dispatch="$(make_candidate missing-dispatch)"
+mutate_route "$missing_dispatch" check-authorization-binding.sh 3 references/goal-format.md
+expect_fail R30-F5 'dispatch owner does not name helper check-authorization-binding.sh' "$missing_dispatch"
+
+presence_only="$(make_candidate presence-only)"
+printf '\ncheck-authorization-binding.sh exists in the package and has direct tests.\n' \
+  >>"$presence_only/skills/implementaudit/references/goal-format.md"
+mutate_route "$presence_only" check-authorization-binding.sh 3 references/goal-format.md
+expect_fail R30-F3/F4 \
+  'procedural route absent: check-authorization-binding.sh' \
+  "$presence_only"
+
+bogus_trigger="$(make_candidate bogus-trigger)"
+mutate_route "$bogus_trigger" check-authorization-binding.sh 2 none
+expect_fail R30-F5 \
+  'unanchored trigger: check-authorization-binding.sh: none' \
+  "$bogus_trigger"
+
+decoy_trigger="$(make_candidate decoy-trigger)"
+mutate_route "$decoy_trigger" check-authorization-binding.sh 2 final
+expect_fail R30-F5 \
+  'unanchored trigger: check-authorization-binding.sh: final' \
+  "$decoy_trigger"
+
+bogus_arguments="$(make_candidate bogus-arguments)"
+mutate_route "$bogus_arguments" check-authorization-binding.sh 5 bogus-arguments
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: bogus-arguments' \
+  "$bogus_arguments"
+
+decoy_arguments="$(make_candidate decoy-arguments)"
+mutate_route "$decoy_arguments" check-authorization-binding.sh 5 'state invocation authorization'
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: state invocation authorization' \
+  "$decoy_arguments"
+
+swapped_arguments="$(make_candidate swapped-arguments)"
+mutate_route "$swapped_arguments" check-authorization-binding.sh 5 \
+  '--auth <state> --invocation <auth> --state <invocation>'
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: --auth <state> --invocation <auth> --state <invocation>' \
+  "$swapped_arguments"
+
+omitted_flag="$(make_candidate omitted-flag)"
+mutate_route "$omitted_flag" check-authorization-binding.sh 5 \
+  '--auth <a> <i> --state <s>'
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: --auth <a> <i> --state <s>' \
+  "$omitted_flag"
+
+truncated_arguments="$(make_candidate truncated-arguments)"
+mutate_route "$truncated_arguments" check-authorization-binding.sh 5 '--auth <a>'
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: --auth <a>' \
+  "$truncated_arguments"
+
+argument_self_anchor="$(make_candidate argument-self-anchor)"
+mutate_route "$argument_self_anchor" check-authorization-binding.sh 5 \
+  '<check-authorization-binding>'
+expect_fail R30-F5 \
+  'unanchored arguments: check-authorization-binding.sh: <check-authorization-binding>' \
+  "$argument_self_anchor"
+
+bogus_boundary="$(make_candidate bogus-boundary)"
+mutate_route "$bogus_boundary" check-authorization-binding.sh 6 none
+expect_fail R30-F5 \
+  'unanchored boundary: check-authorization-binding.sh: none' \
+  "$bogus_boundary"
+
+decoy_boundary="$(make_candidate decoy-boundary)"
+mutate_route "$decoy_boundary" check-authorization-binding.sh 6 final
+expect_fail R30-F5 \
+  'unanchored boundary: check-authorization-binding.sh: final' \
+  "$decoy_boundary"
+
+bad_class="$(make_candidate bad-class)"
+mutate_route "$bad_class" check-authorization-binding.sh 1 U
+expect_fail R30-F1 'invalid applicability class U for check-authorization-binding.sh' "$bad_class"
+
+missing_caller="$(make_candidate missing-caller)"
+mutate_route "$missing_caller" check-respec-impact-set.sh 4 scripts/missing-caller.sh
+expect_fail R30-F11 'unshipped caller: check-respec-impact-set.sh: scripts/missing-caller.sh' "$missing_caller"
+
+repo_only_caller="$(make_candidate repo-only-caller)"
+mutate_route "$repo_only_caller" check-respec-impact-set.sh 4 ../../tests/helper-reachability.test.sh
+expect_fail R30-F11 \
+  'invalid caller: check-respec-impact-set.sh: ../../tests/helper-reachability.test.sh' \
+  "$repo_only_caller"
+
+mention_only_caller="$(make_candidate mention-only-caller)"
+mutate_route "$mention_only_caller" check-respec-impact-set.sh 4 R
+expect_fail R30-F11 \
+  'caller is not a shipped script: check-respec-impact-set.sh: references/repo-state-comparison.md' \
+  "$mention_only_caller"
+
+mention_only_script="$(make_candidate mention-only-script)"
+printf '\n# bash scripts/check-respec-impact-set.sh\ntrue # bash scripts/check-respec-impact-set.sh\n' \
+  >>"$mention_only_script/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$mention_only_script" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$mention_only_script"
+
+echo_only_script="$(make_candidate echo-only-script)"
+printf '\necho bash scripts/check-respec-impact-set.sh\n' \
+  >>"$echo_only_script/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$echo_only_script" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$echo_only_script"
+
+printf_only_script="$(make_candidate printf-only-script)"
+printf "\nprintf '%%s\\n' 'bash scripts/check-respec-impact-set.sh'\n" \
+  >>"$printf_only_script/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$printf_only_script" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$printf_only_script"
+
+bash_parse_only="$(make_candidate bash-parse-only)"
+printf '\nbash -n scripts/check-respec-impact-set.sh\n' \
+  >>"$bash_parse_only/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$bash_parse_only" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$bash_parse_only"
+
+exec_echo_only="$(make_candidate exec-echo-only)"
+printf '\nexec echo scripts/check-respec-impact-set.sh\n' \
+  >>"$exec_echo_only/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$exec_echo_only" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$exec_echo_only"
+
+bash_command_echo="$(make_candidate bash-command-echo)"
+printf "\nbash -c 'echo scripts/check-respec-impact-set.sh'\n" \
+  >>"$bash_command_echo/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$bash_command_echo" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$bash_command_echo"
+
+prefix_collision="$(make_candidate prefix-collision)"
+printf '\nbash scripts/not-check-respec-impact-set.sh\n' \
+  >>"$prefix_collision/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$prefix_collision" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$prefix_collision"
+
+suffix_collision="$(make_candidate suffix-collision)"
+printf '\nbash scripts/check-respec-impact-set.sh-not\n' \
+  >>"$suffix_collision/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$suffix_collision" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$suffix_collision"
+
+variable_prefix_collision="$(make_candidate variable-prefix-collision)"
+printf '\nfake_checker="scripts/not-check-respec-impact-set.sh"\nbash "$fake_checker"\n' \
+  >>"$variable_prefix_collision/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$variable_prefix_collision" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$variable_prefix_collision"
+
+variable_suffix_collision="$(make_candidate variable-suffix-collision)"
+printf '\nfake_checker="scripts/check-respec-impact-set.sh-not"\nbash "$fake_checker"\n' \
+  >>"$variable_suffix_collision/skills/implementaudit/scripts/detect-env.sh"
+mutate_route "$variable_suffix_collision" check-respec-impact-set.sh 4 scripts/detect-env.sh
+expect_fail R30-F11 \
+  'caller does not invoke check-respec-impact-set.sh: scripts/detect-env.sh' \
+  "$variable_suffix_collision"
+
+mandatory_advisory="$(make_candidate mandatory-advisory)"
+mutate_route "$mandatory_advisory" lane-survivor-inventory.sh 6 must-block-closure
+expect_fail R30-F8 'advisory/standalone row implies mandatory enforcement: lane-survivor-inventory.sh' "$mandatory_advisory"
+
+owner_overclaim="$(make_candidate owner-overclaim)"
+printf '\nlane-survivor-inventory.sh\nmust gate closure.\n' \
+  >>"$owner_overclaim/skills/implementaudit/references/child-agents.md"
+expect_fail R30-F8 \
+  'advisory owner overclaim: lane-survivor-inventory.sh' \
+  "$owner_overclaim"
+
+future_helper="$(make_candidate future-helper)"
+cp "$future_helper/skills/implementaudit/scripts/detect-stack.sh" \
+  "$future_helper/skills/implementaudit/scripts/future-helper.sh"
+python - "$future_helper/scripts/build-release-asset.sh" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    '    "skills/implementaudit/scripts/validate-run-root.sh",',
+    '    "skills/implementaudit/scripts/validate-run-root.sh",\n'
+    '    "skills/implementaudit/scripts/future-helper.sh",',
+    1,
+)
+text = text.replace(
+    '    "scripts/validate-run-root.sh",',
+    '    "scripts/validate-run-root.sh",\n'
+    '    "scripts/future-helper.sh",',
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
+expect_fail R30-F20 'missing applicability rows: future-helper.sh (population=19 examined=18)' "$future_helper"
+
+extra_row="$(make_candidate extra-row)"
+printf '%s\n' \
+  'helper-route: ghost-helper.sh|S|owner-diagnosis|R|-|none|never-automatic' \
+  >>"$extra_row/skills/implementaudit/references/repo-state-comparison.md"
+expect_fail R30-F11 'applicability rows not in package: ghost-helper.sh' "$extra_row"
+
+printf 'helper-reachability.test: ok (derived 18/18 + R30-F1-F5/F8/F11/F20 controls)\n'


### PR DESCRIPTION
## Summary

- derive the shipped helper population from the canonical release-asset owner;
- require exactly one closed reachability disposition for every packaged helper;
- bind automatic routes to a real shipped caller and required routes to an exact natural-owner command;
- preserve advisory/non-acting boundaries and fail closed on missing or newly packaged helpers;
- register the gate in local verification and hosted CI;
- retain the underlying scorer diagnostic when a positive closure fixture fails, so qualification abnormalities are classifiable rather than generic.

This is the first PR in the ordered #157 → #144 → #158 → #155 train. It does not close #157: final composed installed-runtime dogfood, hosted checks, and release/public readbacks remain issue-level acceptance gates.

Relates to #157.

## Verification

- `bash scripts/check-planner-stages.sh`
- `bash tests/helper-reachability.test.sh`
- `bash tests/payload-path-hygiene.test.sh`
- `bash tests/source-evidence-pack-runnable.test.sh`
- `bash tests/release-asset.test.sh`
- `bash scripts/build-release-asset.sh --check`
- `bash scripts/verify-package.sh` — `VERIFY_PACKAGE_EXIT=0`, terminal `verify-package: ok`
- independent cold review PASS on exact tree `8b2045948016f3a72d830d4413c5630b4a488738`
- independent metadata-only rebind PASS on commit `2790cb364ea1a5f33d6118e91b9b60c3be8bfc5c`

Candidate package before hosted checks: 215,987 bytes, 49 members, 18 helpers, zero `/dashboard/` members, 2,013 bytes of policy headroom, SHA-256 `59d9f1665001d888dcf68a680b7802565797ff9a9b3d19830b8f3e60a19e32d1`.

## Boundaries

- no change to the published `v0.3.3.0` tag, release, or assets;
- no #117/R28 dashboard mutation or package inclusion;
- no implementation of #144, #155, or #158 in this PR;
- no issue auto-closure from this PR.