### PR TITLE
R02: bind verification windows to complete declared surfaces

### DIFF
--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -25,5 +25,11 @@
   {"id":"R2-F24","window":"closed-historical","surface":"ignored/declared.txt","change":"in-place ignored mutation","expected":"FAIL_HISTORICAL_IGNORED_CONTENT"},
   {"id":"R2-F25","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"unchanged run-root identity","expected":"PASS_UNCHANGED_RUN_ROOT"},
   {"id":"R2-F26","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"in-place run-root mutation","expected":"FAIL_EQUAL_RUN_ROOT_CONTENT"},
-  {"id":"R2-F27","window":"closed-historical","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"in-place run-root mutation","expected":"FAIL_HISTORICAL_RUN_ROOT_CONTENT"}
+  {"id":"R2-F27","window":"closed-historical","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"in-place run-root mutation","expected":"FAIL_HISTORICAL_RUN_ROOT_CONTENT"},
+  {"id":"R2-F28","window":"closed-equal","surface":"ignored/empty/","change":"unchanged empty ignored directory","expected":"PASS_EMPTY_IGNORED_DIRECTORY"},
+  {"id":"R2-F29","window":"closed-equal","surface":"ignored/empty/","change":"create empty ignored directory","expected":"FAIL_CREATED_EMPTY_IGNORED_DIRECTORY"},
+  {"id":"R2-F30","window":"open","surface":"ignored/empty/","change":"delete empty ignored directory","expected":"FAIL_DELETED_EMPTY_IGNORED_DIRECTORY"},
+  {"id":"R2-F31","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"unchanged empty run-root directory","expected":"PASS_EMPTY_RUN_ROOT_DIRECTORY"},
+  {"id":"R2-F32","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"create empty run-root directory","expected":"FAIL_CREATED_EMPTY_RUN_ROOT_DIRECTORY"},
+  {"id":"R2-F33","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"delete empty run-root directory","expected":"FAIL_DELETED_EMPTY_RUN_ROOT_DIRECTORY"}
 ]

--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -11,5 +11,13 @@
   {"id":"R2-F10","window":"open","surface":"curriculum/","change":"curriculum/x.json","expected":"FAIL_DIRECTORY_DESCENDANT"},
   {"id":"R2-F11","window":"open","surface":"missing/declared.txt","change":"delete missing/declared.txt","expected":"FAIL_MISSING_DECLARED"},
   {"id":"R2-F12","window":"open","surface":"curriculum/*.json","change":"curriculum/x.json","expected":"FAIL_GLOB"},
-  {"id":"R2-F13","window":"open","surface":"ignored/declared/**","change":"ignored/not-declared.txt","expected":"PASS_HELD_OUT_DISJOINT"}
+  {"id":"R2-F13","window":"open","surface":"ignored/declared/**","change":"ignored/not-declared.txt","expected":"PASS_HELD_OUT_DISJOINT"},
+  {"id":"R2-F14","window":"closed-equal","surface":"ignored/declared.txt","change":"ignored/declared.txt","expected":"FAIL_CLOSED_EQUAL_IGNORED"},
+  {"id":"R2-F15","window":"closed-historical","surface":"ignored/declared.txt","change":"ignored/declared.txt","expected":"FAIL_CLOSED_HISTORICAL_IGNORED"},
+  {"id":"R2-F16","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":".IMPLEMENTAUDIT/runs/window/live/declared.txt","expected":"FAIL_CLOSED_EQUAL_RUN_ROOT"},
+  {"id":"R2-F17","window":"closed-historical","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":".IMPLEMENTAUDIT/runs/window/live/declared.txt","expected":"FAIL_CLOSED_HISTORICAL_RUN_ROOT"},
+  {"id":"R2-F18","window":"open","surface":"ignored/declared.txt","change":"delete ignored/declared.txt","expected":"FAIL_DELETED_IGNORED"},
+  {"id":"R2-F19","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"delete .IMPLEMENTAUDIT/runs/window/live/declared.txt","expected":"FAIL_DELETED_RUN_ROOT"},
+  {"id":"R2-F20","window":"open","surface":"curriculum/**","change":"enumeration index failure","expected":"FAIL_ENUMERATION_ERROR"},
+  {"id":"R2-F21","window":"closed-equal","surface":"curriculum/**","change":"alter closing identity receipt","expected":"FAIL_CLOSING_RECEIPT_TAMPER"}
 ]

--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -5,5 +5,11 @@
   {"id":"R2-F4","window":"closed","surface":"curriculum/**","change":"curriculum/x.json","expected":"PASS"},
   {"id":"R2-F5","window":"open","surface":"curriculum/**","change":"docs/readme.md","expected":"PASS_DISJOINT"},
   {"id":"R2-F6","window":"open","surface":"curriculum/**","change":"compound stash-check-restore timeout","expected":"FAIL_HIDDEN_STASH"},
-  {"id":"R2-F7","window":"open","surface":"curriculum/**","change":"terminal run-root closure","expected":"FAIL_CLOSURE"}
+  {"id":"R2-F7","window":"open","surface":"curriculum/**","change":"terminal run-root closure","expected":"FAIL_CLOSURE"},
+  {"id":"R2-F8","window":"open","surface":"ignored/declared.txt","change":"ignored/declared.txt","expected":"FAIL_IGNORED_DECLARED"},
+  {"id":"R2-F9","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/**","change":".IMPLEMENTAUDIT/runs/window/live/declared.txt","expected":"FAIL_RUN_ROOT_DECLARED"},
+  {"id":"R2-F10","window":"open","surface":"curriculum/","change":"curriculum/x.json","expected":"FAIL_DIRECTORY_DESCENDANT"},
+  {"id":"R2-F11","window":"open","surface":"missing/declared.txt","change":"delete missing/declared.txt","expected":"FAIL_MISSING_DECLARED"},
+  {"id":"R2-F12","window":"open","surface":"curriculum/*.json","change":"curriculum/x.json","expected":"FAIL_GLOB"},
+  {"id":"R2-F13","window":"open","surface":"ignored/declared/**","change":"ignored/not-declared.txt","expected":"PASS_HELD_OUT_DISJOINT"}
 ]

--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -34,5 +34,6 @@
   {"id":"R2-F33","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"delete empty run-root directory","expected":"FAIL_DELETED_EMPTY_RUN_ROOT_DIRECTORY"},
   {"id":"R2-F34","window":"receipt","surface":"none","change":"empty declared-surface population","expected":"FAIL_SURFACE_POPULATION_REQUIRED"},
   {"id":"R2-F35","window":"open","surface":"ignored/empty/","change":"omit opening receipt declaration","expected":"FAIL_OPENING_SURFACE_BINDING"},
-  {"id":"R2-F36","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"omit closing receipt declaration","expected":"FAIL_CLOSING_SURFACE_BINDING"}
+  {"id":"R2-F36","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"omit closing receipt declaration","expected":"FAIL_CLOSING_SURFACE_BINDING"},
+  {"id":"R2-F37","window":"open","surface":"./ignored/declared.txt","change":"ignored/declared.txt","expected":"FAIL_NORMALIZED_RELATIVE_SURFACE"}
 ]

--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -19,5 +19,11 @@
   {"id":"R2-F18","window":"open","surface":"ignored/declared.txt","change":"delete ignored/declared.txt","expected":"FAIL_DELETED_IGNORED"},
   {"id":"R2-F19","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"delete .IMPLEMENTAUDIT/runs/window/live/declared.txt","expected":"FAIL_DELETED_RUN_ROOT"},
   {"id":"R2-F20","window":"open","surface":"curriculum/**","change":"enumeration index failure","expected":"FAIL_ENUMERATION_ERROR"},
-  {"id":"R2-F21","window":"closed-equal","surface":"curriculum/**","change":"alter closing identity receipt","expected":"FAIL_CLOSING_RECEIPT_TAMPER"}
+  {"id":"R2-F21","window":"closed-equal","surface":"curriculum/**","change":"alter closing identity receipt","expected":"FAIL_CLOSING_RECEIPT_TAMPER"},
+  {"id":"R2-F22","window":"closed-equal","surface":"ignored/declared.txt","change":"unchanged ignored identity","expected":"PASS_UNCHANGED_IGNORED"},
+  {"id":"R2-F23","window":"closed-equal","surface":"ignored/declared.txt","change":"in-place ignored mutation","expected":"FAIL_EQUAL_IGNORED_CONTENT"},
+  {"id":"R2-F24","window":"closed-historical","surface":"ignored/declared.txt","change":"in-place ignored mutation","expected":"FAIL_HISTORICAL_IGNORED_CONTENT"},
+  {"id":"R2-F25","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"unchanged run-root identity","expected":"PASS_UNCHANGED_RUN_ROOT"},
+  {"id":"R2-F26","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"in-place run-root mutation","expected":"FAIL_EQUAL_RUN_ROOT_CONTENT"},
+  {"id":"R2-F27","window":"closed-historical","surface":".IMPLEMENTAUDIT/runs/window/live/declared.txt","change":"in-place run-root mutation","expected":"FAIL_HISTORICAL_RUN_ROOT_CONTENT"}
 ]

--- a/fixtures/verification-window/cases.json
+++ b/fixtures/verification-window/cases.json
@@ -31,5 +31,8 @@
   {"id":"R2-F30","window":"open","surface":"ignored/empty/","change":"delete empty ignored directory","expected":"FAIL_DELETED_EMPTY_IGNORED_DIRECTORY"},
   {"id":"R2-F31","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"unchanged empty run-root directory","expected":"PASS_EMPTY_RUN_ROOT_DIRECTORY"},
   {"id":"R2-F32","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"create empty run-root directory","expected":"FAIL_CREATED_EMPTY_RUN_ROOT_DIRECTORY"},
-  {"id":"R2-F33","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"delete empty run-root directory","expected":"FAIL_DELETED_EMPTY_RUN_ROOT_DIRECTORY"}
+  {"id":"R2-F33","window":"open","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"delete empty run-root directory","expected":"FAIL_DELETED_EMPTY_RUN_ROOT_DIRECTORY"},
+  {"id":"R2-F34","window":"receipt","surface":"none","change":"empty declared-surface population","expected":"FAIL_SURFACE_POPULATION_REQUIRED"},
+  {"id":"R2-F35","window":"open","surface":"ignored/empty/","change":"omit opening receipt declaration","expected":"FAIL_OPENING_SURFACE_BINDING"},
+  {"id":"R2-F36","window":"closed-equal","surface":".IMPLEMENTAUDIT/runs/window/live/empty/","change":"omit closing receipt declaration","expected":"FAIL_CLOSING_SURFACE_BINDING"}
 ]

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -276,7 +276,7 @@ PY
     "${py_cmd[@]}" - "$intent" "$now" "$repo_state" "$BASH" <<'PY'
 import fnmatch
 import hashlib
-import os
+import json
 import re
 import subprocess
 import sys
@@ -321,29 +321,47 @@ def window_changed_paths(opened):
         fail(f"complete window changed-files enumeration returned a non-UTF-8 path for {opened}")
 
 
-def window_identity_paths():
+def identity_records(payload, label):
+    records = {}
+    try:
+        raw_records = [part.decode("utf-8") for part in payload.split(b"\0") if part]
+    except UnicodeDecodeError:
+        fail(f"{label} returned a non-UTF-8 record")
+    for raw in raw_records:
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            fail(f"{label} contains malformed identity JSON")
+        if set(record) != {"path", "type", "extent", "sha256"}:
+            fail(f"{label} identity record has an invalid schema")
+        path = normalize_surface(record["path"])
+        if record["type"] not in {"regular", "directory", "symlink"}:
+            fail(f"{label} identity record has an unsupported type: {record['type']}")
+        if not isinstance(record["extent"], int) or record["extent"] < 0:
+            fail(f"{label} identity record has an invalid extent: {path}")
+        if not re.fullmatch(r"[0-9a-f]{64}", record["sha256"]):
+            fail(f"{label} identity record has an invalid digest: {path}")
+        if path in records:
+            fail(f"{label} contains a duplicate identity path: {path}")
+        records[path] = (record["type"], record["extent"], record["sha256"])
+    return records
+
+
+def window_identity_records():
     identities = subprocess.run(
-        [bash_exe, repo_state, "window-identities", "--null"],
+        [bash_exe, repo_state, "window-identities", "--records"],
         capture_output=True,
         check=False,
     )
     if identities.returncode != 0:
         fail(f"complete window identity enumeration failed: {identities.stderr.decode(errors='replace').strip()}")
     try:
-        candidates = {
-            normalize_surface(part.decode("utf-8"))
-            for part in identities.stdout.split(b"\0")
-            if part
-        }
+        return identity_records(identities.stdout, "complete window identity enumeration")
     except UnicodeDecodeError:
-        fail("complete window identity enumeration returned a non-UTF-8 path")
-    return {
-        path for path in candidates
-        if os.path.lexists(os.path.join(repo_root, path))
-    }
+        fail("complete window identity enumeration returned a non-UTF-8 record")
 
 
-def receipt_paths(receipt_name, expected_digest, label):
+def receipt_records(receipt_name, expected_digest, label):
     receipt = Path(receipt_name)
     if (not receipt_name or receipt.is_absolute() or ".." in receipt.parts
             or receipt_name.startswith("/") or re.match(r"^[A-Za-z]:", receipt_name)):
@@ -357,11 +375,7 @@ def receipt_paths(receipt_name, expected_digest, label):
     if hashlib.sha256(payload).hexdigest() != expected_digest:
         fail(f"verification window {label} identity receipt digest does not match")
     try:
-        return {
-            normalize_surface(part.decode("utf-8"))
-            for part in payload.split(b"\0")
-            if part
-        }
+        return identity_records(payload, f"verification window {label} identity receipt")
     except UnicodeDecodeError:
         fail(f"verification window {label} identity receipt contains a non-UTF-8 path")
 
@@ -371,6 +385,13 @@ def intersecting_paths(paths, surfaces):
         path for path in paths
         if any(surface_matches(path, surface) for surface in surfaces)
     )
+
+
+def identity_delta(before, after):
+    return (set(before) - set(after)) | (set(after) - set(before)) | {
+        path for path in set(before) & set(after)
+        if before[path] != after[path]
+    }
 
 
 if not sha_re.fullmatch(now):
@@ -417,15 +438,6 @@ if head.returncode != 0:
 head_sha = head.stdout.strip()
 if head_sha != now:
     fail(f"--now {now} does not equal current HEAD {head_sha}")
-repo_root = subprocess.run(
-    ["git", "rev-parse", "--show-toplevel"],
-    text=True,
-    capture_output=True,
-    check=False,
-).stdout.strip()
-if not repo_root:
-    fail("--window cannot resolve the current repository root")
-
 open_moved = []
 for index, window in enumerate(windows, 1):
     surfaces = window.get("surfaces", [])
@@ -449,7 +461,7 @@ for index, window in enumerate(windows, 1):
         fail(f"verification_window entry {index} opened_at is not a local commit: {opened}")
     if Path(intent_path).parent.name != chain:
         fail(f"verification_window entry {index} chain does not match its directory: {chain}")
-    opening_paths = receipt_paths(opening_receipt, opening_digest, "opening")
+    opening_records = receipt_records(opening_receipt, opening_digest, "opening")
     if state == "closed":
         marker = intent_path.parent / "chain.done"
         if not marker.is_file():
@@ -468,23 +480,15 @@ for index, window in enumerate(windows, 1):
         closing_digest = window.get("closing_identity_sha256", "")
         if not closing_receipt or not closing_digest:
             fail(f"verification_window entry {index} is closed without a closing identity receipt")
-        recorded_closing_paths = receipt_paths(closing_receipt, closing_digest, "closing")
+        recorded_closing_records = receipt_records(closing_receipt, closing_digest, "closing")
         if closed == now:
-            changed_paths = window_changed_paths(opened)
-            closing_paths = window_identity_paths()
+            window_changed_paths(opened)
+            closing_records = window_identity_records()
         else:
-            changed = subprocess.run(
-                ["git", "diff", "--name-only", opened, closed],
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-            if changed.returncode != 0:
-                fail(f"closing diff enumeration failed for {opened}..{closed}: {changed.stderr.strip()}")
-            changed_paths = [line for line in changed.stdout.splitlines() if line]
-            closing_paths = recorded_closing_paths
+            window_changed_paths(opened)
+            closing_records = recorded_closing_records
         intersecting = intersecting_paths(
-            set(changed_paths) | (closing_paths - opening_paths) | (opening_paths - closing_paths),
+            identity_delta(opening_records, closing_records),
             surfaces,
         )
         if intersecting:
@@ -494,10 +498,10 @@ for index, window in enumerate(windows, 1):
                 f"intersecting=[{', '.join(intersecting)}]"
             )
         continue
-    changed_paths = window_changed_paths(opened)
-    current_paths = window_identity_paths()
+    window_changed_paths(opened)
+    current_records = window_identity_records()
     intersecting = intersecting_paths(
-        set(changed_paths) | (current_paths - opening_paths) | (opening_paths - current_paths),
+        identity_delta(opening_records, current_records),
         surfaces,
     )
     if intersecting:

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -19,8 +19,8 @@ set -euo pipefail
 #   check-evidence-anchor.sh --window <launch-intent-file> --now <sha>
 #       an open verification window refuses an anchor-to-current-tree diff
 #       that intersects a declared surface. Closed windows and complete diffs
-#       proven disjoint pass. The existing repo-state.sh changed-files command
-#       remains the sole complete working-tree enumerator.
+#       proven disjoint pass. Its window-specific repo-state route includes
+#       ignored and .IMPLEMENTAUDIT/ path identities as live declared surfaces.
 
 fail() { printf 'check-evidence-anchor: %s\n' "$*" >&2; exit 1; }
 
@@ -278,7 +278,7 @@ import fnmatch
 import re
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 intent_path = Path(sys.argv[1])
 now = sys.argv[2]
@@ -290,6 +290,33 @@ sha_re = re.compile(r"^[0-9a-f]{40}$")
 def fail(message):
     print(f"check-evidence-anchor: {message}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def normalize_surface(surface):
+    normalized = surface.replace("\\", "/")
+    pure = PurePosixPath(normalized)
+    if (not normalized or pure.is_absolute() or ".." in pure.parts
+            or normalized.startswith("/") or re.match(r"^[A-Za-z]:", normalized)):
+        fail(f"verification window contains unsafe surface: {surface}")
+    return normalized
+
+
+def surface_matches(path, surface):
+    return path.startswith(surface) if surface.endswith("/") else fnmatch.fnmatchcase(path, surface)
+
+
+def window_changed_paths(opened):
+    changed = subprocess.run(
+        [bash_exe, repo_state, "window-changed-files", "--null", opened],
+        capture_output=True,
+        check=False,
+    )
+    if changed.returncode != 0:
+        fail(f"complete window changed-files enumeration failed for {opened}: {changed.stderr.decode(errors='replace').strip()}")
+    try:
+        return sorted({part.decode("utf-8") for part in changed.stdout.split(b"\0") if part})
+    except UnicodeDecodeError:
+        fail(f"complete window changed-files enumeration returned a non-UTF-8 path for {opened}")
 
 
 if not sha_re.fullmatch(now):
@@ -311,7 +338,7 @@ for raw in text.splitlines():
     match = re.match(r"^\s*-\s*surfaces:\s*\[(.*)\]\s*$", raw)
     if match:
         surfaces = [
-            item.strip().strip("'\"`")
+            normalize_surface(item.strip().strip("'\"`"))
             for item in match.group(1).split(",")
             if item.strip()
         ]
@@ -372,12 +399,7 @@ for index, window in enumerate(windows, 1):
         if closed == opened:
             continue
         if closed == now:
-            changed = subprocess.run(
-                [bash_exe, repo_state, "changed-files", opened],
-                text=True,
-                capture_output=True,
-                check=False,
-            )
+            changed_paths = window_changed_paths(opened)
         else:
             changed = subprocess.run(
                 ["git", "diff", "--name-only", opened, closed],
@@ -385,13 +407,13 @@ for index, window in enumerate(windows, 1):
                 capture_output=True,
                 check=False,
             )
-        if changed.returncode != 0:
-            fail(f"closing diff enumeration failed for {opened}..{closed}: {changed.stderr.strip()}")
-        changed_paths = [line for line in changed.stdout.splitlines() if line]
+            if changed.returncode != 0:
+                fail(f"closing diff enumeration failed for {opened}..{closed}: {changed.stderr.strip()}")
+            changed_paths = [line for line in changed.stdout.splitlines() if line]
         intersecting = sorted(
             path
             for path in changed_paths
-            if any(fnmatch.fnmatchcase(path, surface) for surface in surfaces)
+            if any(surface_matches(path, surface) for surface in surfaces)
         )
         if intersecting:
             fail(
@@ -400,21 +422,11 @@ for index, window in enumerate(windows, 1):
                 f"intersecting=[{', '.join(intersecting)}]"
             )
         continue
-    if now == opened:
-        continue
-    changed = subprocess.run(
-        [bash_exe, repo_state, "changed-files", opened],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if changed.returncode != 0:
-        fail(f"complete changed-files enumeration failed for {opened}: {changed.stderr.strip()}")
-    changed_paths = [line for line in changed.stdout.splitlines() if line]
+    changed_paths = window_changed_paths(opened)
     intersecting = sorted(
         path
         for path in changed_paths
-        if any(fnmatch.fnmatchcase(path, surface) for surface in surfaces)
+        if any(surface_matches(path, surface) for surface in surfaces)
     )
     if intersecting:
         fail(

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -277,6 +277,7 @@ PY
 import fnmatch
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -321,13 +322,37 @@ def window_changed_paths(opened):
         fail(f"complete window changed-files enumeration returned a non-UTF-8 path for {opened}")
 
 
-def identity_records(payload, label):
+def normalized_surface_population(surfaces, label):
+    if not surfaces or any(not isinstance(surface, str) for surface in surfaces):
+        fail(f"{label} has no valid declared surfaces")
+    normalized = [normalize_surface(surface) for surface in surfaces]
+    if len(set(normalized)) != len(normalized):
+        fail(f"{label} contains duplicate declared surfaces")
+    return sorted(normalized)
+
+
+def identity_records(payload, label, expected_surfaces):
     records = {}
     try:
         raw_records = [part.decode("utf-8") for part in payload.split(b"\0") if part]
     except UnicodeDecodeError:
         fail(f"{label} returned a non-UTF-8 record")
-    for raw in raw_records:
+    if not raw_records:
+        fail(f"{label} contains no receipt header")
+    try:
+        header = json.loads(raw_records[0])
+    except json.JSONDecodeError:
+        fail(f"{label} contains malformed receipt header JSON")
+    if (not isinstance(header, dict)
+            or set(header) != {"schema", "surfaces"}
+            or header.get("schema") != "verification-window-identity-receipt-v1"
+            or not isinstance(header.get("surfaces"), list)):
+        fail(f"{label} has an invalid receipt header")
+    declared_population = normalized_surface_population(header["surfaces"], label)
+    expected_population = normalized_surface_population(expected_surfaces, "verification window")
+    if declared_population != expected_population:
+        fail(f"{label} declared surfaces do not match the verification window: receipt={declared_population} expected={expected_population}")
+    for raw in raw_records[1:]:
         try:
             record = json.loads(raw)
         except json.JSONDecodeError:
@@ -348,22 +373,24 @@ def identity_records(payload, label):
 
 
 def window_identity_records(surfaces):
+    command = [bash_exe, repo_state, "window-identities", "--records", "--surfaces-env"]
+    environment = os.environ.copy()
+    environment["IMPLEMENTAUDIT_WINDOW_SURFACES_JSON"] = json.dumps(surfaces)
     identities = subprocess.run(
-        [bash_exe, repo_state, "window-identities", "--records", *(
-            value for surface in surfaces for value in ("--surface", surface)
-        )],
+        command,
         capture_output=True,
         check=False,
+        env=environment,
     )
     if identities.returncode != 0:
         fail(f"complete window identity enumeration failed: {identities.stderr.decode(errors='replace').strip()}")
     try:
-        return identity_records(identities.stdout, "complete window identity enumeration")
+        return identity_records(identities.stdout, "complete window identity enumeration", surfaces)
     except UnicodeDecodeError:
         fail("complete window identity enumeration returned a non-UTF-8 record")
 
 
-def receipt_records(receipt_name, expected_digest, label):
+def receipt_records(receipt_name, expected_digest, label, surfaces):
     receipt = Path(receipt_name)
     if (not receipt_name or receipt.is_absolute() or ".." in receipt.parts
             or receipt_name.startswith("/") or re.match(r"^[A-Za-z]:", receipt_name)):
@@ -377,7 +404,7 @@ def receipt_records(receipt_name, expected_digest, label):
     if hashlib.sha256(payload).hexdigest() != expected_digest:
         fail(f"verification window {label} identity receipt digest does not match")
     try:
-        return identity_records(payload, f"verification window {label} identity receipt")
+        return identity_records(payload, f"verification window {label} identity receipt", surfaces)
     except UnicodeDecodeError:
         fail(f"verification window {label} identity receipt contains a non-UTF-8 path")
 
@@ -463,7 +490,7 @@ for index, window in enumerate(windows, 1):
         fail(f"verification_window entry {index} opened_at is not a local commit: {opened}")
     if Path(intent_path).parent.name != chain:
         fail(f"verification_window entry {index} chain does not match its directory: {chain}")
-    opening_records = receipt_records(opening_receipt, opening_digest, "opening")
+    opening_records = receipt_records(opening_receipt, opening_digest, "opening", surfaces)
     if state == "closed":
         marker = intent_path.parent / "chain.done"
         if not marker.is_file():
@@ -482,7 +509,7 @@ for index, window in enumerate(windows, 1):
         closing_digest = window.get("closing_identity_sha256", "")
         if not closing_receipt or not closing_digest:
             fail(f"verification_window entry {index} is closed without a closing identity receipt")
-        recorded_closing_records = receipt_records(closing_receipt, closing_digest, "closing")
+        recorded_closing_records = receipt_records(closing_receipt, closing_digest, "closing", surfaces)
         if closed == now:
             window_changed_paths(opened)
             closing_records = window_identity_records(surfaces)

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -301,7 +301,12 @@ def normalize_surface(surface):
     if (not normalized or pure.is_absolute() or ".." in pure.parts
             or normalized.startswith("/") or re.match(r"^[A-Za-z]:", normalized)):
         fail(f"verification window contains unsafe surface: {surface}")
-    return normalized
+    canonical = str(pure)
+    if canonical in {"", "."}:
+        fail(f"verification window contains unsafe surface: {surface}")
+    if normalized.endswith("/"):
+        canonical += "/"
+    return canonical
 
 
 def surface_matches(path, surface):

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -275,6 +275,8 @@ PY
     repo_state="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/repo-state.sh"
     "${py_cmd[@]}" - "$intent" "$now" "$repo_state" "$BASH" <<'PY'
 import fnmatch
+import hashlib
+import os
 import re
 import subprocess
 import sys
@@ -319,6 +321,58 @@ def window_changed_paths(opened):
         fail(f"complete window changed-files enumeration returned a non-UTF-8 path for {opened}")
 
 
+def window_identity_paths():
+    identities = subprocess.run(
+        [bash_exe, repo_state, "window-identities", "--null"],
+        capture_output=True,
+        check=False,
+    )
+    if identities.returncode != 0:
+        fail(f"complete window identity enumeration failed: {identities.stderr.decode(errors='replace').strip()}")
+    try:
+        candidates = {
+            normalize_surface(part.decode("utf-8"))
+            for part in identities.stdout.split(b"\0")
+            if part
+        }
+    except UnicodeDecodeError:
+        fail("complete window identity enumeration returned a non-UTF-8 path")
+    return {
+        path for path in candidates
+        if os.path.lexists(os.path.join(repo_root, path))
+    }
+
+
+def receipt_paths(receipt_name, expected_digest, label):
+    receipt = Path(receipt_name)
+    if (not receipt_name or receipt.is_absolute() or ".." in receipt.parts
+            or receipt_name.startswith("/") or re.match(r"^[A-Za-z]:", receipt_name)):
+        fail(f"verification window {label} identity receipt is unsafe: {receipt_name}")
+    receipt_path = intent_path.parent / receipt
+    if not receipt_path.is_file() or receipt_path.is_symlink():
+        fail(f"verification window {label} identity receipt is not a regular file: {receipt_path}")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+        fail(f"verification window {label} identity receipt digest is invalid")
+    payload = receipt_path.read_bytes()
+    if hashlib.sha256(payload).hexdigest() != expected_digest:
+        fail(f"verification window {label} identity receipt digest does not match")
+    try:
+        return {
+            normalize_surface(part.decode("utf-8"))
+            for part in payload.split(b"\0")
+            if part
+        }
+    except UnicodeDecodeError:
+        fail(f"verification window {label} identity receipt contains a non-UTF-8 path")
+
+
+def intersecting_paths(paths, surfaces):
+    return sorted(
+        path for path in paths
+        if any(surface_matches(path, surface) for surface in surfaces)
+    )
+
+
 if not sha_re.fullmatch(now):
     fail("--now must be a full 40-hex SHA")
 
@@ -345,7 +399,10 @@ for raw in text.splitlines():
         current = {"surfaces": surfaces}
         windows.append(current)
         continue
-    match = re.match(r"^\s*(opened_at|closed_at|chain|state):\s*(.*?)\s*$", raw)
+    match = re.match(
+        r"^\s*(opened_at|closed_at|chain|state|opening_identity_receipt|opening_identity_sha256|closing_identity_receipt|closing_identity_sha256):\s*(.*?)\s*$",
+        raw,
+    )
     if match and current is not None:
         current[match.group(1)] = match.group(2).strip().strip("'\"`")
 
@@ -360,6 +417,14 @@ if head.returncode != 0:
 head_sha = head.stdout.strip()
 if head_sha != now:
     fail(f"--now {now} does not equal current HEAD {head_sha}")
+repo_root = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    text=True,
+    capture_output=True,
+    check=False,
+).stdout.strip()
+if not repo_root:
+    fail("--window cannot resolve the current repository root")
 
 open_moved = []
 for index, window in enumerate(windows, 1):
@@ -368,7 +433,9 @@ for index, window in enumerate(windows, 1):
     closed = window.get("closed_at", "")
     state = window.get("state", "")
     chain = window.get("chain", "")
-    if not surfaces or not chain or state not in {"open", "closed"}:
+    opening_receipt = window.get("opening_identity_receipt", "")
+    opening_digest = window.get("opening_identity_sha256", "")
+    if not surfaces or not chain or state not in {"open", "closed"} or not opening_receipt or not opening_digest:
         fail(f"verification_window entry {index} is incomplete or invalid")
     if not sha_re.fullmatch(opened):
         fail(f"verification_window entry {index} opened_at must be a full 40-hex SHA")
@@ -382,6 +449,7 @@ for index, window in enumerate(windows, 1):
         fail(f"verification_window entry {index} opened_at is not a local commit: {opened}")
     if Path(intent_path).parent.name != chain:
         fail(f"verification_window entry {index} chain does not match its directory: {chain}")
+    opening_paths = receipt_paths(opening_receipt, opening_digest, "opening")
     if state == "closed":
         marker = intent_path.parent / "chain.done"
         if not marker.is_file():
@@ -396,10 +464,14 @@ for index, window in enumerate(windows, 1):
         )
         if verify_closed.returncode != 0:
             fail(f"verification_window entry {index} closed_at is not a local commit: {closed}")
-        if closed == opened:
-            continue
+        closing_receipt = window.get("closing_identity_receipt", "")
+        closing_digest = window.get("closing_identity_sha256", "")
+        if not closing_receipt or not closing_digest:
+            fail(f"verification_window entry {index} is closed without a closing identity receipt")
+        recorded_closing_paths = receipt_paths(closing_receipt, closing_digest, "closing")
         if closed == now:
             changed_paths = window_changed_paths(opened)
+            closing_paths = window_identity_paths()
         else:
             changed = subprocess.run(
                 ["git", "diff", "--name-only", opened, closed],
@@ -410,10 +482,10 @@ for index, window in enumerate(windows, 1):
             if changed.returncode != 0:
                 fail(f"closing diff enumeration failed for {opened}..{closed}: {changed.stderr.strip()}")
             changed_paths = [line for line in changed.stdout.splitlines() if line]
-        intersecting = sorted(
-            path
-            for path in changed_paths
-            if any(surface_matches(path, surface) for surface in surfaces)
+            closing_paths = recorded_closing_paths
+        intersecting = intersecting_paths(
+            set(changed_paths) | (closing_paths - opening_paths) | (opening_paths - closing_paths),
+            surfaces,
         )
         if intersecting:
             fail(
@@ -423,10 +495,10 @@ for index, window in enumerate(windows, 1):
             )
         continue
     changed_paths = window_changed_paths(opened)
-    intersecting = sorted(
-        path
-        for path in changed_paths
-        if any(surface_matches(path, surface) for surface in surfaces)
+    current_paths = window_identity_paths()
+    intersecting = intersecting_paths(
+        set(changed_paths) | (current_paths - opening_paths) | (opening_paths - current_paths),
+        surfaces,
     )
     if intersecting:
         fail(

--- a/skills/implementaudit/scripts/check-evidence-anchor.sh
+++ b/skills/implementaudit/scripts/check-evidence-anchor.sh
@@ -347,9 +347,11 @@ def identity_records(payload, label):
     return records
 
 
-def window_identity_records():
+def window_identity_records(surfaces):
     identities = subprocess.run(
-        [bash_exe, repo_state, "window-identities", "--records"],
+        [bash_exe, repo_state, "window-identities", "--records", *(
+            value for surface in surfaces for value in ("--surface", surface)
+        )],
         capture_output=True,
         check=False,
     )
@@ -483,7 +485,7 @@ for index, window in enumerate(windows, 1):
         recorded_closing_records = receipt_records(closing_receipt, closing_digest, "closing")
         if closed == now:
             window_changed_paths(opened)
-            closing_records = window_identity_records()
+            closing_records = window_identity_records(surfaces)
         else:
             window_changed_paths(opened)
             closing_records = recorded_closing_records
@@ -499,7 +501,7 @@ for index, window in enumerate(windows, 1):
             )
         continue
     window_changed_paths(opened)
-    current_records = window_identity_records()
+    current_records = window_identity_records(surfaces)
     intersecting = intersecting_paths(
         identity_delta(opening_records, current_records),
         surfaces,

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -113,9 +113,25 @@ cmd_window_changed_files() {
     # current path identity that can intersect a declared surface. In
     # particular, ignored files and .IMPLEMENTAUDIT/ run-root files are live
     # surfaces when explicitly declared by an open window.
-    git diff --name-only -z "$baseline" 2>/dev/null || true
-    git ls-files --others --exclude-standard -z 2>/dev/null || true
-    git ls-files --others --ignored --exclude-standard -z 2>/dev/null || true
+    git diff --name-only -z "$baseline" || return $?
+    git ls-files --others --exclude-standard -z || return $?
+    git ls-files --others --ignored --exclude-standard -z || return $?
+  fi
+}
+
+cmd_window_identities() {
+  local format="$1"
+  [ "$format" = "--null" ] || {
+    printf 'usage: repo-state.sh window-identities --null\n' >&2
+    return 2
+  }
+  if in_git_repo; then
+    # This is the opening/closing receipt population for verification windows.
+    # Do not inherit changed-files exclusions: explicitly declared ignored and
+    # run-root paths are live window identities.
+    git ls-files -z || return $?
+    git ls-files --others --exclude-standard -z || return $?
+    git ls-files --others --ignored --exclude-standard -z || return $?
   fi
 }
 
@@ -399,6 +415,13 @@ case "$subcommand" in
     }
     cmd_window_changed_files "$1" "$2"
     ;;
+  window-identities)
+    [ "$#" -eq 1 ] || {
+      printf 'usage: repo-state.sh window-identities --null\n' >&2
+      exit 2
+    }
+    cmd_window_identities "$1"
+    ;;
   added-lines)
     [ "$#" -ge 1 ] || {
       printf 'usage: repo-state.sh added-lines <baseline>\n' >&2
@@ -413,6 +436,7 @@ repo-state.sh - evaluate complete working-tree state vs a baseline commit.
   repo-state.sh deliverable   <baseline> <path>
   repo-state.sh changed-files <baseline>
   repo-state.sh window-changed-files --null <baseline>
+  repo-state.sh window-identities --null
   repo-state.sh added-lines   <baseline>
   repo-state.sh commit-message <message-file> [--ledger-linked]
   repo-state.sh ignored-artifact <source|package|release> <artifact> <published-digest-record> <authority-baseline>

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -121,18 +121,107 @@ cmd_window_changed_files() {
 
 cmd_window_identities() {
   local format="$1"
-  [ "$format" = "--null" ] || {
-    printf 'usage: repo-state.sh window-identities --null\n' >&2
-    return 2
-  }
-  if in_git_repo; then
-    # This is the opening/closing receipt population for verification windows.
-    # Do not inherit changed-files exclusions: explicitly declared ignored and
-    # run-root paths are live window identities.
-    git ls-files -z || return $?
-    git ls-files --others --exclude-standard -z || return $?
-    git ls-files --others --ignored --exclude-standard -z || return $?
-  fi
+  case "$format" in
+    --null)
+      if in_git_repo; then
+        git ls-files -z || return $?
+        git ls-files --others --exclude-standard -z || return $?
+        git ls-files --others --ignored --exclude-standard -z || return $?
+      fi
+      ;;
+    --records)
+      if command -v python >/dev/null 2>&1; then
+        local py_cmd=(python)
+      elif command -v python3 >/dev/null 2>&1; then
+        local py_cmd=(python3)
+      elif command -v py >/dev/null 2>&1; then
+        local py_cmd=(py -3)
+      else
+        printf 'repo-state: python, python3, or py -3 is required for window identity records\n' >&2
+        return 127
+      fi
+      "${py_cmd[@]}" - <<'PY'
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+
+
+def git(*args):
+    result = subprocess.run(["git", *args], capture_output=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.buffer.write(result.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+root = git("rev-parse", "--show-toplevel").decode("utf-8").strip()
+candidates = set()
+for args in (
+    ("ls-files", "--full-name", "-z"),
+    ("ls-files", "--full-name", "--others", "--exclude-standard", "-z"),
+    ("ls-files", "--full-name", "--others", "--ignored", "--exclude-standard", "-z"),
+):
+    for raw in git(*args).split(b"\0"):
+        if not raw:
+            continue
+        path = raw.decode("utf-8")
+        if not path or os.path.isabs(path) or ".." in path.split("/"):
+            raise SystemExit(f"repo-state: unsafe window identity path: {path}")
+        candidates.add(path)
+
+
+def digest_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def record(path, display=None):
+    full = os.path.join(root, path)
+    if not os.path.lexists(full):
+        return None
+    shown = path if display is None else display
+    mode = os.lstat(full).st_mode
+    if stat.S_ISREG(mode):
+        return {"path": shown, "type": "regular", "extent": os.lstat(full).st_size, "sha256": digest_file(full)}
+    if stat.S_ISLNK(mode):
+        target = os.readlink(full).encode("utf-8", "surrogateescape")
+        return {"path": shown, "type": "symlink", "extent": len(target), "sha256": hashlib.sha256(target).hexdigest()}
+    if stat.S_ISDIR(mode):
+        children = []
+        for base, dirs, files in os.walk(full, followlinks=False):
+            dirs.sort()
+            files.sort()
+            for name in dirs + files:
+                child = os.path.join(base, name)
+                relative = os.path.relpath(child, full).replace(os.sep, "/")
+                child_record = record(os.path.relpath(child, root).replace(os.sep, "/"), relative)
+                if child_record is not None:
+                    children.append(child_record)
+        payload = json.dumps(children, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return {"path": shown, "type": "directory", "extent": len(children), "sha256": hashlib.sha256(payload).hexdigest()}
+    raise SystemExit(f"repo-state: unsupported window identity type: {path}")
+
+
+records = [item for item in (record(path) for path in sorted(candidates)) if item is not None]
+payload = b"\0".join(
+    json.dumps(item, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    for item in records
+)
+if payload:
+    sys.stdout.buffer.write(payload + b"\0")
+PY
+      ;;
+    *)
+      printf 'usage: repo-state.sh window-identities --null|--records\n' >&2
+      return 2
+      ;;
+  esac
 }
 
 cmd_added_lines() {
@@ -417,7 +506,7 @@ case "$subcommand" in
     ;;
   window-identities)
     [ "$#" -eq 1 ] || {
-      printf 'usage: repo-state.sh window-identities --null\n' >&2
+      printf 'usage: repo-state.sh window-identities --null|--records\n' >&2
       exit 2
     }
     cmd_window_identities "$1"
@@ -436,7 +525,7 @@ repo-state.sh - evaluate complete working-tree state vs a baseline commit.
   repo-state.sh deliverable   <baseline> <path>
   repo-state.sh changed-files <baseline>
   repo-state.sh window-changed-files --null <baseline>
-  repo-state.sh window-identities --null
+  repo-state.sh window-identities --null|--records
   repo-state.sh added-lines   <baseline>
   repo-state.sh commit-message <message-file> [--ledger-linked]
   repo-state.sh ignored-artifact <source|package|release> <artifact> <published-digest-record> <authority-baseline>

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -102,6 +102,23 @@ cmd_changed_files() {
   fi
 }
 
+cmd_window_changed_files() {
+  local format="$1" baseline="$2"
+  [ "$format" = "--null" ] || {
+    printf 'usage: repo-state.sh window-changed-files --null <baseline>\n' >&2
+    return 2
+  }
+  if in_git_repo && baseline_ok "$baseline"; then
+    # Unlike changed-files, this verification-window census must retain every
+    # current path identity that can intersect a declared surface. In
+    # particular, ignored files and .IMPLEMENTAUDIT/ run-root files are live
+    # surfaces when explicitly declared by an open window.
+    git diff --name-only -z "$baseline" 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null || true
+    git ls-files --others --ignored --exclude-standard -z 2>/dev/null || true
+  fi
+}
+
 cmd_added_lines() {
   local baseline="$1"
   if in_git_repo && baseline_ok "$baseline"; then
@@ -375,6 +392,13 @@ case "$subcommand" in
     }
     cmd_changed_files "$1"
     ;;
+  window-changed-files)
+    [ "$#" -eq 2 ] || {
+      printf 'usage: repo-state.sh window-changed-files --null <baseline>\n' >&2
+      exit 2
+    }
+    cmd_window_changed_files "$1" "$2"
+    ;;
   added-lines)
     [ "$#" -ge 1 ] || {
       printf 'usage: repo-state.sh added-lines <baseline>\n' >&2
@@ -388,6 +412,7 @@ repo-state.sh - evaluate complete working-tree state vs a baseline commit.
 
   repo-state.sh deliverable   <baseline> <path>
   repo-state.sh changed-files <baseline>
+  repo-state.sh window-changed-files --null <baseline>
   repo-state.sh added-lines   <baseline>
   repo-state.sh commit-message <message-file> [--ledger-linked]
   repo-state.sh ignored-artifact <source|package|release> <artifact> <published-digest-record> <authority-baseline>

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -177,6 +177,7 @@ import os
 import stat
 import subprocess
 import sys
+from pathlib import PurePosixPath
 
 
 def git(*args):
@@ -208,11 +209,17 @@ if not arguments:
     raise SystemExit(2)
 for surface in arguments:
     normalized = surface.replace("\\", "/")
-    path = normalized.rstrip("/")
-    if (not path or os.path.isabs(path) or ".." in path.split("/")
-            or (len(path) > 1 and path[1] == ":")):
+    pure = PurePosixPath(normalized)
+    if (not normalized or pure.is_absolute() or ".." in pure.parts
+            or normalized.startswith("/")
+            or (len(normalized) > 1 and normalized[1] == ":")):
         print(f"repo-state: unsafe declared window surface: {surface}", file=sys.stderr)
         raise SystemExit(2)
+    path = str(pure)
+    if path in {"", "."}:
+        print(f"repo-state: unsafe declared window surface: {surface}", file=sys.stderr)
+        raise SystemExit(2)
+    normalized = path + "/" if normalized.endswith("/") else path
     declared_surfaces.append(normalized)
     if normalized.endswith("/"):
         if any(char in path for char in "*?[]"):

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -137,12 +137,28 @@ cmd_window_identities() {
     --records)
       local surfaces=()
       while [ "$#" -gt 0 ]; do
-        [ "$1" = "--surface" ] && [ "$#" -ge 2 ] || {
-          printf 'usage: repo-state.sh window-identities --records [--surface <directory-surface>]...\n' >&2
-          return 2
-        }
-        surfaces+=("$2")
-        shift 2
+        case "$1" in
+          --surface)
+            [ "$#" -ge 2 ] || {
+              printf 'usage: repo-state.sh window-identities --records [--surface <directory-surface>]...\n' >&2
+              return 2
+            }
+            surfaces+=("$2")
+            shift 2
+            ;;
+          --surfaces-env)
+            [ "$#" -eq 1 ] || {
+              printf 'usage: repo-state.sh window-identities --records [--surface <directory-surface>]...\n' >&2
+              return 2
+            }
+            surfaces+=("$1")
+            shift
+            ;;
+          *)
+            printf 'usage: repo-state.sh window-identities --records [--surface <directory-surface>]...\n' >&2
+            return 2
+            ;;
+        esac
       done
       if command -v python >/dev/null 2>&1; then
         local py_cmd=(python)
@@ -172,16 +188,40 @@ def git(*args):
 
 
 root = git("rev-parse", "--show-toplevel").decode("utf-8").strip()
+arguments = sys.argv[1:]
+if arguments == ["--surfaces-env"]:
+    try:
+        arguments = json.loads(os.environ["IMPLEMENTAUDIT_WINDOW_SURFACES_JSON"])
+    except (KeyError, json.JSONDecodeError):
+        print("repo-state: window identity records have invalid declared surfaces", file=sys.stderr)
+        raise SystemExit(2)
+    if not isinstance(arguments, list) or any(not isinstance(surface, str) for surface in arguments):
+        print("repo-state: window identity records have invalid declared surfaces", file=sys.stderr)
+        raise SystemExit(2)
+elif "--surfaces-env" in arguments:
+    print("repo-state: --surfaces-env cannot be combined with --surface", file=sys.stderr)
+    raise SystemExit(2)
 explicit_directories = {}
-for surface in sys.argv[1:]:
+declared_surfaces = []
+if not arguments:
+    print("repo-state: window identity receipt requires at least one declared surface", file=sys.stderr)
+    raise SystemExit(2)
+for surface in arguments:
     normalized = surface.replace("\\", "/")
-    if not normalized.endswith("/"):
-        continue
     path = normalized.rstrip("/")
     if (not path or os.path.isabs(path) or ".." in path.split("/")
-            or any(char in path for char in "*?[]")):
-        raise SystemExit(f"repo-state: unsafe explicit window directory surface: {surface}")
-    explicit_directories[path] = normalized
+            or (len(path) > 1 and path[1] == ":")):
+        print(f"repo-state: unsafe declared window surface: {surface}", file=sys.stderr)
+        raise SystemExit(2)
+    declared_surfaces.append(normalized)
+    if normalized.endswith("/"):
+        if any(char in path for char in "*?[]"):
+            print(f"repo-state: unsupported declared directory surface: {surface}", file=sys.stderr)
+            raise SystemExit(2)
+        explicit_directories[path] = normalized
+if len(set(declared_surfaces)) != len(declared_surfaces):
+    print("repo-state: declared window surfaces must be unique", file=sys.stderr)
+    raise SystemExit(2)
 candidates = set()
 for args in (
     ("ls-files", "--full-name", "-z"),
@@ -240,12 +280,10 @@ records = [
     )
     if item is not None
 ]
-payload = b"\0".join(
-    json.dumps(item, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    for item in records
-)
-if payload:
-    sys.stdout.buffer.write(payload + b"\0")
+header = {"schema": "verification-window-identity-receipt-v1", "surfaces": sorted(declared_surfaces)}
+sys.stdout.buffer.write(json.dumps(header, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\0")
+for item in records:
+    sys.stdout.buffer.write(json.dumps(item, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\0")
 PY
       ;;
     *)

--- a/skills/implementaudit/scripts/repo-state.sh
+++ b/skills/implementaudit/scripts/repo-state.sh
@@ -121,8 +121,13 @@ cmd_window_changed_files() {
 
 cmd_window_identities() {
   local format="$1"
+  shift
   case "$format" in
     --null)
+      [ "$#" -eq 0 ] || {
+        printf 'usage: repo-state.sh window-identities --null\n' >&2
+        return 2
+      }
       if in_git_repo; then
         git ls-files -z || return $?
         git ls-files --others --exclude-standard -z || return $?
@@ -130,6 +135,15 @@ cmd_window_identities() {
       fi
       ;;
     --records)
+      local surfaces=()
+      while [ "$#" -gt 0 ]; do
+        [ "$1" = "--surface" ] && [ "$#" -ge 2 ] || {
+          printf 'usage: repo-state.sh window-identities --records [--surface <directory-surface>]...\n' >&2
+          return 2
+        }
+        surfaces+=("$2")
+        shift 2
+      done
       if command -v python >/dev/null 2>&1; then
         local py_cmd=(python)
       elif command -v python3 >/dev/null 2>&1; then
@@ -140,7 +154,7 @@ cmd_window_identities() {
         printf 'repo-state: python, python3, or py -3 is required for window identity records\n' >&2
         return 127
       fi
-      "${py_cmd[@]}" - <<'PY'
+      "${py_cmd[@]}" - "${surfaces[@]}" <<'PY'
 import hashlib
 import json
 import os
@@ -158,6 +172,16 @@ def git(*args):
 
 
 root = git("rev-parse", "--show-toplevel").decode("utf-8").strip()
+explicit_directories = {}
+for surface in sys.argv[1:]:
+    normalized = surface.replace("\\", "/")
+    if not normalized.endswith("/"):
+        continue
+    path = normalized.rstrip("/")
+    if (not path or os.path.isabs(path) or ".." in path.split("/")
+            or any(char in path for char in "*?[]")):
+        raise SystemExit(f"repo-state: unsafe explicit window directory surface: {surface}")
+    explicit_directories[path] = normalized
 candidates = set()
 for args in (
     ("ls-files", "--full-name", "-z"),
@@ -171,6 +195,7 @@ for args in (
         if not path or os.path.isabs(path) or ".." in path.split("/"):
             raise SystemExit(f"repo-state: unsafe window identity path: {path}")
         candidates.add(path)
+candidates.update(explicit_directories)
 
 
 def digest_file(path):
@@ -208,7 +233,13 @@ def record(path, display=None):
     raise SystemExit(f"repo-state: unsupported window identity type: {path}")
 
 
-records = [item for item in (record(path) for path in sorted(candidates)) if item is not None]
+records = [
+    item for item in (
+        record(path, explicit_directories.get(path))
+        for path in sorted(candidates)
+    )
+    if item is not None
+]
 payload = b"\0".join(
     json.dumps(item, sort_keys=True, separators=(",", ":")).encode("utf-8")
     for item in records
@@ -218,7 +249,7 @@ if payload:
 PY
       ;;
     *)
-      printf 'usage: repo-state.sh window-identities --null|--records\n' >&2
+      printf 'usage: repo-state.sh window-identities --null|--records [--surface <directory-surface>]...\n' >&2
       return 2
       ;;
   esac
@@ -505,11 +536,11 @@ case "$subcommand" in
     cmd_window_changed_files "$1" "$2"
     ;;
   window-identities)
-    [ "$#" -eq 1 ] || {
-      printf 'usage: repo-state.sh window-identities --null|--records\n' >&2
+    [ "$#" -ge 1 ] || {
+      printf 'usage: repo-state.sh window-identities --null|--records [--surface <directory-surface>]...\n' >&2
       exit 2
     }
-    cmd_window_identities "$1"
+    cmd_window_identities "$@"
     ;;
   added-lines)
     [ "$#" -ge 1 ] || {
@@ -525,7 +556,7 @@ repo-state.sh - evaluate complete working-tree state vs a baseline commit.
   repo-state.sh deliverable   <baseline> <path>
   repo-state.sh changed-files <baseline>
   repo-state.sh window-changed-files --null <baseline>
-  repo-state.sh window-identities --null|--records
+  repo-state.sh window-identities --null|--records [--surface <directory-surface>]...
   repo-state.sh added-lines   <baseline>
   repo-state.sh commit-message <message-file> [--ledger-linked]
   repo-state.sh ignored-artifact <source|package|release> <artifact> <published-digest-record> <authority-baseline>

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -458,7 +458,9 @@ with a durable status contract, never awaited inline:
    produced by that chain; record an `evidence-mismatch` Andon, re-run, or mark
    the verdict unverified. After closure, cite the verdict only when the closing
    anchor equals `opened_at` or the complete `opened_at`-to-`closed_at` diff is disjoint
-   from `surfaces`. A disjoint mutation does not freeze the whole repository.
+   from `surfaces`. Window intersection uses complete path identities, including ignored
+   and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces. A disjoint
+   mutation does not freeze the whole repository.
    Compound shell verification (`git stash`, `git checkout --`, or an
    `&&`-chained restore) is itself a surface mutation: run the check as one
    command and restore state in a separate, separately observed action.

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -462,9 +462,10 @@ with a durable status contract, never awaited inline:
    and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces. A disjoint
    mutation does not freeze the whole repository. At open, persist a NUL-delimited
    `opening_identity_receipt` with its `opening_identity_sha256`; at close, persist a
-   `closing_identity_receipt` with its `closing_identity_sha256`. The checker compares
-   those bound identity populations and fails closed if either receipt is unavailable,
-   altered, or cannot be enumerated.
+   `closing_identity_receipt` with its `closing_identity_sha256`. Each record binds a
+   path, type, extent, and SHA-256 digest. The checker compares those bound identity
+   populations and fails closed if either receipt is unavailable, altered, or cannot be
+   enumerated.
    Compound shell verification (`git stash`, `git checkout --`, or an
    `&&`-chained restore) is itself a surface mutation: run the check as one
    command and restore state in a separate, separately observed action.

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -462,10 +462,12 @@ with a durable status contract, never awaited inline:
    and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces. A disjoint
    mutation does not freeze the whole repository. At open, persist a NUL-delimited
    `opening_identity_receipt` with its `opening_identity_sha256`; at close, persist a
-   `closing_identity_receipt` with its `closing_identity_sha256`. Each record binds a
-   path, type, extent, and SHA-256 digest. The checker compares those bound identity
-   populations and fails closed if either receipt is unavailable, altered, or cannot be
-   enumerated. Declared trailing-slash directory surfaces are explicitly included in
+   `closing_identity_receipt` with its `closing_identity_sha256`. Each receipt binds the
+   normalized complete declared-surface population, including explicitly absent paths and directories,
+   as well as records binding each present path, type, extent, and SHA-256 digest. The checker
+   requires each receipt declaration to equal the window's declared
+   surfaces, compares those bound identity populations, and fails closed if either receipt
+   is unavailable, altered, or cannot be enumerated. Declared trailing-slash directory surfaces are explicitly included in
    those receipts, so empty ignored or run-root directories retain identity without
    expanding the census to unrelated directory trees.
    Compound shell verification (`git stash`, `git checkout --`, or an

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -460,7 +460,11 @@ with a durable status contract, never awaited inline:
    anchor equals `opened_at` or the complete `opened_at`-to-`closed_at` diff is disjoint
    from `surfaces`. Window intersection uses complete path identities, including ignored
    and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces. A disjoint
-   mutation does not freeze the whole repository.
+   mutation does not freeze the whole repository. At open, persist a NUL-delimited
+   `opening_identity_receipt` with its `opening_identity_sha256`; at close, persist a
+   `closing_identity_receipt` with its `closing_identity_sha256`. The checker compares
+   those bound identity populations and fails closed if either receipt is unavailable,
+   altered, or cannot be enumerated.
    Compound shell verification (`git stash`, `git checkout --`, or an
    `&&`-chained restore) is itself a surface mutation: run the check as one
    command and restore state in a separate, separately observed action.

--- a/skills/implementaudit/templates/PROTOCOL.md
+++ b/skills/implementaudit/templates/PROTOCOL.md
@@ -465,7 +465,9 @@ with a durable status contract, never awaited inline:
    `closing_identity_receipt` with its `closing_identity_sha256`. Each record binds a
    path, type, extent, and SHA-256 digest. The checker compares those bound identity
    populations and fails closed if either receipt is unavailable, altered, or cannot be
-   enumerated.
+   enumerated. Declared trailing-slash directory surfaces are explicitly included in
+   those receipts, so empty ignored or run-root directories retain identity without
+   expanding the census to unrelated directory trees.
    Compound shell verification (`git stash`, `git checkout --`, or an
    `&&`-chained restore) is itself a surface mutation: run the check as one
    command and restore state in a separate, separately observed action.

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -740,13 +740,13 @@ with zipfile.ZipFile(asset) as zf:
         "owner", "dedicated-calibration-lane",
     }
 
-    # The extracted payload is byte-identical to the 227,999-byte final R29
-    # package; canonical Zopfli method-8 DEFLATE yields 220,699 bytes. This
-    # dedicated R33 calibration lane uses the smallest whole-1,000-byte value
-    # preserving at least 2,000 bytes of measured headroom. The 230,000-byte
-    # outer bound remains unchanged, and capacity is not a target.
-    MAX_ASSET_BYTES = 223_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 220_699
+    # The R02 verification-window repair raises the canonical Zopfli method-8
+    # package to 224,063 bytes. This dedicated R33 calibration uses the
+    # smallest whole-1,000-byte value preserving at least 2,000 bytes of
+    # measured headroom. The 230,000-byte outer bound remains unchanged, and
+    # capacity is not a target.
+    MAX_ASSET_BYTES = 227_000
+    CURRENT_CALIBRATION_ASSET_BYTES = 224_063
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -741,12 +741,12 @@ with zipfile.ZipFile(asset) as zf:
     }
 
     # The R02 verification-window repair raises the canonical Zopfli method-8
-    # package to 224,063 bytes. This dedicated R33 calibration uses the
+    # package to 224,179 bytes. This dedicated R33 calibration uses the
     # smallest whole-1,000-byte value preserving at least 2,000 bytes of
     # measured headroom. The 230,000-byte outer bound remains unchanged, and
     # capacity is not a target.
     MAX_ASSET_BYTES = 227_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 224_063
+    CURRENT_CALIBRATION_ASSET_BYTES = 224_179
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -30,7 +30,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 28)]
+expected = [f"R2-F{i}" for i in range(1, 34)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY
@@ -59,11 +59,11 @@ write_intent() {
   fi
   mkdir -p "$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a"
   if [ ! -f "$opening_receipt" ]; then
-    (cd "$repo" && bash "$repo_state" window-identities --records > "$opening_receipt") \
+    (cd "$repo" && bash "$repo_state" window-identities --records --surface "$surface" > "$opening_receipt") \
       || fail 'unable to record opening identity receipt'
   fi
   if [ "$state" = closed ]; then
-    (cd "$repo" && bash "$repo_state" window-identities --records > "$closing_receipt") \
+    (cd "$repo" && bash "$repo_state" window-identities --records --surface "$surface" > "$closing_receipt") \
       || fail 'unable to record closing identity receipt'
   fi
   local opening_digest
@@ -534,6 +534,84 @@ if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now"
 fi
 ok
 
+# R2-F28/R2-F29/R2-F30: declared empty ignored directories retain their own
+# identity. Existing empty directories pass, while creation and deletion fail.
+new_repo f28-unchanged-empty-ignored-directory
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-empty-directory
+mkdir -p "$case_repo/ignored/empty"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/empty/'
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/empty/'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+(cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f28.out" 2>&1 \
+  || fail 'R2-F28 unchanged empty ignored directory must pass'
+ok
+
+new_repo f29-created-empty-ignored-directory
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-empty-directory
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/empty/'
+mkdir -p "$case_repo/ignored/empty"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/empty/'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f29.out" 2>&1; then
+  fail 'R2-F29 created empty ignored directory must fail'
+fi
+ok
+
+new_repo f30-deleted-empty-ignored-directory
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-empty-directory
+mkdir -p "$case_repo/ignored/empty"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/empty/'
+rmdir "$case_repo/ignored/empty"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f30.out" 2>&1; then
+  fail 'R2-F30 deleted empty ignored directory must fail'
+fi
+ok
+
+# R2-F31/R2-F32/R2-F33 repeat the empty-directory controls for an explicit
+# run-root surface that Git does not otherwise enumerate.
+new_repo f31-unchanged-empty-run-root-directory
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live/empty"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/empty/'
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/empty/'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+(cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f31.out" 2>&1 \
+  || fail 'R2-F31 unchanged empty run-root directory must pass'
+ok
+
+new_repo f32-created-empty-run-root-directory
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/empty/'
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live/empty"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/empty/'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f32.out" 2>&1; then
+  fail 'R2-F32 created empty run-root directory must fail'
+fi
+ok
+
+new_repo f33-deleted-empty-run-root-directory
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live/empty"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/empty/'
+rmdir "$case_repo/.IMPLEMENTAUDIT/runs/window/live/empty"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f33.out" 2>&1; then
+  fail 'R2-F33 deleted empty run-root directory must fail'
+fi
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -558,8 +636,11 @@ ok
 grep -Fq 'path, type, extent, and SHA-256 digest' "$protocol" \
   || fail 'verification-window content identity receipt contract missing'
 ok
+grep -Fq 'Declared trailing-slash directory surfaces are explicitly included' "$protocol" \
+  || fail 'verification-window empty directory identity contract missing'
+ok
 grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-design verification boundary missing'
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/38)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/45)\n' "$count"

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -30,7 +30,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 22)]
+expected = [f"R2-F{i}" for i in range(1, 28)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY
@@ -59,11 +59,11 @@ write_intent() {
   fi
   mkdir -p "$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a"
   if [ ! -f "$opening_receipt" ]; then
-    (cd "$repo" && bash "$repo_state" window-identities --null > "$opening_receipt") \
+    (cd "$repo" && bash "$repo_state" window-identities --records > "$opening_receipt") \
       || fail 'unable to record opening identity receipt'
   fi
   if [ "$state" = closed ]; then
-    (cd "$repo" && bash "$repo_state" window-identities --null > "$closing_receipt") \
+    (cd "$repo" && bash "$repo_state" window-identities --records > "$closing_receipt") \
       || fail 'unable to record closing identity receipt'
   fi
   local opening_digest
@@ -430,6 +430,110 @@ grep -Fq 'closing identity receipt digest does not match' "$tmp/f21.out" \
   || fail 'R2-F21 output missing closing receipt integrity failure'
 ok
 
+# R2-F22: an ignored identity that existed at opening and remains byte-for-byte
+# unchanged through an equal-SHA close is not a mutation.
+new_repo f22-equal-unchanged-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-unchanged
+mkdir -p "$case_repo/ignored"
+printf 'unchanged\n' > "$case_repo/ignored/declared.txt"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+(cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f22.out" 2>&1 \
+  || fail 'R2-F22 unchanged ignored identity at equal-SHA close must pass'
+ok
+
+# R2-F23/R2-F24: pre-existing ignored content must stale both equal-SHA and
+# historical closing windows when its bytes change during the window.
+new_repo f23-equal-mutated-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-mutated-equal
+mkdir -p "$case_repo/ignored"
+printf 'before\n' > "$case_repo/ignored/declared.txt"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+printf 'after\n' > "$case_repo/ignored/declared.txt"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f23.out" 2>&1; then
+  fail 'R2-F23 in-place ignored mutation at equal-SHA close must fail'
+fi
+ok
+
+new_repo f24-historical-mutated-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-mutated-historical
+mkdir -p "$case_repo/ignored"
+printf 'before\n' > "$case_repo/ignored/declared.txt"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+printf 'after\n' > "$case_repo/ignored/declared.txt"
+printf 'closing anchor\n' > "$case_repo/docs/readme.md"
+git -C "$case_repo" add docs/readme.md
+git -C "$case_repo" commit -qm historical-close
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/declared.txt'
+printf 'later ordinary work\n' > "$case_repo/scratch/later.txt"
+git -C "$case_repo" add scratch/later.txt
+git -C "$case_repo" commit -qm post-close
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f24.out" 2>&1; then
+  fail 'R2-F24 in-place ignored mutation at historical close must fail'
+fi
+ok
+
+# R2-F25/R2-F26/R2-F27 repeat the unchanged and in-place controls for a
+# declared run-root identity.
+new_repo f25-equal-unchanged-run-root
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'unchanged\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+(cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f25.out" 2>&1 \
+  || fail 'R2-F25 unchanged run-root identity at equal-SHA close must pass'
+ok
+
+new_repo f26-equal-mutated-run-root
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'before\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+printf 'after\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f26.out" 2>&1; then
+  fail 'R2-F26 in-place run-root mutation at equal-SHA close must fail'
+fi
+ok
+
+new_repo f27-historical-mutated-run-root
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'before\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+printf 'after\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+printf 'closing anchor\n' > "$case_repo/docs/readme.md"
+git -C "$case_repo" add docs/readme.md
+git -C "$case_repo" commit -qm historical-close
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+printf 'later ordinary work\n' > "$case_repo/scratch/later.txt"
+git -C "$case_repo" add scratch/later.txt
+git -C "$case_repo" commit -qm post-close
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f27.out" 2>&1; then
+  fail 'R2-F27 in-place run-root mutation at historical close must fail'
+fi
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -451,8 +555,11 @@ grep -Fq 'opening_identity_receipt' "$protocol" \
 grep -Fq 'closing_identity_receipt' "$protocol" \
   || fail 'verification-window closing identity receipt contract missing'
 ok
+grep -Fq 'path, type, extent, and SHA-256 digest' "$protocol" \
+  || fail 'verification-window content identity receipt contract missing'
+ok
 grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-design verification boundary missing'
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/31)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/38)\n' "$count"

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -30,7 +30,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 34)]
+expected = [f"R2-F{i}" for i in range(1, 37)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY
@@ -612,6 +612,56 @@ if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now"
 fi
 ok
 
+# R2-F34: receipt creation requires the declared surface population, rather
+# than allowing an unbound record set with zero --surface inputs.
+new_repo f34-empty-surface-population
+if (cd "$case_repo" && bash "$repo_state" window-identities --records) >"$tmp/f34.out" 2>&1; then
+  fail 'R2-F34 window identity receipt without declared surfaces must fail'
+fi
+grep -Fq 'requires at least one declared surface' "$tmp/f34.out" \
+  || fail 'R2-F34 output missing declared-surface requirement'
+ok
+
+# R2-F35: a digest-rebound opening receipt that omits an existing empty ignored
+# directory declaration cannot buy an open-window pass.
+new_repo f35-omitted-opening-empty-ignored-directory
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-empty-directory
+mkdir -p "$case_repo/ignored/empty"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/empty/'
+opening_receipt="$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/opening-identities.nul"
+(cd "$case_repo" && bash "$repo_state" window-identities --records --surface 'docs/' > "$opening_receipt")
+opening_digest="$(sha256sum "$opening_receipt" | awk '{print $1}')"
+sed -i "s/^    opening_identity_sha256: .*/    opening_identity_sha256: $opening_digest/" "$case_intent"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f35.out" 2>&1; then
+  fail 'R2-F35 omitted opening empty ignored declaration must fail'
+fi
+grep -Fq 'declared surfaces do not match' "$tmp/f35.out" \
+  || fail 'R2-F35 output missing opening surface-binding failure'
+ok
+
+# R2-F36: the same declaration-binding check applies to the closing receipt of
+# an unchanged empty run-root directory.
+new_repo f36-omitted-closing-empty-run-root-directory
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live/empty"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/empty/'
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/empty/'
+closing_receipt="$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/closing-identities.nul"
+(cd "$case_repo" && bash "$repo_state" window-identities --records --surface 'docs/' > "$closing_receipt")
+closing_digest="$(sha256sum "$closing_receipt" | awk '{print $1}')"
+sed -i "s/^    closing_identity_sha256: .*/    closing_identity_sha256: $closing_digest/" "$case_intent"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f36.out" 2>&1; then
+  fail 'R2-F36 omitted closing empty run-root declaration must fail'
+fi
+grep -Fq 'declared surfaces do not match' "$tmp/f36.out" \
+  || fail 'R2-F36 output missing closing surface-binding failure'
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -627,6 +677,8 @@ grep -Fq 'Window intersection uses complete path identities, including ignored' 
   || fail 'verification-window complete identity route missing'
 grep -Fq 'and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces' "$protocol" \
   || fail 'verification-window complete identity route missing'
+grep -Fq 'normalized complete declared-surface population, including explicitly absent paths and directories' "$protocol" \
+  || fail 'verification-window receipt surface binding contract missing'
 ok
 grep -Fq 'opening_identity_receipt' "$protocol" \
   || fail 'verification-window opening identity receipt contract missing'
@@ -643,4 +695,4 @@ grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/45)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/48)\n' "$count"

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -662,6 +662,24 @@ grep -Fq 'declared surfaces do not match' "$tmp/f36.out" \
   || fail 'R2-F36 output missing closing surface-binding failure'
 ok
 
+# R2-F37: equivalent repo-relative spellings are normalized before receipt
+# binding and intersection. A leading ./ must not hide an ignored mutation.
+new_repo f37-normalized-relative-surface
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+mkdir -p "$case_repo/ignored"
+printf 'before\n' > "$case_repo/ignored/declared.txt"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm normalize-declared-surface
+write_intent "$case_repo" open './ignored/declared.txt'
+printf 'after\n' > "$case_repo/ignored/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f37.out" 2>&1; then
+  fail 'R2-F37 leading-dot declared surface mutation must fail'
+fi
+grep -Fq 'ignored/declared.txt' "$tmp/f37.out" \
+  || fail 'R2-F37 output missing normalized intersecting path'
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -695,4 +713,4 @@ grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/48)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/49)\n' "$count"

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -29,7 +29,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 8)]
+expected = [f"R2-F{i}" for i in range(1, 14)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY
@@ -177,6 +177,96 @@ set -e
 grep -Fq 'Compound shell verification' "$protocol" || fail 'R2-F6 compound verification prohibition missing'
 ok
 
+# R2-F8: an ignored, declared file remains a live verification surface. This
+# starts with HEAD at opened_at, so an enumerator that only consults committed
+# diffs or standard untracked files incorrectly returns the anchor-current PASS.
+new_repo f8-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-declared-surface
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+mkdir -p "$case_repo/ignored"
+printf 'mutated while open\n' > "$case_repo/ignored/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f8.out" 2>&1; then
+  fail 'R2-F8 declared ignored surface mutation during an open window must fail'
+fi
+grep -Fq 'ignored/declared.txt' "$tmp/f8.out" || fail 'R2-F8 output missing ignored changed path'
+ok
+
+# R2-F9: a declared run-root file is a live verification surface even though
+# the ordinary repo-state census deliberately excludes .IMPLEMENTAUDIT/.
+new_repo f9-run-root
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/**'
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'mutated while open\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f9.out" 2>&1; then
+  fail 'R2-F9 declared run-root surface mutation during an open window must fail'
+fi
+grep -Fq '.IMPLEMENTAUDIT/runs/window/live/declared.txt' "$tmp/f9.out" \
+  || fail 'R2-F9 output missing run-root changed path'
+ok
+
+# R2-F10: a declared directory covers its descendants, rather than requiring
+# every child to be repeated as a separate path/glob surface.
+new_repo f10-directory
+write_intent "$case_repo" open 'curriculum/'
+printf 'mutated\n' > "$case_repo/curriculum/x.json"
+git -C "$case_repo" add curriculum/x.json
+git -C "$case_repo" commit -qm directory-intersection
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f10.out" 2>&1; then
+  fail 'R2-F10 declared directory mutation during an open window must fail'
+fi
+grep -Fq 'curriculum/x.json' "$tmp/f10.out" || fail 'R2-F10 output missing directory child path'
+ok
+
+# R2-F11: deletion is a declared-surface mutation even when the path is absent
+# when the window is checked.
+new_repo f11-missing
+mkdir -p "$case_repo/missing"
+printf 'present at open\n' > "$case_repo/missing/declared.txt"
+git -C "$case_repo" add missing/declared.txt
+git -C "$case_repo" commit -qm missing-path-at-open
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'missing/declared.txt'
+rm "$case_repo/missing/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f11.out" 2>&1; then
+  fail 'R2-F11 deleted declared path during an open window must fail'
+fi
+grep -Fq 'missing/declared.txt' "$tmp/f11.out" || fail 'R2-F11 output missing deleted path'
+ok
+
+# R2-F12: the glob control remains enforced by the repaired enumeration.
+new_repo f12-glob
+write_intent "$case_repo" open 'curriculum/*.json'
+printf 'mutated\n' > "$case_repo/curriculum/x.json"
+git -C "$case_repo" add curriculum/x.json
+git -C "$case_repo" commit -qm glob-intersection
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f12.out" 2>&1; then
+  fail 'R2-F12 declared glob mutation during an open window must fail'
+fi
+ok
+
+# R2-F13: complete enumeration remains surface-specific. An ignored held-out
+# path does not stale a window whose declared ignored surface is disjoint.
+new_repo f13-held-out
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-held-out
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared/**'
+mkdir -p "$case_repo/ignored"
+printf 'held out\n' > "$case_repo/ignored/not-declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+(cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f13.out" 2>&1 \
+  || fail 'R2-F13 ignored held-out path must remain disjoint'
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -188,8 +278,13 @@ ok
 grep -Fq '7. Verification-window freeze.' "$protocol" || fail 'PROTOCOL item 7 was not filled'
 grep -Fq '8. Wait contract.' "$protocol" || fail '#81 item 8 moved'
 grep -Fq '12. Checkpoint before block.' "$protocol" || fail '#81 item 12 moved'
+grep -Fq 'Window intersection uses complete path identities, including ignored' "$protocol" \
+  || fail 'verification-window complete identity route missing'
+grep -Fq 'and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces' "$protocol" \
+  || fail 'verification-window complete identity route missing'
+ok
 grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-design verification boundary missing'
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/15)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/22)\n' "$count"

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -30,7 +30,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 37)]
+expected = [f"R2-F{i}" for i in range(1, 38)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY

--- a/tests/verification-window-contract.test.sh
+++ b/tests/verification-window-contract.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 checker="$repo_root/skills/implementaudit/scripts/check-evidence-anchor.sh"
+repo_state="$repo_root/skills/implementaudit/scripts/repo-state.sh"
 cases="$repo_root/fixtures/verification-window/cases.json"
 protocol="$repo_root/skills/implementaudit/templates/PROTOCOL.md"
 phase_design="$repo_root/skills/implementaudit/references/phase-design.md"
@@ -29,7 +30,7 @@ fail() { printf 'verification-window-contract.test: %s\n' "$*" >&2; exit 1; }
 import json, sys
 rows = json.load(open(sys.argv[1], encoding="utf-8"))
 ids = [row.get("id") for row in rows]
-expected = [f"R2-F{i}" for i in range(1, 14)]
+expected = [f"R2-F{i}" for i in range(1, 22)]
 if ids != expected:
     raise SystemExit(f"verification-window cases must be exactly {expected}, got {ids}")
 PY
@@ -51,10 +52,26 @@ new_repo() {
 write_intent() {
   local repo="$1" state="$2" surface="${3:-curriculum/**}"
   local closed_at=none
+  local opening_receipt="$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/opening-identities.nul"
+  local closing_receipt="$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/closing-identities.nul"
   if [ "$state" = closed ]; then
     closed_at="$(git -C "$repo" rev-parse HEAD)"
   fi
   mkdir -p "$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a"
+  if [ ! -f "$opening_receipt" ]; then
+    (cd "$repo" && bash "$repo_state" window-identities --null > "$opening_receipt") \
+      || fail 'unable to record opening identity receipt'
+  fi
+  if [ "$state" = closed ]; then
+    (cd "$repo" && bash "$repo_state" window-identities --null > "$closing_receipt") \
+      || fail 'unable to record closing identity receipt'
+  fi
+  local opening_digest
+  opening_digest="$(sha256sum "$opening_receipt" | awk '{print $1}')"
+  local closing_digest=none
+  if [ "$state" = closed ]; then
+    closing_digest="$(sha256sum "$closing_receipt" | awk '{print $1}')"
+  fi
   printf '%s\n' \
     'command: verify-curriculum' \
     'owner/source: tests/verification-window-contract.test.sh' \
@@ -71,6 +88,10 @@ write_intent() {
     "    closed_at: $closed_at" \
     '    chain: chain-a' \
     "    state: $state" \
+    '    opening_identity_receipt: opening-identities.nul' \
+    "    opening_identity_sha256: $opening_digest" \
+    "    closing_identity_receipt: $([ "$state" = closed ] && printf '%s' closing-identities.nul || printf none)" \
+    "    closing_identity_sha256: $closing_digest" \
     > "$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/launch-intent.md"
   case_intent="$repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/launch-intent.md"
 }
@@ -267,6 +288,148 @@ case_now="$(git -C "$case_repo" rev-parse HEAD)"
   || fail 'R2-F13 ignored held-out path must remain disjoint'
 ok
 
+# R2-F14: a closed equal-SHA window still has to inspect its complete current
+# identity population. The ignored mutation occurs before chain.done but does
+# not move HEAD.
+new_repo f14-closed-equal-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-closed-equal
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+mkdir -p "$case_repo/ignored"
+printf 'mutated before close\n' > "$case_repo/ignored/declared.txt"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f14.out" 2>&1; then
+  fail 'R2-F14 closed equal-SHA ignored mutation must fail'
+fi
+grep -Fq 'ignored/declared.txt' "$tmp/f14.out" || fail 'R2-F14 output missing ignored path'
+ok
+
+# R2-F15: an ignored mutation before a historical closing anchor must not be
+# erased by the tracked-only opened-to-closed diff.
+new_repo f15-closed-historical-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-closed-historical
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+mkdir -p "$case_repo/ignored"
+printf 'mutated before close\n' > "$case_repo/ignored/declared.txt"
+printf 'closing anchor\n' > "$case_repo/docs/readme.md"
+git -C "$case_repo" add docs/readme.md
+git -C "$case_repo" commit -qm historical-close
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed 'ignored/declared.txt'
+printf 'later ordinary work\n' > "$case_repo/scratch/later.txt"
+git -C "$case_repo" add scratch/later.txt
+git -C "$case_repo" commit -qm post-close
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f15.out" 2>&1; then
+  fail 'R2-F15 historical closed ignored mutation must fail'
+fi
+grep -Fq 'ignored/declared.txt' "$tmp/f15.out" || fail 'R2-F15 output missing ignored path'
+ok
+
+# R2-F16: the closed equal-SHA route also retains a declared run-root path.
+new_repo f16-closed-equal-run-root
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'mutated before close\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f16.out" 2>&1; then
+  fail 'R2-F16 closed equal-SHA run-root mutation must fail'
+fi
+grep -Fq '.IMPLEMENTAUDIT/runs/window/live/declared.txt' "$tmp/f16.out" \
+  || fail 'R2-F16 output missing run-root path'
+ok
+
+# R2-F17: historical closure also retains declared run-root mutations.
+new_repo f17-closed-historical-run-root
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'mutated before close\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+printf 'closing anchor\n' > "$case_repo/docs/readme.md"
+git -C "$case_repo" add docs/readme.md
+git -C "$case_repo" commit -qm historical-close
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+printf 'later ordinary work\n' > "$case_repo/scratch/later.txt"
+git -C "$case_repo" add scratch/later.txt
+git -C "$case_repo" commit -qm post-close
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f17.out" 2>&1; then
+  fail 'R2-F17 historical closed run-root mutation must fail'
+fi
+grep -Fq '.IMPLEMENTAUDIT/runs/window/live/declared.txt' "$tmp/f17.out" \
+  || fail 'R2-F17 output missing run-root path'
+ok
+
+# R2-F18: a declared ignored identity present at opening cannot disappear
+# silently while the window is open.
+new_repo f18-deleted-ignored
+printf 'ignored/**\n' > "$case_repo/.gitignore"
+git -C "$case_repo" add .gitignore
+git -C "$case_repo" commit -qm ignore-deletion
+mkdir -p "$case_repo/ignored"
+printf 'present at open\n' > "$case_repo/ignored/declared.txt"
+case_opened="$(git -C "$case_repo" rev-parse HEAD)"
+write_intent "$case_repo" open 'ignored/declared.txt'
+rm "$case_repo/ignored/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f18.out" 2>&1; then
+  fail 'R2-F18 deleted ignored surface during an open window must fail'
+fi
+grep -Fq 'ignored/declared.txt' "$tmp/f18.out" || fail 'R2-F18 output missing deleted ignored path'
+ok
+
+# R2-F19: the opening identity receipt also makes a deleted declared run-root
+# path visible to the open-window check.
+new_repo f19-deleted-run-root
+mkdir -p "$case_repo/.IMPLEMENTAUDIT/runs/window/live"
+printf 'present at open\n' > "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+write_intent "$case_repo" open '.IMPLEMENTAUDIT/runs/window/live/declared.txt'
+rm "$case_repo/.IMPLEMENTAUDIT/runs/window/live/declared.txt"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f19.out" 2>&1; then
+  fail 'R2-F19 deleted run-root surface during an open window must fail'
+fi
+grep -Fq '.IMPLEMENTAUDIT/runs/window/live/declared.txt' "$tmp/f19.out" \
+  || fail 'R2-F19 output missing deleted run-root path'
+ok
+
+# R2-F20: a failed complete enumeration is a checker failure, never a quiet
+# disjoint verdict. `/dev/null` is not a valid Git index, while rev-parse can
+# still resolve the commit identity.
+new_repo f20-enumerator-failure
+write_intent "$case_repo" open
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && GIT_INDEX_FILE=/dev/null bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f20.out" 2>&1; then
+  fail 'R2-F20 failed window enumeration must fail the checker'
+fi
+grep -Fq 'complete window changed-files enumeration failed' "$tmp/f20.out" \
+  || fail 'R2-F20 output missing enumeration failure'
+ok
+
+# R2-F21: even at the closing HEAD, a closing receipt cannot be altered after
+# its digest was bound into the launch intent.
+new_repo f21-altered-closing-receipt
+write_intent "$case_repo" open
+touch "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/chain.done"
+write_intent "$case_repo" closed
+printf 'tampered\0' >> "$case_repo/.IMPLEMENTAUDIT/runs/window/background/chain-a/closing-identities.nul"
+case_now="$(git -C "$case_repo" rev-parse HEAD)"
+if (cd "$case_repo" && bash "$checker" --window "$case_intent" --now "$case_now") >"$tmp/f21.out" 2>&1; then
+  fail 'R2-F21 altered closing identity receipt must fail'
+fi
+grep -Fq 'closing identity receipt digest does not match' "$tmp/f21.out" \
+  || fail 'R2-F21 output missing closing receipt integrity failure'
+ok
+
 # Legacy anchor modes remain compatible.
 bash "$checker" --row 'legacy evidence without an anchor' >/dev/null
 artifact="$tmp/artifact.md"
@@ -283,8 +446,13 @@ grep -Fq 'Window intersection uses complete path identities, including ignored' 
 grep -Fq 'and .IMPLEMENTAUDIT/ run-root paths, when they are declared surfaces' "$protocol" \
   || fail 'verification-window complete identity route missing'
 ok
+grep -Fq 'opening_identity_receipt' "$protocol" \
+  || fail 'verification-window opening identity receipt contract missing'
+grep -Fq 'closing_identity_receipt' "$protocol" \
+  || fail 'verification-window closing identity receipt contract missing'
+ok
 grep -Fq 'verification is reading the same tree' "$phase_design" || fail 'phase-design verification boundary missing'
 grep -Fq 'post-state was compared' "$lean" || fail 'Lean post-state evidence boundary missing'
 ok; ok; ok; ok; ok
 
-printf 'verification-window-contract.test: ok (%d/22)\n' "$count"
+printf 'verification-window-contract.test: ok (%d/31)\n' "$count"


### PR DESCRIPTION
## Summary

- repair the reopened R02 false green by binding verification windows to complete declared-surface identity receipts, including ignored files, `.IMPLEMENTAUDIT/` run-root paths, missing paths, and explicit empty directories
- compare path, type, extent, and SHA-256 identities at opening, closing, and current readback; propagate enumeration failures instead of treating them as empty evidence
- normalize equivalent repo-relative surface spellings before receipt binding and intersection
- preserve tracked/disjoint/post-terminal cheap paths and avoid a universal filesystem census

## Exact candidate

- source head: `26d38fb1a9665581b43b291e93a2964c33685231`
- source tree: `3e246d8822fe11e48fa4a07b17646ba48b4dc9e1`
- base main: `1372a8e1041f22c54633bf277f4db6241d50839d`
- package: 224,179 bytes
- SHA-256: `67f85da14fc8143d8c7023547365feb74e45467cdecb374429f0b44d7d30eac9`
- members: 50; dashboard members: 0
- calibrated ceiling/headroom: 227,000 / 2,821 bytes under the unchanged 230,000 outer bound

## Evidence

- original reopened witness: an explicitly declared ignored or run-root surface could mutate while an open window still reported disjoint/current
- additional independent held-outs caught closed equal-SHA bypasses, deleted excluded surfaces, masked enumeration failure, zero-surface receipts, and `./` normalization mismatch
- fixture population now binds exactly `R2-F1..R2-F37`
- focused PASS: verification-window 49/49, repo-state, shell syntax, exact release-asset policy, exact-commit reproducibility, R33 semantic preservation 21/21, R35 acceptance integrity 39/39, Lean 17/17, diff/commit cleanliness
- normalization adjacent held-outs: 7/7 PASS, including doubled separators, embedded `./`, trailing directories, root rejection, and canonical duplicate rejection
- independent exact-tree review: PASS, no remaining finding, safe to push

No local complete verifier was run for this rebased candidate. Hosted validation on this exact head is the broad verdict.

## Boundaries

This repairs R02's declared verification-surface interval contract. It does not implement R36's wider observation-bound destructive mutation, CAS, locking, rollback, byte-preservation, or binary-safety residual.

Links #75 without closing it. Closure remains evidence-bound to exact merged main and hosted readback.