### PR TITLE
fix(release): qualify same-tag merge identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ download/install readback gates.
   `509660798` (`IMPLEMENTAUDIT.skill`) and `509660797` (`CHECKSUMS.txt`). The
   original release body had SHA-256
   `21e7e7b379dbf9a312643186e749d4fb5bd97cdbdde3ad162e3f42f77da6751e`.
-- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536` (227,995 bytes) → final `151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e` (227,999 bytes).
+- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536` (227,995 bytes) -> final `151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e` (227,999 bytes).
 - The corrected candidate contains 50 members, excludes `/dashboard/`, and
   leaves 2,001 bytes under the unchanged 230,000-byte owner bound. Focused
   R29/R30/R33/R35, package, source/package parity, temporary-install, and

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "f3fa7a3ec44f330ac9ffe4687169426b4edcdace08d33b9834da5bf315472be6",
+    "builder_sha256": "d54341cb20e43801c67d7c1f7b97cf2e05d7ca9171903b86720f139f6a62d2e4",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -231,7 +231,7 @@ if mode == "same-tag-correction":
 
 if mode == "family-forward":
     shown = subprocess.run(
-        ["git", "-C", str(root), "show", "--format=", "--unified=0", commit_sha, "--", "CHANGELOG.md"],
+        ["git", "-C", str(root), "show", "--first-parent", "--format=", "--unified=0", commit_sha, "--", "CHANGELOG.md"],
         encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -278,7 +278,7 @@ candidate_digest = hashlib.sha256(candidate_path.read_bytes()).hexdigest()
 candidate_bytes = candidate_path.stat().st_size
 
 shown = subprocess.run(
-    ["git", "-C", str(root), "show", "--format=", "--unified=0", commit_sha, "--", "CHANGELOG.md"],
+    ["git", "-C", str(root), "show", "--first-parent", "--format=", "--unified=0", commit_sha, "--", "CHANGELOG.md"],
     encoding="utf-8",
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -81,11 +81,30 @@ if [ "${1:-}" = "--identity-only" ]; then
     git -C "$root" -c user.email=t@example.invalid -c user.name=t commit -qm same-tag-correction
   }
 
+  make_same_tag_merge_fixture() {
+    local root="$1"
+    make_same_tag_correction_fixture "$root"
+    local correction_commit base_commit
+    correction_commit="$(git -C "$root" rev-parse HEAD)"
+    base_commit="$(git -C "$root" rev-parse HEAD^)"
+    git -C "$root" switch -q -c main-side "$base_commit"
+    printf 'main-side merge marker\n' > "$root/main-side.txt"
+    git -C "$root" add main-side.txt
+    git -C "$root" commit -qm main-side
+    git -C "$root" merge -q --no-ff -m merge-correction "$correction_commit"
+  }
+
   same_tag_correction="$tmp_parent/same-tag-correction"
   make_same_tag_correction_fixture "$same_tag_correction"
   bash scripts/build-release-asset.sh --check-release-identity \
     same-tag-correction v0.3.3.3 HEAD "$same_tag_correction" >/dev/null \
     || fail 'valid v0.3.3.3 same-tag correction was rejected'
+
+  same_tag_merge="$tmp_parent/same-tag-merge"
+  make_same_tag_merge_fixture "$same_tag_merge"
+  bash scripts/build-release-asset.sh --check-release-identity \
+    same-tag-correction v0.3.3.3 HEAD "$same_tag_merge" >/dev/null \
+    || fail 'valid same-tag correction merged through a pull request was rejected'
 
   if bash scripts/build-release-asset.sh --check-release-identity \
       same-tag-correction v0.3.3.2 HEAD "$same_tag_correction" >/dev/null 2>&1; then


### PR DESCRIPTION
## What changed

- makes the same-tag v0.3.3.3 release-identity checker inspect a merge commit against its first parent;
- adds a deterministic PR-style merge fixture, preserving all existing branch-head and mode-substitution controls;
- changes only the correction receipt's arrow glyph (`→` to accepted ASCII `->`) so the final merge commit carries one semantically identical old-to-final asset pair;
- rebinds the R33 builder identity to the exact changed checker bytes.

## Why

The corrected release candidate passed same-tag identity on its branch head, but the actual GitHub merge commit emitted no default `git show` diff and was rejected with “must add exactly one … pair”. The release contract must qualify the repository's real merge topology before the existing v0.3.3.3 tag or assets are corrected.

## Verification

- RED: a valid PR-style same-tag merge fixture was rejected
- GREEN: identity-only PASS, including merge and all prior positive/negative modes
- R33 semantic preservation: 21/21
- Lean discipline: 17/17
- R35 acceptance-instrument discipline: 39/39
- release asset: 227,999 bytes, SHA-256 `151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e`, 2,001-byte headroom
- `git diff --check`: PASS

Related: #155. This PR does not close #155 or #167 and does not mutate the tag, release, or assets.
