### PR TITLE
R33: restore package headroom with canonical DEFLATE

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes ripgrep
+          python -m pip install --disable-pip-version-check --no-deps --requirement requirements-release.txt
           rg --version
 
       - name: Validate whitespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ schema evidence proved four-component plugin manifest versions are accepted.
 
 ## [Unreleased]
 
-No changes are recorded after the final corrected `v0.3.3.3` release.
+### Changed
+
+- R33 package builds now use pinned, deterministic Zopfli method-8 DEFLATE.
+  Extracted member bytes, paths, modes, timestamps, runtime dependencies and
+  the 230,000-byte owner outer bound are unchanged; the stronger build-only
+  compressor restores headroom without deleting governed runtime semantics.
 
 ## [v0.3.3.3] - 2026-08-11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,11 @@ do not ship in `IMPLEMENTAUDIT.skill`.
   Git Bash is the established, release-qualified path. WSL is usable only when
   the checkout is accessible from WSL and its `python` command resolves to
   Python 3; verify both before relying on that route.
+- Canonical release builds require the pinned build-only dependency in
+  `requirements-release.txt`. Install it with
+  `python -m pip install --no-deps --requirement requirements-release.txt`; the resulting
+  archive remains standard ZIP method-8 DEFLATE and the installed runtime gains
+  no Python-package dependency.
 - Preserve LF line endings in shell scripts and generated/source evidence. Do
   not hide line-ending churn inside a semantic change.
 - Keep one worktree and branch focused on one coherent outcome. Use an isolated

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "d54341cb20e43801c67d7c1f7b97cf2e05d7ca9171903b86720f139f6a62d2e4",
+    "builder_sha256": "03d0e0fa65449513efe073c02a1bf91e5838134c2938d75cda061d9884fd63ad",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",
@@ -50,7 +50,7 @@
     },
     "unshipped-owner": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "1e91fa3df34a22a22181092d6e31c67bf012e3be39253219da94340f0b8450ef", "anchor": "Package semantic preservation"},
-      "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "007640af5d52721dd7407aea652beaf1eac5cff334059b11ca9d807e54f02959", "anchor": "# Contributing"},
+      "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "d7a3c1852202aa6a564641af6835f554662b34dd4ab654ce75f8edda4bf9b30d", "anchor": "# Contributing"},
       "consumers": [
         {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d492fd77942cef97a92ce57ec8c4eeae714e2f0614768fe4d7218c6f56369441", "route_anchor": "references/lean-operating-discipline.md"}
       ]

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,0 +1,1 @@
+zopfli==0.2.3.post1

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -448,7 +448,27 @@ import sys
 import tempfile
 import time
 import zipfile
+import zlib
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+
+try:
+    import zopfli.zlib
+except ImportError as exc:
+    raise SystemExit(
+        "release build requires zopfli 0.2.3.post1; "
+        "run: python -m pip install --no-deps --requirement requirements-release.txt"
+    ) from exc
+
+try:
+    zopfli_version = version("zopfli")
+except PackageNotFoundError as exc:
+    raise SystemExit("release build cannot resolve the zopfli package version") from exc
+if zopfli_version != "0.2.3.post1":
+    raise SystemExit(
+        "release build requires zopfli 0.2.3.post1, "
+        f"found {zopfli_version}"
+    )
 
 repo = Path.cwd()
 asset = Path(sys.argv[1]).resolve()
@@ -709,13 +729,54 @@ payload_entries.extend(
 payload_entries.sort(key=lambda item: item[0].as_posix())
 
 
+class CanonicalZopfliCompressor:
+    """Buffer one member and emit deterministic raw method-8 DEFLATE."""
+
+    def __init__(self):
+        self.buffer = bytearray()
+
+    def compress(self, data):
+        self.buffer.extend(data)
+        return b""
+
+    def flush(self):
+        source = bytes(self.buffer)
+        stream = zopfli.zlib.compress(
+            source,
+            numiterations=15,
+            blocksplitting=1,
+            blocksplittinglast=0,
+            blocksplittingmax=15,
+        )
+        raw_deflate = stream[2:-4]
+        if (zlib.decompress(stream) != source
+                or zlib.decompress(raw_deflate, wbits=-15) != source):
+            raise SystemExit("zopfli round-trip validation failed")
+        return raw_deflate
+
+
+stdlib_get_compressor = getattr(zipfile, "_get_compressor", None)
+if not callable(stdlib_get_compressor):
+    raise SystemExit("unsupported Python zipfile compressor interface")
+
+
+def canonical_get_compressor(compress_type, compresslevel=None):
+    if compress_type == zipfile.ZIP_DEFLATED:
+        return CanonicalZopfliCompressor()
+    return stdlib_get_compressor(compress_type, compresslevel)
+
+
 asset.parent.mkdir(parents=True, exist_ok=True)
-with zipfile.ZipFile(
-        asset, "w", compression=zipfile.ZIP_DEFLATED,
-        compresslevel=9, strict_timestamps=True) as zf:
-    for archive_rel, data, mode in payload_entries:
-        info = zip_info(archive_rel, mode)
-        zf.writestr(info, data)
+zipfile._get_compressor = canonical_get_compressor
+try:
+    with zipfile.ZipFile(
+            asset, "w", compression=zipfile.ZIP_DEFLATED,
+            strict_timestamps=True) as zf:
+        for archive_rel, data, mode in payload_entries:
+            info = zip_info(archive_rel, mode)
+            zf.writestr(info, data)
+finally:
+    zipfile._get_compressor = stdlib_get_compressor
 
 with zipfile.ZipFile(asset) as zf:
     names = set(zf.namelist())

--- a/scripts/build-source-evidence-pack.sh
+++ b/scripts/build-source-evidence-pack.sh
@@ -48,6 +48,7 @@ include_files = [
     "CLAUDE.md",
     "CONTRIBUTING.md",
     "README.md",
+    "requirements-release.txt",
     "docs/audits/INDEX.md",
     "docs/audits/RETENTION.md",
 ]
@@ -80,6 +81,9 @@ marketplace claim, provenance artifact, issue publication, license selection,
 or real-home install proof.
 
 Extract the zip, then run from the extracted pack root:
+
+Canonical release-package builds additionally require
+`python -m pip install --no-deps --requirement requirements-release.txt`.
 
 | Suite | Command | Expected exit | Expected last line |
 |---|---|---:|---|
@@ -136,6 +140,7 @@ if len(names) != len(set(names)):
     raise SystemExit("duplicate source evidence archive entries")
 
 for required in [
+    "requirements-release.txt",
     "skills/implementaudit/SKILL.md",
     "skills/implementaudit/references/sidecars.md",
     "skills/implementaudit/templates/final-report.md",

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -565,10 +565,14 @@ fi
 
 "${py_cmd[@]}" - "$asset" <<'PY'
 import json
+import struct
 import sys
 import tempfile
 import zipfile
+from importlib.metadata import version
 from pathlib import Path
+
+import zopfli.zlib
 
 asset = Path(sys.argv[1])
 
@@ -638,6 +642,31 @@ allowed_top_level = {"SKILL.md", "references", "scripts", "templates", ".claude-
 
 with zipfile.ZipFile(asset) as zf:
     names = set(zf.namelist())
+
+    if version("zopfli") != "0.2.3.post1":
+        raise SystemExit("canonical release build requires zopfli 0.2.3.post1")
+
+    archive_bytes = asset.read_bytes()
+    for info in zf.infolist():
+        if info.compress_type != zipfile.ZIP_DEFLATED:
+            raise SystemExit(f"non-DEFLATE package member: {info.filename}")
+        header = archive_bytes[info.header_offset:info.header_offset + 30]
+        if len(header) != 30 or header[:4] != b"PK\x03\x04":
+            raise SystemExit(f"invalid local ZIP header: {info.filename}")
+        filename_len, extra_len = struct.unpack_from("<HH", header, 26)
+        payload_offset = info.header_offset + 30 + filename_len + extra_len
+        observed = archive_bytes[payload_offset:payload_offset + info.compress_size]
+        expected = zopfli.zlib.compress(
+            zf.read(info.filename),
+            numiterations=15,
+            blocksplitting=1,
+            blocksplittinglast=0,
+            blocksplittingmax=15,
+        )[2:-4]
+        if observed != expected:
+            raise SystemExit(
+                f"member is not canonical Zopfli DEFLATE: {info.filename}"
+            )
 
     # Regression guard: skills/implementaudit/SKILL.md must NOT be in the archive.
     # Claude import requires SKILL.md at archive root.
@@ -711,13 +740,13 @@ with zipfile.ZipFile(asset) as zf:
         "owner", "dedicated-calibration-lane",
     }
 
-    # The final R29 audience/owner/rendered-consumer candidate is 227,999 bytes
-    # after semantic-preserving representation compaction. Owner authority
-    # for this corrective source lane retains the smallest whole-1,000-byte
-    # value that preserves at least 2,000 bytes of measured headroom. The outer
-    # 230,000-byte bound remains unchanged, and capacity is not a target.
-    MAX_ASSET_BYTES = 230_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 227_999
+    # The extracted payload is byte-identical to the 227,999-byte final R29
+    # package; canonical Zopfli method-8 DEFLATE yields 220,699 bytes. This
+    # dedicated R33 calibration lane uses the smallest whole-1,000-byte value
+    # preserving at least 2,000 bytes of measured headroom. The 230,000-byte
+    # outer bound remains unchanged, and capacity is not a target.
+    MAX_ASSET_BYTES = 223_000
+    CURRENT_CALIBRATION_ASSET_BYTES = 220_699
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730

--- a/tests/source-evidence-pack.test.sh
+++ b/tests/source-evidence-pack.test.sh
@@ -32,6 +32,7 @@ with zipfile.ZipFile(pack) as zf:
     names = set(zf.namelist())
     required = {
         "RUN-VALIDATION.md",
+        "requirements-release.txt",
         "skills/implementaudit/SKILL.md",
         "skills/implementaudit/references/sidecars.md",
         "skills/implementaudit/templates/final-report.md",


### PR DESCRIPTION
## Summary

- use pinned build-only `zopfli==0.2.3.post1` to produce canonical standard ZIP method-8 DEFLATE streams
- preserve every extracted package member byte, mode, timestamp, path, installed-runtime dependency, and public capability
- require the release-build input in the runnable source-evidence pack
- recalibrate the evidence-derived current ceiling to 223,000 bytes while preserving the 230,000 outer bound and at least 2,000 bytes of headroom

## Exact candidate

- source head: `4a0f02770d6ed5cdb97bd9e604192efc1e0bd780`
- source tree: `052fffad68e06f3afc776caf11a19d6db11eb930`
- package: 220,699 bytes
- SHA-256: `dcc213ca5683fdefa19b6ccbb0c1076ca416dea2818e51cf5e3081663b879e96`
- members: 50
- dashboard members: 0
- calibrated ceiling/headroom: 223,000 / 2,301 bytes

## Evidence

- TDD RED: the prior builder failed the new per-member raw Zopfli-stream discriminator
- Windows Python 3.11 and Linux/WSL Python 3.12 produced byte-identical archives
- terminal public v0.3.3.3 asset and candidate have identical extracted names, bytes, modes, and timestamps; only compressed representation differs
- missing or wrong Zopfli versions fail with an actionable pinned install command
- extracted source-evidence pack rebuilds the exact package bytes and digest
- focused PASS: release asset, reproducibility, source pack/runnable pack, R33 semantic preservation 21/21, R35 acceptance integrity 39/39, R29 census 33/33 with 45 controls, docs 39/39, public claims, diff check
- exact-tree independent review: PASS, no P0/P1/P2, safe to push

The one local complete-verifier process outlived tool supervision and later exited without recoverable stdout/exit status; it is retained as terminal-state-unverified, not PASS or FAIL, and was not rerun. Hosted validation on this exact head is the broad verdict.

## Scope and boundaries

This is a non-semantic archive representation change. It does not alter runtime `0.3.3`, package membership, installed behavior, public v0.3.3.3 assets, release identity, or the 230,000-byte outer policy. The dependency is build-only and is not packaged.

Links #161 without closing it. Issue closure remains evidence-bound to merged-main and hosted readback.