### PR TITLE
Fix same-tag correction maintainer policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,8 +161,11 @@ passing local check:
 
 Each external mutation needs explicit authority. After an authorised mutation,
 read back the remote state independently; command success alone is not proof.
-Do not replace bytes under an already-published tag. Correct forward under a
-fresh identity when a later package change warrants publication.
+Published identities are immutable by default. An in-place correction requires
+explicit owner authority, append-only custody of the superseded tag, release,
+assets and body, a dedicated same-identity gate, and independent public
+readback. Without that bounded authority, correct forward under a fresh
+identity.
 
 ## Evidence and handoff
 

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -50,7 +50,7 @@
     },
     "unshipped-owner": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "1e91fa3df34a22a22181092d6e31c67bf012e3be39253219da94340f0b8450ef", "anchor": "Package semantic preservation"},
-      "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "c9ec195a6a3009c8e0e0476a5c7610cad97670033f9847f27d9c9901e9e98366", "anchor": "# Contributing"},
+      "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "007640af5d52721dd7407aea652beaf1eac5cff334059b11ca9d807e54f02959", "anchor": "# Contributing"},
       "consumers": [
         {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d492fd77942cef97a92ce57ec8c4eeae714e2f0614768fe4d7218c6f56369441", "route_anchor": "references/lean-operating-discipline.md"}
       ]

--- a/scripts/check-public-claim-boundaries.sh
+++ b/scripts/check-public-claim-boundaries.sh
@@ -58,6 +58,10 @@ unsupported_claims = [
 ]
 stale_current_release_claims = [
     (
+        "do not replace bytes under an already-published tag",
+        "release policy must preserve bounded owner-authorised same-identity correction",
+    ),
+    (
         "current release-gate-verified public release is `v0.3.3.0`",
         "current release claim must not pin the superseded v0.3.3.0 public release",
     ),

--- a/tests/docs-portal.test.sh
+++ b/tests/docs-portal.test.sh
@@ -855,6 +855,34 @@ if bash scripts/check-public-claim-boundaries.sh >/dev/null 2>&1; then
 else
   ok "check-public-claim-boundaries.sh rejects the superseded v0.3.3.0 current-release claim"
 fi
+
+if "${py_cmd[@]}" - <<'PY'
+from pathlib import Path
+
+text = " ".join(Path("CONTRIBUTING.md").read_text(encoding="utf-8").split())
+raise SystemExit(0 if "An in-place correction requires explicit owner authority" in text else 1)
+PY
+then
+  ok "CONTRIBUTING.md states the bounded same-identity correction authority"
+else
+  fail_check "CONTRIBUTING.md is missing the bounded same-identity correction authority"
+fi
+
+"${py_cmd[@]}" - "$host_claim_fixture" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    "Do not replace bytes under an already-" + "published tag. "
+    "Correct forward under a fresh identity.\n",
+    encoding="utf-8",
+)
+PY
+if bash scripts/check-public-claim-boundaries.sh >/dev/null 2>&1; then
+  fail_check "check-public-claim-boundaries.sh accepted an absolute forward-only release policy"
+else
+  ok "check-public-claim-boundaries.sh rejects an absolute forward-only release policy"
+fi
 rm -f "$host_claim_fixture"
 
 if bash scripts/verify-docs-portal.sh >/dev/null; then


### PR DESCRIPTION
## Summary
- replace the stale absolute forward-only release instruction with the bounded same-identity correction contract already exercised by v0.3.3.3
- keep immutable-by-default semantics and require explicit owner authority, append-only superseded custody, the dedicated identity gate, and independent public readback
- add a deterministic negative control so the obsolete absolute cannot recur

## Verification
- docs portal: 39/39
- R29 census: 33/33 with 45 controls
- public-claim boundaries: PASS
- parent/head package parity: 227,999 bytes, 50 members, SHA-256 151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e
- independent exact-tree review: PASS

No packaged source or release/public object changes.