### PR TITLE
docs(release): bind final body readback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,8 @@ assets, checksum, and body were corrected in place and independently read back.
   `6d57060aeab3aeec1d0ad090c2fa7ab66ca9de67` resolves to final commit
   `3b5c300...`. Release ID `368332810` serves asset ID `510191694` at 227,999
   bytes and checksum asset ID `510191721` at 96 bytes. The final user-facing
-  body is 11,519 UTF-8 bytes with SHA-256
-  `dedd29580d042d45f10cd30a00dcf731910e8b5af101ff806d91cb8b97dacf80`.
+  body is 11,483 UTF-8 bytes with SHA-256
+  `b03fc28e2bb9a712fc14f0cb9ec95b190ee016d775b2ce1e7e2edd2d6eca5798`.
 - R36 / #167 remains open and was not shipped or qualified in this release. R28 /
   #117 remains open, optional, and nonblocking. `/dashboard/` remains excluded
   from `IMPLEMENTAUDIT.skill`.

--- a/docs/audits/archive/v0.3.3.3-release-report.md
+++ b/docs/audits/archive/v0.3.3.3-release-report.md
@@ -385,10 +385,11 @@ as chronology and are not credited to the corrected final assets below.
   `90a420245f3a4fefadce97dc8dccb77d98ac85e4`.
 - **Release object/body:** existing release ID `368332810` remains non-draft and
   non-prerelease with title `v0.3.3.3 — Corrective completion of the v0.3.3
-  runtime family`. Its replacement user-facing body is 11,519 UTF-8 bytes with
-  SHA-256 `dedd29580d042d45f10cd30a00dcf731910e8b5af101ff806d91cb8b97dacf80`,
+  runtime family`. Its final user-facing body is 11,483 UTF-8 bytes with
+  SHA-256 `b03fc28e2bb9a712fc14f0cb9ec95b190ee016d775b2ce1e7e2edd2d6eca5798`,
   zero unresolved placeholders, and no successor-version claim. The release
-  object update was read back at `2026-08-11T13:51:16Z`.
+  object update was read back at `2026-08-11T14:27:02Z`; its canonical report
+  link resolves to this terminal ledger on `main`.
 - **Assets:** `IMPLEMENTAUDIT.skill` asset ID `510191694` is 227,999 bytes with
   API and fresh-download SHA-256
   `151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e`.


### PR DESCRIPTION
## Outcome

Binds the final observed GitHub release-body identity after its canonical report link was repointed from the preterminal tag snapshot to the terminal ledger on `main`.

- Live body: 11,483 UTF-8 bytes
- SHA-256: `b03fc28e2bb9a712fc14f0cb9ec95b190ee016d775b2ce1e7e2edd2d6eca5798`
- Release update readback: `2026-08-11T14:27:02Z`
- Link census: exactly one `blob/main/.../v0.3.3.3-release-report.md`; zero pinned preterminal report links
- Zero placeholders, `v0.3.3.4`, or cyclic digest claims

## Scope

Exactly two repository evidence owners change: `CHANGELOG.md` and the canonical v0.3.3.3 release report. Package/runtime bytes are unchanged.

## Verification

- Docs portal 37/37
- Audit retention PASS
- Public-claim boundaries PASS
- Live body independent readback PASS
- Fresh exact-tree review PASS; no P0/P1/P2

Non-closing linkage: #167.