### PR TITLE
Support v0.3.3.3 family-forward release identity

### DIFF
--- a/docs/portal/site.json
+++ b/docs/portal/site.json
@@ -5,12 +5,6 @@
     "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0",
     "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md",
     "status": "v0.3.3.0 is published; its tag, release assets, checksum, hosted validation, Pages deployment, and tracker closure were independently read back. Repo-generic dogfood follow-up #155 remains open and nonblocking; these checks establish publication and artifact integrity, not signature, attestation, marketplace, or provenance claims",
-    "last_release_gate_verified_public_release": {
-      "milestone": "v0.3.3.0",
-      "manifest_version": "0.3.3",
-      "url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/releases/tag/v0.3.3.0",
-      "audit_ledger_url": "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md"
-    },
     "checksum_boundary": "release-body SHA-256 digest supports artifact-integrity readback and may support a separately authorized provenance gate"
   },
   "semantic_sources": [

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "72870fe420fe895a5f35e1b92b73b6dfb11d679c945749f86b1d928d18ecc878",
+    "builder_sha256": "772f289ab21aa85380ff02d7ba8803a0fb3acde3af3ac70b414f52c2706f6faf",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",

--- a/scripts/build-docs-portal.py
+++ b/scripts/build-docs-portal.py
@@ -160,13 +160,26 @@ def plugin_version(root: Path) -> str:
         return "unknown"
 
 
-def project_milestone(version: str) -> str:
-    if version == "unknown":
-        return "unknown"
-    parts = version.split(".")
-    if len(parts) == 3:
-        return f"v{parts[0]}.{parts[1]}.{parts[2]}.0"
-    return f"v{version}"
+def validate_project_milestone(milestone: str, runtime_version: str) -> None:
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", runtime_version):
+        raise SystemExit("site release manifest_version must use three numeric components")
+    match = re.fullmatch(r"v([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)", milestone)
+    if not match:
+        raise SystemExit("site release milestone must be v-prefixed with four numeric components")
+    if match.group(1) != runtime_version:
+        raise SystemExit(
+            f"site release milestone {milestone!r} does not belong to runtime family {runtime_version}"
+        )
+
+
+def validate_release_ledger(milestone: str, audit_ledger_url: str) -> None:
+    ledger_name = audit_ledger_url.strip().rstrip("/").rsplit("/", 1)[-1]
+    expected_ledger_name = f"{milestone}-release-report.md"
+    if ledger_name != expected_ledger_name:
+        raise SystemExit(
+            f"site release audit_ledger_url must name a non-placeholder "
+            f"{milestone} markdown ledger"
+        )
 
 
 def load_site(source_dir: Path) -> tuple[list[dict], dict]:
@@ -269,7 +282,9 @@ def release_info(site: dict, root: Path) -> dict:
     if release.get("manifest_version") in (None, "unknown"):
         release["manifest_version"] = version
     if release.get("milestone") in (None, "unknown"):
-        release["milestone"] = project_milestone(str(release["manifest_version"]))
+        raise SystemExit("docs/portal/site.json must declare an explicit release milestone")
+    validate_project_milestone(str(release["milestone"]), str(release["manifest_version"]))
+    validate_release_ledger(str(release["milestone"]), str(release.get("audit_ledger_url", "")))
     return release
 
 
@@ -617,8 +632,8 @@ def build_portal(out_dir: Path) -> None:
         "worktree_state": worktree_state,
         "worktree_dirty": worktree_state == "dirty",
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "project_milestone": project_milestone(version),
-        "plugin_manifest_version": version,
+        "project_milestone": release["milestone"],
+        "plugin_manifest_version": release["manifest_version"],
         "release_url": release.get("url", REPO_URL),
         "audit_ledger_url": release.get("audit_ledger_url", DEFAULT_RELEASE["audit_ledger_url"]),
         "checksum_boundary": release.get("checksum_boundary", DEFAULT_RELEASE["checksum_boundary"]),

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -23,11 +23,22 @@ asset_name="IMPLEMENTAUDIT.skill"
 cleanup_dir=""
 
 check_release_identity() {
-  local mode="${1:-}" previous_version="${2:-}" release_commit="${3:-}" check_root="${4:-$repo_root}"
-  local candidate_asset="${5:-$check_root/$asset_name}"
-  [ -n "$mode" ] && [ -n "$previous_version" ] && [ -n "$release_commit" ] \
-    || fail "--check-release-identity requires <forward|republish> <previous-version> <release-commit> [repo-root] [candidate-asset]"
-  "${py_cmd[@]}" - "$mode" "$previous_version" "$release_commit" "$check_root" "$candidate_asset" <<'PY'
+  local mode="${1:-}" previous_identity="${2:-}" candidate_identity="" release_commit="" check_root="" candidate_asset=""
+  if [ "$mode" = "family-forward" ]; then
+    candidate_identity="${3:-}"
+    release_commit="${4:-}"
+    check_root="${5:-$repo_root}"
+    candidate_asset="${6:-$check_root/$asset_name}"
+    [ -n "$previous_identity" ] && [ -n "$candidate_identity" ] && [ -n "$release_commit" ] \
+      || fail "--check-release-identity family-forward requires <previous-tag> <candidate-tag> <release-commit> [repo-root] [candidate-asset]"
+  else
+    release_commit="${3:-}"
+    check_root="${4:-$repo_root}"
+    candidate_asset="${5:-$check_root/$asset_name}"
+    [ -n "$mode" ] && [ -n "$previous_identity" ] && [ -n "$release_commit" ] \
+      || fail "--check-release-identity requires <forward|republish> <previous-version> <release-commit> [repo-root] [candidate-asset]"
+  fi
+  "${py_cmd[@]}" - "$mode" "$previous_identity" "$candidate_identity" "$release_commit" "$check_root" "$candidate_asset" <<'PY'
 import hashlib
 import json
 import re
@@ -35,10 +46,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-mode, previous_version, release_commit, root_arg, candidate_arg = sys.argv[1:]
+mode, previous_identity, candidate_identity, release_commit, root_arg, candidate_arg = sys.argv[1:]
 root = Path(root_arg).resolve()
-if mode not in {"forward", "republish"}:
-    raise SystemExit("prospective release identity mode must be forward or republish")
+if mode not in {"forward", "republish", "family-forward"}:
+    raise SystemExit("prospective release identity mode must be forward, republish, or family-forward")
 
 plugin_path = root / ".claude-plugin" / "plugin.json"
 skill_path = root / "skills" / "implementaudit" / "SKILL.md"
@@ -46,6 +57,7 @@ changelog_path = root / "CHANGELOG.md"
 for path in (plugin_path, skill_path, changelog_path):
     if not path.is_file():
         raise SystemExit(f"release identity owner is missing: {path}")
+portal_path = root / "docs" / "portal" / "site.json"
 
 plugin_version = str(json.loads(plugin_path.read_text(encoding="utf-8")).get("version", "")).strip()
 skill_text = skill_path.read_text(encoding="utf-8")
@@ -68,24 +80,72 @@ def normalized_heading(value: str) -> str:
     return ".".join(parts)
 
 
+heading_values = re.findall(
+    r"(?m)^## \[v?([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)(?: [^\]]+)?\]",
+    changelog_path.read_text(encoding="utf-8"),
+)
 headings = [
     normalized_heading(value)
-    for value in re.findall(
-        r"(?m)^## \[v?([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)(?: [^\]]+)?\]",
-        changelog_path.read_text(encoding="utf-8"),
-    )
+    for value in heading_values
 ]
 distinct_headings = list(dict.fromkeys(headings))
 if not distinct_headings:
     raise SystemExit("CHANGELOG.md has no published version heading")
-if mode == "forward":
+if mode == "family-forward":
+    if not portal_path.is_file():
+        raise SystemExit(f"release identity owner is missing: {portal_path}")
+    portal_release = json.loads(portal_path.read_text(encoding="utf-8")).get("release", {})
+    portal_milestone = str(portal_release.get("milestone", "")).strip()
+    if candidate_identity != portal_milestone:
+        raise SystemExit(
+            f"family-forward candidate tag {candidate_identity!r} != "
+            f"docs/portal/site.json milestone {portal_milestone!r}"
+        )
+    portal_ledger = str(portal_release.get("audit_ledger_url", "")).strip()
+    ledger_name = portal_ledger.rstrip("/").rsplit("/", 1)[-1]
+    expected_ledger_name = f"{candidate_identity}-release-report.md"
+    if ledger_name != expected_ledger_name:
+        raise SystemExit(
+            f"docs/portal/site.json audit ledger must name a non-placeholder "
+            f"{candidate_identity} markdown ledger"
+        )
+    public_tag_pattern = re.compile(r"v([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)")
+    previous_match = public_tag_pattern.fullmatch(previous_identity)
+    candidate_match = public_tag_pattern.fullmatch(candidate_identity)
+    if not previous_match or not candidate_match:
+        raise SystemExit("family-forward release identities must be v-prefixed with four numeric components")
+    previous_family = ".".join(previous_match.groups()[:3])
+    candidate_family = ".".join(candidate_match.groups()[:3])
+    if previous_family != plugin_version or candidate_family != plugin_version:
+        raise SystemExit(
+            f"family-forward tags must remain in runtime family {plugin_version}: "
+            f"previous={previous_identity!r} candidate={candidate_identity!r}"
+        )
+    if candidate_identity == previous_identity:
+        raise SystemExit("family-forward candidate tag must differ from the previous public tag")
+    if candidate_match.group(4) == "0":
+        raise SystemExit("family-forward candidate tag must use a non-zero fourth component")
+    if int(candidate_match.group(4)) <= int(previous_match.group(4)):
+        raise SystemExit("family-forward candidate fourth component must be greater than the previous tag")
+    changelog_text = changelog_path.read_text(encoding="utf-8")
+    candidate_heading = re.compile(
+        rf"(?m)^## \[{re.escape(candidate_identity)}\](?:\s+-\s+[^\n]+)?\s*$"
+    )
+    if not candidate_heading.search(changelog_text):
+        raise SystemExit("CHANGELOG.md does not contain exact candidate release heading")
+    public_headings = list(dict.fromkeys(f"v{value}" for value in heading_values if value.count(".") == 3))
+    if not public_headings or public_headings[0] != candidate_identity:
+        raise SystemExit("family-forward candidate tag must be the first public CHANGELOG heading")
+    prior_public_headings = [value for value in public_headings if value != candidate_identity]
+    authoritative_previous = prior_public_headings[0] if prior_public_headings else ""
+elif mode == "forward":
     candidates = [value for value in distinct_headings if value != plugin_version]
     authoritative_previous = candidates[0] if candidates else ""
 else:
     authoritative_previous = distinct_headings[0]
-if previous_version != authoritative_previous:
+if previous_identity != authoritative_previous:
     raise SystemExit(
-        f"declared previous version {previous_version!r} != CHANGELOG authority {authoritative_previous!r}"
+        f"declared previous identity {previous_identity!r} != CHANGELOG authority {authoritative_previous!r}"
     )
 
 resolved = subprocess.run(
@@ -97,6 +157,27 @@ resolved = subprocess.run(
 if resolved.returncode != 0:
     raise SystemExit("release identity commit does not resolve")
 commit_sha = resolved.stdout.strip()
+owner_relpaths = [
+    ".claude-plugin/plugin.json",
+    "skills/implementaudit/SKILL.md",
+    "CHANGELOG.md",
+]
+if mode == "family-forward":
+    owner_relpaths.append("docs/portal/site.json")
+for owner_relpath in owner_relpaths:
+    committed_owner = subprocess.run(
+        ["git", "-C", str(root), "show", f"{commit_sha}:{owner_relpath}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if committed_owner.returncode != 0:
+        raise SystemExit(
+            f"release identity owner {owner_relpath} is missing from release commit {commit_sha}"
+        )
+    if (root / owner_relpath).read_bytes() != committed_owner.stdout:
+        raise SystemExit(
+            f"release identity owner {owner_relpath} does not match release commit {commit_sha}"
+        )
 commit_tree = subprocess.run(
     ["git", "-C", str(root), "rev-parse", f"{commit_sha}^{{tree}}"],
     check=True,
@@ -119,13 +200,20 @@ if ancestor.returncode != 0:
 if commit_tree != head_tree:
     raise SystemExit("release identity commit tree must equal current HEAD tree")
 
-if mode == "forward":
-    if plugin_version == previous_version:
-        raise SystemExit("forward release must change the prior published version")
-    print(f"build-release-asset: release identity forward {previous_version} -> {plugin_version} at {commit_sha}")
+if mode == "family-forward":
+    print(
+        f"build-release-asset: release identity family-forward "
+        f"{previous_identity} -> {candidate_identity} (runtime {plugin_version}) at {commit_sha}"
+    )
     raise SystemExit(0)
 
-if plugin_version != previous_version:
+if mode == "forward":
+    if plugin_version == previous_identity:
+        raise SystemExit("forward release must change the prior published version")
+    print(f"build-release-asset: release identity forward {previous_identity} -> {plugin_version} at {commit_sha}")
+    raise SystemExit(0)
+
+if plugin_version != previous_identity:
     raise SystemExit("same-version republication must retain the prior published version")
 
 candidate_path = Path(candidate_arg)

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -13,14 +13,21 @@ release_identity_args=()
 release_identity_tmp=""
 trap 'if [ -n "${release_identity_tmp:-}" ]; then rm -rf "$release_identity_tmp"; fi' EXIT
 if [ "${1:-}" = "--release-identity" ]; then
-  [ "$#" -eq 4 ] \
-    || fail "--release-identity requires <forward|republish> <previous-version> <release-commit>"
   case "$2" in
-    forward|republish) : ;;
-    *) fail "--release-identity mode must be forward or republish" ;;
+    family-forward)
+      [ "$#" -eq 5 ] \
+        || fail "--release-identity family-forward requires <previous-tag> <candidate-tag> <release-commit>"
+      release_identity_args=("$2" "$3" "$4" "$5")
+      shift 5
+      ;;
+    forward|republish)
+      [ "$#" -eq 4 ] \
+        || fail "--release-identity requires <forward|republish> <previous-version> <release-commit>"
+      release_identity_args=("$2" "$3" "$4")
+      shift 4
+      ;;
+    *) fail "--release-identity mode must be forward, republish, or family-forward" ;;
   esac
-  release_identity_args=("$2" "$3" "$4")
-  shift 4
 fi
 [ "$#" -eq 0 ] || fail "unknown argument: $1"
 
@@ -442,6 +449,7 @@ PY
 
 "${py_cmd[@]}" - <<'PY'
 import json
+import re
 from pathlib import Path
 
 plugin = json.loads(Path(".claude-plugin/plugin.json").read_text())
@@ -455,7 +463,7 @@ if plugin.get("skills") != "./skills/":
 if not plugin.get("version"):
     raise SystemExit("plugin version is required")
 if plugin.get("version") != "0.3.3":
-    raise SystemExit("plugin version must be 0.3.3 for the v0.3.3.0 project milestone")
+    raise SystemExit("plugin version must be 0.3.3 for the v0.3.3 runtime family")
 
 marketplace = json.loads(Path(".claude-plugin/marketplace.json").read_text())
 plugins = marketplace.get("plugins")
@@ -466,19 +474,28 @@ if plugins[0].get("source") != "./":
 if "path" in plugins[0]:
     raise SystemExit("source marketplace entry must not use archive-only path")
 
-# Public version-claim truth: README's "Version and release notes" claim must
-# match the live manifest. The other version pins are checker-enforced; this
-# line drifted silently at v0.2.9.0 because nothing derived it from the
-# manifest.
+# Public version-claim truth: the portal site owns the four-component project
+# milestone while the plugin manifest owns the three-component runtime family.
+# README must project both identities without synthesising the public tag from
+# the runtime version.
 readme = Path("README.md").read_text(encoding="utf-8")
 version = plugin["version"]
+site = json.loads(Path("docs/portal/site.json").read_text(encoding="utf-8"))
+milestone = str(site.get("release", {}).get("milestone", "")).strip()
+milestone_match = re.fullmatch(r"v([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)", milestone)
+if not milestone_match:
+    raise SystemExit("docs/portal/site.json release milestone must be v-prefixed with four numeric components")
+if milestone_match.group(1) != version:
+    raise SystemExit(
+        f"docs/portal/site.json release milestone {milestone!r} does not belong to runtime family {version}"
+    )
 claim_lines = [l for l in readme.splitlines() if "Current project milestone:" in l]
 if not claim_lines:
     raise SystemExit("README must state 'Current project milestone:' in Version and release notes")
 for line in claim_lines:
-    if f"v{version}.0" not in line or f"`{version}`" not in line:
+    if f"`{milestone}`" not in line or f"`{version}`" not in line:
         raise SystemExit(
-            f"README version claim does not match manifest {version}: {line.strip()}"
+            f"README version claim does not match milestone {milestone} and manifest {version}: {line.strip()}"
         )
 PY
 

--- a/tests/docs-portal.test.sh
+++ b/tests/docs-portal.test.sh
@@ -131,6 +131,121 @@ else
   fail_check "metadata/site nav/page shell mismatch"
 fi
 
+if "${py_cmd[@]}" - "$tmp/portal-release-identity" <<'PY'
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+source_root = Path.cwd()
+fixture_root = Path(sys.argv[1])
+shutil.copytree(source_root / "docs" / "portal", fixture_root / "docs" / "portal")
+(fixture_root / "scripts").mkdir(parents=True)
+shutil.copy2(source_root / "scripts" / "build-docs-portal.py", fixture_root / "scripts" / "build-docs-portal.py")
+
+site_path = fixture_root / "docs" / "portal" / "site.json"
+site = json.loads(site_path.read_text(encoding="utf-8"))
+rel_sources = set(site.get("semantic_sources", []))
+for page in site["pages"].values():
+    rel_sources.update(page.get("sources", []))
+rel_sources.add(".claude-plugin/plugin.json")
+for rel in rel_sources:
+    source = source_root / rel
+    target = fixture_root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+site["release"]["milestone"] = "v0.3.3.3"
+site["release"]["manifest_version"] = "0.3.3"
+site["release"]["audit_ledger_url"] = (
+    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/"
+    "docs/audits/archive/v0.3.3.3-release-report.md"
+)
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+valid = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert valid.returncode == 0, valid.stderr
+metadata = json.loads((fixture_root / "dist" / "docs-portal" / "docs-metadata.json").read_text(encoding="utf-8"))
+assert metadata["project_milestone"] == "v0.3.3.3", metadata["project_milestone"]
+
+site["release"]["milestone"] = "v0.3.4.3"
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+wrong_family = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert wrong_family.returncode != 0
+assert "does not belong to runtime family 0.3.3" in wrong_family.stderr
+
+site["release"]["milestone"] = "v0.3.3.3"
+site["release"]["audit_ledger_url"] = (
+    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/"
+    "docs/audits/archive/v0.3.3.0-release-report.md"
+)
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+stale_ledger = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert stale_ledger.returncode != 0, "generator accepted a v0.3.3.0 audit ledger for v0.3.3.3"
+assert "must name a non-placeholder v0.3.3.3 markdown ledger" in stale_ledger.stderr
+
+site["release"]["audit_ledger_url"] = "unknown"
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+placeholder_ledger = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert placeholder_ledger.returncode != 0, "generator accepted a placeholder audit ledger"
+assert "must name a non-placeholder v0.3.3.3 markdown ledger" in placeholder_ledger.stderr
+
+site["release"]["audit_ledger_url"] = (
+    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/"
+    "docs/audits/archive/placeholder-v0.3.3.3-TBD.md"
+)
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+exact_tag_placeholder_ledger = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert exact_tag_placeholder_ledger.returncode != 0, (
+    "generator accepted placeholder-v0.3.3.3-TBD.md instead of the canonical ledger basename"
+)
+assert "must name a non-placeholder v0.3.3.3 markdown ledger" in exact_tag_placeholder_ledger.stderr
+
+site["release"]["audit_ledger_url"] = (
+    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/"
+    "docs/audits/archive/v0.3.3.30-release-report.md"
+)
+site_path.write_text(json.dumps(site, indent=2) + "\n", encoding="utf-8")
+prefix_collision_ledger = subprocess.run(
+    [sys.executable, str(fixture_root / "scripts" / "build-docs-portal.py"), "--out", str(fixture_root / "dist" / "docs-portal")],
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+assert prefix_collision_ledger.returncode != 0, "generator accepted a v0.3.3.30 ledger for v0.3.3.3"
+assert "must name a non-placeholder v0.3.3.3 markdown ledger" in prefix_collision_ledger.stderr
+PY
+then
+  ok "explicit portal milestone and matching non-placeholder ledger control release metadata"
+else
+  fail_check "portal release milestone, runtime-family, or audit-ledger validation failed"
+fi
+
 if "${py_cmd[@]}" - "$out" <<'PY'
 import sys
 from pathlib import Path
@@ -352,13 +467,16 @@ fi
 
 cp -R "$out" "$bad_overview_release"
 "${py_cmd[@]}" - "$bad_overview_release/index.html" <<'PY'
+import json
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
+current_ledger = json.loads(Path("docs/portal/site.json").read_text(encoding="utf-8"))["release"]["audit_ledger_url"]
+assert current_ledger in text
 text = text.replace(
-    "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.0-release-report.md",
+    current_ledger,
     "https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.2.9.0-andon-escalation-jidoka-repair.md",
 )
 path.write_text(text, encoding="utf-8")

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -18,11 +18,11 @@ if [ "${1:-}" = "--identity-only" ]; then
   b_digest='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 
   make_fixture() {
-    local root="$1" version="$2"
+    local root="$1" version="$2" previous_tag="${3:-v0.3.2.0}"
     mkdir -p "$root/.claude-plugin" "$root/skills/implementaudit"
     printf '{"version":"%s"}\n' "$version" > "$root/.claude-plugin/plugin.json"
     printf '%s\n' '---' 'metadata:' "  version: \"$version\"" '---' > "$root/skills/implementaudit/SKILL.md"
-    printf '# Changelog\n\n## [v0.3.2.0] - 2026-07-18\n' > "$root/CHANGELOG.md"
+    printf '# Changelog\n\n## [%s] - 2026-07-18\n' "$previous_tag" > "$root/CHANGELOG.md"
     printf 'original payload\n' > "$root/payload.txt"
     printf 'original package\n' > "$root/IMPLEMENTAUDIT.skill"
     git -C "$root" init -q
@@ -30,6 +30,25 @@ if [ "${1:-}" = "--identity-only" ]; then
     git -C "$root" config user.name t
     git -C "$root" add .
     git -C "$root" -c user.email=t@example.invalid -c user.name=t commit -qm initial
+  }
+
+  make_family_forward_fixture() {
+    local root="$1" runtime_version="$2" previous_tag="$3" candidate_tag="$4"
+    local site_milestone="${5:-$candidate_tag}"
+    local ledger_milestone="${6:-$site_milestone}"
+    local ledger_name="${7:-${ledger_milestone}-release-report.md}"
+    make_fixture "$root" "$runtime_version" "$previous_tag"
+    mkdir -p "$root/docs/portal"
+    printf '{"release":{"milestone":"%s","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/%s"}}\n' \
+      "$site_milestone" "$ledger_name" > "$root/docs/portal/site.json"
+    printf 'changed payload\n' > "$root/payload.txt"
+    {
+      printf '# Changelog\n\n## [%s] - 2026-08-10\n- Corrective and completion release.\n\n' "$candidate_tag"
+      tail -n +3 "$root/CHANGELOG.md"
+    } > "$root/CHANGELOG.md.next"
+    mv "$root/CHANGELOG.md.next" "$root/CHANGELOG.md"
+    git -C "$root" add payload.txt CHANGELOG.md docs/portal/site.json
+    git -C "$root" -c user.email=t@example.invalid -c user.name=t commit -qm family-forward
   }
 
   no_record="$tmp_parent/republish-no-record"
@@ -119,6 +138,146 @@ if [ "${1:-}" = "--identity-only" ]; then
       forward 0.2.0 HEAD "$forward" >/dev/null 2>&1; then
     fail 'caller-supplied non-current previous version bypassed CHANGELOG authority'
   fi
+
+  family_forward="$tmp_parent/family-forward"
+  make_family_forward_fixture "$family_forward" 0.3.3 v0.3.3.0 v0.3.3.3
+  bash scripts/build-release-asset.sh --check-release-identity \
+    family-forward v0.3.3.0 v0.3.3.3 HEAD "$family_forward" >/dev/null \
+    || fail 'valid v0.3.3.3 public identity for runtime 0.3.3 was rejected'
+
+  dirty_candidate_owners="$tmp_parent/family-forward-dirty-candidate-owners"
+  make_fixture "$dirty_candidate_owners" 0.3.3 v0.3.3.0
+  printf '\n' >> "$dirty_candidate_owners/.claude-plugin/plugin.json"
+  printf '\n' >> "$dirty_candidate_owners/skills/implementaudit/SKILL.md"
+  mkdir -p "$dirty_candidate_owners/docs/portal"
+  printf '{"release":{"milestone":"v0.3.3.3","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.3-release-report.md"}}\n' \
+    > "$dirty_candidate_owners/docs/portal/site.json"
+  {
+    printf '# Changelog\n\n## [v0.3.3.3] - 2026-08-10\n- Corrective and completion release.\n\n'
+    tail -n +3 "$dirty_candidate_owners/CHANGELOG.md"
+  } > "$dirty_candidate_owners/CHANGELOG.md.next"
+  mv "$dirty_candidate_owners/CHANGELOG.md.next" "$dirty_candidate_owners/CHANGELOG.md"
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$dirty_candidate_owners" >/dev/null 2>&1; then
+    fail 'family-forward accepted dirty candidate owners absent from the v0.3.3.0 release commit'
+  fi
+
+  for dirty_owner in \
+      .claude-plugin/plugin.json \
+      skills/implementaudit/SKILL.md \
+      CHANGELOG.md \
+      docs/portal/site.json; do
+    owner_slug="$(printf '%s' "$dirty_owner" | tr '/.' '--')"
+    dirty_owner_root="$tmp_parent/family-forward-dirty-owner-$owner_slug"
+    make_family_forward_fixture "$dirty_owner_root" 0.3.3 v0.3.3.0 v0.3.3.3
+    printf '\n' >> "$dirty_owner_root/$dirty_owner"
+    if bash scripts/build-release-asset.sh --check-release-identity \
+        family-forward v0.3.3.0 v0.3.3.3 HEAD "$dirty_owner_root" >/dev/null 2>&1; then
+      fail "family-forward accepted dirty release identity owner $dirty_owner"
+    fi
+  done
+
+  backward_9_to_3="$tmp_parent/family-forward-backward-9-to-3"
+  make_family_forward_fixture "$backward_9_to_3" 0.3.3 v0.3.3.9 v0.3.3.3
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.9 v0.3.3.3 HEAD "$backward_9_to_3" >/dev/null 2>&1; then
+    fail 'family-forward accepted v0.3.3.9 -> v0.3.3.3 rollback'
+  fi
+
+  backward_3_to_2="$tmp_parent/family-forward-backward-3-to-2"
+  make_family_forward_fixture "$backward_3_to_2" 0.3.3 v0.3.3.3 v0.3.3.2
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.3 v0.3.3.2 HEAD "$backward_3_to_2" >/dev/null 2>&1; then
+    fail 'family-forward accepted v0.3.3.3 -> v0.3.3.2 rollback'
+  fi
+
+  site_mismatch="$tmp_parent/family-forward-site-mismatch"
+  make_family_forward_fixture "$site_mismatch" 0.3.3 v0.3.3.0 v0.3.3.3 v0.3.3.2
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$site_mismatch" >/dev/null 2>&1; then
+    fail 'family-forward accepted a candidate tag different from docs/portal/site.json milestone'
+  fi
+
+  stale_ledger="$tmp_parent/family-forward-stale-ledger"
+  make_family_forward_fixture "$stale_ledger" 0.3.3 v0.3.3.0 v0.3.3.3 v0.3.3.3 v0.3.3.0
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$stale_ledger" >/dev/null 2>&1; then
+    fail 'family-forward accepted a v0.3.3.0 audit ledger for v0.3.3.3'
+  fi
+
+  prefix_collision_ledger="$tmp_parent/family-forward-prefix-collision-ledger"
+  make_family_forward_fixture "$prefix_collision_ledger" 0.3.3 v0.3.3.0 v0.3.3.3 v0.3.3.3 v0.3.3.30
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$prefix_collision_ledger" >/dev/null 2>&1; then
+    fail 'family-forward accepted a v0.3.3.30 audit ledger for v0.3.3.3'
+  fi
+
+  exact_tag_placeholder_ledger="$tmp_parent/family-forward-exact-tag-placeholder-ledger"
+  make_family_forward_fixture "$exact_tag_placeholder_ledger" 0.3.3 v0.3.3.0 v0.3.3.3 \
+    v0.3.3.3 v0.3.3.3 placeholder-v0.3.3.3-TBD.md
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$exact_tag_placeholder_ledger" >/dev/null 2>&1; then
+    fail 'family-forward accepted placeholder-v0.3.3.3-TBD.md instead of the canonical ledger basename'
+  fi
+
+  wrong_family="$tmp_parent/family-forward-wrong-family"
+  make_family_forward_fixture "$wrong_family" 0.3.3 v0.3.3.0 v0.3.4.3
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.4.3 HEAD "$wrong_family" >/dev/null 2>&1; then
+    fail 'family-forward accepted a candidate tag outside runtime 0.3.3'
+  fi
+
+  zero_suffix="$tmp_parent/family-forward-zero-suffix"
+  make_family_forward_fixture "$zero_suffix" 0.3.3 v0.3.3.2 v0.3.3.0
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.2 v0.3.3.0 HEAD "$zero_suffix" >/dev/null 2>&1; then
+    fail 'family-forward accepted a zero fourth-component candidate tag'
+  fi
+
+  equal_tag="$tmp_parent/family-forward-equal-tag"
+  make_family_forward_fixture "$equal_tag" 0.3.3 v0.3.3.3 v0.3.3.3
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.3 v0.3.3.3 HEAD "$equal_tag" >/dev/null 2>&1; then
+    fail 'family-forward accepted an unchanged public tag'
+  fi
+
+  missing_heading="$tmp_parent/family-forward-missing-heading"
+  make_fixture "$missing_heading" 0.3.3 v0.3.3.0
+  printf 'changed payload\n' > "$missing_heading/payload.txt"
+  git -C "$missing_heading" add payload.txt
+  git -C "$missing_heading" -c user.email=t@example.invalid -c user.name=t commit -qm family-forward
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$missing_heading" >/dev/null 2>&1; then
+    fail 'family-forward accepted a candidate without an exact CHANGELOG heading'
+  fi
+
+  four_component_runtime="$tmp_parent/family-forward-four-component-runtime"
+  make_family_forward_fixture "$four_component_runtime" 0.3.3.3 v0.3.3.0 v0.3.3.3
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$four_component_runtime" >/dev/null 2>&1; then
+    fail 'family-forward accepted a four-component runtime version'
+  fi
+
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.3 HEAD "$family_forward" >/dev/null 2>&1; then
+    fail 'republish substituted for a family-forward release'
+  fi
+
+  family_forward_commit="$(git -C "$family_forward" rev-parse HEAD)"
+  printf 'moved head\n' >> "$family_forward/payload.txt"
+  git -C "$family_forward" add payload.txt
+  git -C "$family_forward" -c user.email=t@example.invalid -c user.name=t commit -qm moved-head
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 "$family_forward_commit" "$family_forward" >/dev/null 2>&1; then
+    fail 'family-forward accepted a candidate commit after HEAD moved'
+  fi
+
+  verify_output="$(bash scripts/verify-package.sh --release-identity \
+    family-forward v0.3.3.0 v0.3.3.3 HEAD 2>&1 || true)"
+  case "$verify_output" in
+    *"family-forward candidate tag 'v0.3.3.3' != docs/portal/site.json milestone 'v0.3.3.0'"*) : ;;
+    *) fail 'verify-package.sh did not expose family-forward identity mode' ;;
+  esac
 
   real_record_commit="$(git log -1 --format=%H -S 'This entry is the one retroactive application' -- CHANGELOG.md)"
   [ -n "$real_record_commit" ] || fail 'real #96 retroactive digest-pair commit not found'


### PR DESCRIPTION
## What changed

Adds an explicit `family-forward` release-identity mode for corrective fourth-component publications such as `v0.3.3.0` to `v0.3.3.3` while the loaded plugin/runtime manifest remains `0.3.3`.

The change:

- preserves the existing `forward` and `republish` modes;
- requires a strictly increasing fourth component within the manifest's three-component runtime family;
- binds the candidate tag to the first public CHANGELOG heading and the explicit docs-portal milestone;
- requires the canonical `<milestone>-release-report.md` ledger owner;
- binds plugin, skill, CHANGELOG, and portal owner bytes to the resolved release commit;
- stops synthesising a four-component public milestone from the runtime manifest;
- removes an unused duplicate portal release object.

## Why

`v0.3.3.3` is a corrective and completion publication of the `0.3.3` runtime family. The previous release machinery only represented a runtime-version advance or same-version republication, so it could not truthfully validate this distinct public identity.

## Validation

- `bash tests/release-asset.test.sh --identity-only`
- `bash tests/docs-portal.test.sh` (`36/36`)
- `bash tests/release-asset.test.sh`
- Bash syntax, Python AST, JSON parse, and `git diff --check`
- Fresh exact-tree independent review: PASS
- Package invariant: 227,995 bytes, SHA-256 `bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536`, 2,005 bytes headroom under 230,000

This PR prepares the release mechanism only. It does not publish, tag, close issues, change runtime version `0.3.3`, or include R36/#167.