### PR TITLE
Repair R11 rehearsal execution and R30 reachability

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,6 +62,7 @@ jobs:
           bash tests/closure-surface-contract.test.sh
           bash tests/authorization-binding-contract.test.sh
           bash tests/scarce-resource-rehearsal-contract.test.sh
+          bash tests/r11-r30-review-heldouts.test.sh
           bash tests/convergence-mode-contract.test.sh
           bash tests/andon-escalation-judgment.test.sh
           bash tests/background-chain-contract.test.sh

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -268,13 +268,35 @@ def has_mediated_execution(body):
                 and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == base and node.func.attr == attribute)
 
-    bridge_written = any(is_call(node, "bridge_path", "write_text")
-                         for node in ast.walk(tree))
+    def literal_truth(node):
+        return bool(node.value) if isinstance(node, ast.Constant) else None
+
+    def executable_nodes(nodes):
+        for node in nodes:
+            yield node
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(node, ast.If):
+                truth = literal_truth(node.test)
+                branches = node.orelse if truth is False else node.body if truth is True else node.body + node.orelse
+                yield from executable_nodes(branches)
+                continue
+            if isinstance(node, (ast.While, ast.For, ast.AsyncFor)):
+                if isinstance(node, ast.While) and literal_truth(node.test) is False:
+                    yield from executable_nodes(node.orelse)
+                else:
+                    yield from executable_nodes(node.body + node.orelse)
+                continue
+            for child in ast.iter_child_nodes(node):
+                yield from executable_nodes([child])
+
+    live = list(executable_nodes(tree.body))
+    bridge_written = any(is_call(node, "bridge_path", "write_text") for node in live)
     thread_bound = False
     thread_started = False
     thread_joined = False
     stub_function = None
-    for node in ast.walk(tree):
+    for node in live:
         if isinstance(node, ast.FunctionDef) and node.name == "run_bounded_stub":
             stub_function = node
         if not (isinstance(node, ast.Assign) and len(node.targets) == 1
@@ -290,7 +312,7 @@ def has_mediated_execution(body):
                            and isinstance(keyword.value, ast.Name)
                            and keyword.value.id == "run_bounded_stub"
                            for keyword in value.keywords)
-    for node in ast.walk(tree):
+    for node in live:
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                 and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == "mediator_thread"):
@@ -302,7 +324,7 @@ def has_mediated_execution(body):
         and isinstance(node.func.value, ast.Name) and node.func.value.id == "subprocess"
         and node.func.attr == "run" and node.args
         and isinstance(node.args[0], ast.Name) and node.args[0].id == "command"
-        for node in ast.walk(stub_function)
+        for node in executable_nodes(stub_function.body)
     )
     return bridge_written and thread_bound and thread_started and thread_joined and stub_runs
 

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -23,6 +23,7 @@ fi
 
 "${py_cmd[@]}" - "$repo_root" <<'PY'
 import ast
+import operator
 import re
 import sys
 from pathlib import Path
@@ -235,38 +236,126 @@ transport_match = re.search(
     rehearsal_text,
 )
 
+UNKNOWN_CONSTANT = object()
+COMPARISON_OPERATIONS = {
+    ast.Eq: operator.eq, ast.NotEq: operator.ne,
+    ast.Is: operator.is_, ast.IsNot: operator.is_not,
+    ast.Lt: operator.lt, ast.LtE: operator.le,
+    ast.Gt: operator.gt, ast.GtE: operator.ge,
+    ast.In: lambda left, right: left in right,
+    ast.NotIn: lambda left, right: left not in right,
+}
+UNARY_OPERATIONS = {
+    ast.Not: operator.not_, ast.UAdd: operator.pos,
+    ast.USub: operator.neg, ast.Invert: operator.invert,
+}
+BINARY_OPERATIONS = {
+    ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+    ast.Div: operator.truediv, ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod, ast.BitAnd: operator.and_, ast.BitOr: operator.or_,
+    ast.BitXor: operator.xor, ast.LShift: operator.lshift,
+    ast.RShift: operator.rshift,
+}
+
+def compare_constants(operation, left, right):
+    function = COMPARISON_OPERATIONS.get(type(operation))
+    if function is None:
+        return UNKNOWN_CONSTANT
+    try:
+        return function(left, right)
+    except (TypeError, ValueError):
+        return UNKNOWN_CONSTANT
+
+def constant_value(node):
+    """Evaluate a bounded pure-literal expression without executing source."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        values = [constant_value(item) for item in node.elts]
+        if UNKNOWN_CONSTANT in values:
+            return UNKNOWN_CONSTANT
+        if isinstance(node, ast.Tuple):
+            return tuple(values)
+        if isinstance(node, ast.List):
+            return values
+        return set(values)
+    if isinstance(node, ast.Dict):
+        keys = [constant_value(item) for item in node.keys]
+        values = [constant_value(item) for item in node.values]
+        if UNKNOWN_CONSTANT in keys or UNKNOWN_CONSTANT in values:
+            return UNKNOWN_CONSTANT
+        try:
+            return dict(zip(keys, values))
+        except (TypeError, ValueError):
+            return UNKNOWN_CONSTANT
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id in {"dict", "list", "set", "tuple"}
+            and not node.args and not node.keywords):
+        return {"dict": {}, "list": [], "set": set(), "tuple": ()}[node.func.id]
+    if isinstance(node, ast.UnaryOp):
+        value = constant_value(node.operand)
+        if value is UNKNOWN_CONSTANT:
+            return value
+        function = UNARY_OPERATIONS.get(type(node.op))
+        if function is None:
+            return UNKNOWN_CONSTANT
+        try:
+            return function(value)
+        except (TypeError, ValueError, OverflowError):
+            return UNKNOWN_CONSTANT
+    if isinstance(node, ast.BinOp):
+        left = constant_value(node.left)
+        right = constant_value(node.right)
+        if UNKNOWN_CONSTANT in (left, right):
+            return UNKNOWN_CONSTANT
+        function = BINARY_OPERATIONS.get(type(node.op))
+        if function is None:
+            return UNKNOWN_CONSTANT
+        if isinstance(node.op, (ast.LShift, ast.RShift)):
+            if not isinstance(right, int) or not 0 <= right <= 64:
+                return UNKNOWN_CONSTANT
+        if isinstance(node.op, ast.Mult):
+            for value in (left, right):
+                if isinstance(value, int) and abs(value) > 10_000:
+                    return UNKNOWN_CONSTANT
+        try:
+            return function(left, right)
+        except (TypeError, ValueError, ZeroDivisionError, OverflowError):
+            return UNKNOWN_CONSTANT
+    if isinstance(node, ast.BoolOp):
+        value = UNKNOWN_CONSTANT
+        for item in node.values:
+            value = constant_value(item)
+            if value is UNKNOWN_CONSTANT:
+                return value
+            if isinstance(node.op, ast.And) and not value:
+                return value
+            if isinstance(node.op, ast.Or) and value:
+                return value
+        return value
+    if isinstance(node, ast.Compare):
+        left = constant_value(node.left)
+        if left is UNKNOWN_CONSTANT:
+            return left
+        for operation, comparator in zip(node.ops, node.comparators):
+            right = constant_value(comparator)
+            if right is UNKNOWN_CONSTANT:
+                return right
+            outcome = compare_constants(operation, left, right)
+            if outcome is UNKNOWN_CONSTANT or not outcome:
+                return outcome
+            left = right
+        return True
+    return UNKNOWN_CONSTANT
+
 def constant_truth(node):
     """Return a statically known truth value without executing source."""
-    if isinstance(node, ast.Constant):
-        return bool(node.value)
     if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
         return bool(node.elts)
     if isinstance(node, ast.Dict):
         return bool(node.keys)
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
-        value = constant_truth(node.operand)
-        return None if value is None else not value
-    if isinstance(node, ast.BoolOp):
-        values = [constant_truth(value) for value in node.values]
-        if isinstance(node.op, ast.And):
-            if False in values:
-                return False
-            return True if all(value is True for value in values) else None
-        if isinstance(node.op, ast.Or):
-            if True in values:
-                return True
-            return False if all(value is False for value in values) else None
-    if (isinstance(node, ast.Compare) and len(node.ops) == 1
-            and len(node.comparators) == 1
-            and isinstance(node.left, ast.Constant)
-            and isinstance(node.comparators[0], ast.Constant)):
-        left = node.left.value
-        right = node.comparators[0].value
-        if isinstance(node.ops[0], (ast.Eq, ast.Is)):
-            return left == right
-        if isinstance(node.ops[0], (ast.NotEq, ast.IsNot)):
-            return left != right
-    return None
+    value = constant_value(node)
+    return None if value is UNKNOWN_CONSTANT else bool(value)
 
 def terminating_call(node):
     if not isinstance(node, ast.Call):
@@ -286,65 +375,21 @@ def terminates_route(node):
         return True
     return isinstance(node, ast.Expr) and terminating_call(node.value)
 
-def mandatory_expression_nodes(node):
-    """Return required expression nodes and whether their evaluation terminates."""
-    result = [node]
-    if isinstance(node, ast.Lambda):
-        return result, False
-    if isinstance(node, ast.IfExp):
-        nested, terminated = mandatory_expression_nodes(node.test)
-        result.extend(nested)
-        if terminated:
-            return result, True
-        truth = constant_truth(node.test)
-        branch = node.body if truth is True else node.orelse if truth is False else None
-        if branch is not None:
-            nested, terminated = mandatory_expression_nodes(branch)
-            result.extend(nested)
-            if terminated:
-                return result, True
-        return result, False
-    if isinstance(node, ast.BoolOp):
-        for value in node.values:
-            nested, terminated = mandatory_expression_nodes(value)
-            result.extend(nested)
-            if terminated:
-                return result, True
-            truth = constant_truth(value)
-            if isinstance(node.op, ast.And) and truth is not True:
-                break
-            if isinstance(node.op, ast.Or) and truth is not False:
-                break
-        return result, False
-    if isinstance(node, (ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp)):
-        for generator in node.generators:
-            nested, terminated = mandatory_expression_nodes(generator.iter)
-            result.extend(nested)
-            if terminated:
-                return result, True
-            break
-        return result, False
-    for child in ast.iter_child_nodes(node):
-        if isinstance(child, ast.expr):
-            nested, terminated = mandatory_expression_nodes(child)
-            result.extend(nested)
-            if terminated:
-                return result, True
-    return result, terminating_call(node)
+def expression_terminates(node):
+    """Conservatively reject route expressions containing an explicit process exit."""
+    return any(terminating_call(item) for item in ast.walk(node))
 
 def normal_path_nodes(statements):
-    """Return ordered nodes on the non-exception route and whether it terminates."""
+    """Return ordered statements on the normal non-exception route."""
     result = []
     for node in statements:
         result.append(node)
-        if terminates_route(node):
-            return result, True
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             continue
+        if terminates_route(node):
+            return result, True
         if isinstance(node, ast.If):
-            test_nodes, test_terminated = mandatory_expression_nodes(node.test)
-            result.extend(test_nodes)
-            if test_terminated:
+            if expression_terminates(node.test):
                 return result, True
             truth = constant_truth(node.test)
             branch = node.orelse if truth is False else node.body if truth is True else []
@@ -365,15 +410,15 @@ def normal_path_nodes(statements):
                 return result, True
             continue
         if isinstance(node, (ast.With, ast.AsyncWith)):
+            if any(expression_terminates(item.context_expr) for item in node.items):
+                return result, True
             nested, terminated = normal_path_nodes(node.body)
             result.extend(nested)
             if terminated:
                 return result, True
             continue
         if isinstance(node, ast.While):
-            test_nodes, test_terminated = mandatory_expression_nodes(node.test)
-            result.extend(test_nodes)
-            if test_terminated:
+            if expression_terminates(node.test):
                 return result, True
             truth = constant_truth(node.test)
             if truth is False:
@@ -387,24 +432,35 @@ def normal_path_nodes(statements):
                 return result, True
             continue
         if isinstance(node, (ast.For, ast.AsyncFor)):
+            if expression_terminates(node.iter):
+                return result, True
             continue
         for child in ast.iter_child_nodes(node):
-            if isinstance(child, ast.expr):
-                nested, terminated = mandatory_expression_nodes(child)
-                result.extend(nested)
-                if terminated:
-                    return result, True
+            if isinstance(child, ast.expr) and expression_terminates(child):
+                return result, True
     return result, False
 
+def statement_call(node):
+    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+        return node.value
+    if (isinstance(node, ast.Assign) and len(node.targets) == 1
+            and isinstance(node.value, ast.Call)):
+        return node.value
+    return None
+
 def is_launch_subprocess(node):
-    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "subprocess" and node.func.attr == "run"
-            and node.args and isinstance(node.args[0], ast.Subscript)
-            and isinstance(node.args[0].value, ast.Name)
-            and node.args[0].value.id == "launch"):
+    call = statement_call(node)
+    if not (call and isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "completed"
+            and isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "subprocess" and call.func.attr == "run"
+            and call.args and isinstance(call.args[0], ast.Subscript)
+            and isinstance(call.args[0].value, ast.Name)
+            and call.args[0].value.id == "launch"):
         return False
-    slice_node = node.args[0].slice
+    slice_node = call.args[0].slice
     return isinstance(slice_node, ast.Constant) and slice_node.value == "argv"
 
 def has_launch_subprocess(body):
@@ -427,9 +483,11 @@ def has_mediated_execution(body):
         return False
 
     def is_call(node, base, attribute):
-        return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == base and node.func.attr == attribute)
+        call = statement_call(node)
+        return (call is not None and isinstance(node, ast.Expr)
+                and isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == base and call.func.attr == attribute)
 
     live, _ = normal_path_nodes(tree.body)
     bridge_position = None
@@ -467,10 +525,13 @@ def has_mediated_execution(body):
             thread_position = position
     stub_live, _ = normal_path_nodes(stub_function.body if stub_function else [])
     stub_runs = bool(stub_function) and any(
-        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-        and isinstance(node.func.value, ast.Name) and node.func.value.id == "subprocess"
-        and node.func.attr == "run" and node.args
-        and isinstance(node.args[0], ast.Name) and node.args[0].id == "command"
+        isinstance(node, ast.Assign) and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "result"
+        and (call := statement_call(node)) is not None
+        and isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name) and call.func.value.id == "subprocess"
+        and call.func.attr == "run" and call.args
+        and isinstance(call.args[0], ast.Name) and call.args[0].id == "command"
         for node in stub_live
     )
     positions = (

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -264,25 +264,80 @@ def constant_truth(node):
             return left != right
     return None
 
-def executable_nodes(nodes):
-    """Yield mandatory-route nodes, excluding dead or conditionally optional edges."""
-    for node in nodes:
-        yield node
+def terminates_route(node):
+    if isinstance(node, (ast.Raise, ast.Return)):
+        return True
+    if not (isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)):
+        return False
+    call = node.value.func
+    if isinstance(call, ast.Name):
+        return call.id in {"exit", "quit"}
+    return (isinstance(call, ast.Attribute) and isinstance(call.value, ast.Name)
+            and (call.value.id, call.attr) in {
+                ("sys", "exit"), ("os", "_exit"),
+            })
+
+def normal_path_nodes(statements):
+    """Return ordered nodes on the non-exception route and whether it terminates."""
+    result = []
+    for node in statements:
+        result.append(node)
+        if terminates_route(node):
+            return result, True
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             continue
         if isinstance(node, ast.If):
             truth = constant_truth(node.test)
-            branches = node.orelse if truth is False else node.body if truth is True else []
-            yield from executable_nodes(branches)
+            branch = node.orelse if truth is False else node.body if truth is True else []
+            nested, terminated = normal_path_nodes(branch)
+            result.extend(nested)
+            if terminated:
+                return result, True
             continue
-        if isinstance(node, (ast.While, ast.For, ast.AsyncFor)):
-            if isinstance(node, ast.While):
-                truth = constant_truth(node.test)
-                branches = node.orelse if truth is False else node.body if truth is True else []
-                yield from executable_nodes(branches)
+        if isinstance(node, ast.Try):
+            nested, terminated = normal_path_nodes(node.body)
+            result.extend(nested)
+            if not terminated:
+                nested, terminated = normal_path_nodes(node.orelse)
+                result.extend(nested)
+            final_nodes, final_terminated = normal_path_nodes(node.finalbody)
+            result.extend(final_nodes)
+            if terminated or final_terminated:
+                return result, True
             continue
-        for child in ast.iter_child_nodes(node):
-            yield from executable_nodes([child])
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            nested, terminated = normal_path_nodes(node.body)
+            result.extend(nested)
+            if terminated:
+                return result, True
+            continue
+        if isinstance(node, ast.While):
+            truth = constant_truth(node.test)
+            if truth is False:
+                nested, terminated = normal_path_nodes(node.orelse)
+                result.extend(nested)
+                if terminated:
+                    return result, True
+            elif truth is True:
+                nested, _ = normal_path_nodes(node.body)
+                result.extend(nested)
+                return result, True
+            continue
+        if isinstance(node, (ast.For, ast.AsyncFor)):
+            continue
+        result.extend(list(ast.walk(node))[1:])
+    return result, False
+
+def is_launch_subprocess(node):
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "subprocess" and node.func.attr == "run"
+            and node.args and isinstance(node.args[0], ast.Subscript)
+            and isinstance(node.args[0].value, ast.Name)
+            and node.args[0].value.id == "launch"):
+        return False
+    slice_node = node.args[0].slice
+    return isinstance(slice_node, ast.Constant) and slice_node.value == "argv"
 
 def has_launch_subprocess(body):
     if not body:
@@ -291,18 +346,8 @@ def has_launch_subprocess(body):
         tree = ast.parse(body)
     except SyntaxError:
         return False
-    for node in executable_nodes(tree.body):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "subprocess" and node.func.attr == "run"
-                and node.args and isinstance(node.args[0], ast.Subscript)
-                and isinstance(node.args[0].value, ast.Name)
-                and node.args[0].value.id == "launch"):
-            continue
-        slice_node = node.args[0].slice
-        if isinstance(slice_node, ast.Constant) and slice_node.value == "argv":
-            return True
-    return False
+    live, _ = normal_path_nodes(tree.body)
+    return any(is_launch_subprocess(node) for node in live)
 
 def has_mediated_execution(body):
     """Require executable bridge -> thread start/join -> stub-run edges."""
@@ -318,15 +363,25 @@ def has_mediated_execution(body):
                 and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == base and node.func.attr == attribute)
 
-    live = list(executable_nodes(tree.body))
-    bridge_written = any(is_call(node, "bridge_path", "write_text") for node in live)
+    live, _ = normal_path_nodes(tree.body)
+    bridge_position = None
+    thread_position = None
+    start_position = None
+    launch_position = None
+    join_position = None
     thread_bound = False
-    thread_started = False
-    thread_joined = False
     stub_function = None
-    for node in live:
+    for position, node in enumerate(live):
         if isinstance(node, ast.FunctionDef) and node.name == "run_bounded_stub":
             stub_function = node
+        if bridge_position is None and is_call(node, "bridge_path", "write_text"):
+            bridge_position = position
+        if start_position is None and is_call(node, "mediator_thread", "start"):
+            start_position = position
+        if launch_position is None and is_launch_subprocess(node):
+            launch_position = position
+        if join_position is None and is_call(node, "mediator_thread", "join"):
+            join_position = position
         if not (isinstance(node, ast.Assign) and len(node.targets) == 1
                 and isinstance(node.targets[0], ast.Name)
                 and node.targets[0].id == "mediator_thread"):
@@ -340,21 +395,25 @@ def has_mediated_execution(body):
                            and isinstance(keyword.value, ast.Name)
                            and keyword.value.id == "run_bounded_stub"
                            for keyword in value.keywords)
-    for node in live:
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "mediator_thread"):
-            continue
-        thread_started = thread_started or node.func.attr == "start"
-        thread_joined = thread_joined or node.func.attr == "join"
+        if thread_bound and thread_position is None:
+            thread_position = position
+    stub_live, _ = normal_path_nodes(stub_function.body if stub_function else [])
     stub_runs = bool(stub_function) and any(
         isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
         and isinstance(node.func.value, ast.Name) and node.func.value.id == "subprocess"
         and node.func.attr == "run" and node.args
         and isinstance(node.args[0], ast.Name) and node.args[0].id == "command"
-        for node in executable_nodes(stub_function.body)
+        for node in stub_live
     )
-    return bridge_written and thread_bound and thread_started and thread_joined and stub_runs
+    positions = (
+        bridge_position, thread_position, start_position,
+        launch_position, join_position,
+    )
+    return (
+        thread_bound and stub_runs
+        and all(position is not None for position in positions)
+        and list(positions) == sorted(positions)
+    )
 
 transport_body = transport_match.group(2) if transport_match else ""
 rehearsal_transport = (

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -239,6 +239,10 @@ def constant_truth(node):
     """Return a statically known truth value without executing source."""
     if isinstance(node, ast.Constant):
         return bool(node.value)
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return bool(node.elts)
+    if isinstance(node, ast.Dict):
+        return bool(node.keys)
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
         value = constant_truth(node.operand)
         return None if value is None else not value
@@ -264,14 +268,10 @@ def constant_truth(node):
             return left != right
     return None
 
-def terminates_route(node):
-    if isinstance(node, (ast.Raise, ast.Return)):
-        return True
-    if isinstance(node, ast.Assert) and constant_truth(node.test) is False:
-        return True
-    if not (isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)):
+def terminating_call(node):
+    if not isinstance(node, ast.Call):
         return False
-    call = node.value.func
+    call = node.func
     if isinstance(call, ast.Name):
         return call.id in {"exit", "quit"}
     return (isinstance(call, ast.Attribute) and isinstance(call.value, ast.Name)
@@ -279,36 +279,58 @@ def terminates_route(node):
                 ("sys", "exit"), ("os", "_exit"),
             })
 
+def terminates_route(node):
+    if isinstance(node, (ast.Raise, ast.Return)):
+        return True
+    if isinstance(node, ast.Assert) and constant_truth(node.test) is False:
+        return True
+    return isinstance(node, ast.Expr) and terminating_call(node.value)
+
 def mandatory_expression_nodes(node):
-    """Return expression nodes that the normal route must evaluate."""
+    """Return required expression nodes and whether their evaluation terminates."""
     result = [node]
     if isinstance(node, ast.Lambda):
-        return result
+        return result, False
     if isinstance(node, ast.IfExp):
-        result.extend(mandatory_expression_nodes(node.test))
+        nested, terminated = mandatory_expression_nodes(node.test)
+        result.extend(nested)
+        if terminated:
+            return result, True
         truth = constant_truth(node.test)
         branch = node.body if truth is True else node.orelse if truth is False else None
         if branch is not None:
-            result.extend(mandatory_expression_nodes(branch))
-        return result
+            nested, terminated = mandatory_expression_nodes(branch)
+            result.extend(nested)
+            if terminated:
+                return result, True
+        return result, False
     if isinstance(node, ast.BoolOp):
         for value in node.values:
-            result.extend(mandatory_expression_nodes(value))
+            nested, terminated = mandatory_expression_nodes(value)
+            result.extend(nested)
+            if terminated:
+                return result, True
             truth = constant_truth(value)
             if isinstance(node.op, ast.And) and truth is not True:
                 break
             if isinstance(node.op, ast.Or) and truth is not False:
                 break
-        return result
+        return result, False
     if isinstance(node, (ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp)):
         for generator in node.generators:
-            result.extend(mandatory_expression_nodes(generator.iter))
+            nested, terminated = mandatory_expression_nodes(generator.iter)
+            result.extend(nested)
+            if terminated:
+                return result, True
             break
-        return result
+        return result, False
     for child in ast.iter_child_nodes(node):
         if isinstance(child, ast.expr):
-            result.extend(mandatory_expression_nodes(child))
-    return result
+            nested, terminated = mandatory_expression_nodes(child)
+            result.extend(nested)
+            if terminated:
+                return result, True
+    return result, terminating_call(node)
 
 def normal_path_nodes(statements):
     """Return ordered nodes on the non-exception route and whether it terminates."""
@@ -320,6 +342,10 @@ def normal_path_nodes(statements):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             continue
         if isinstance(node, ast.If):
+            test_nodes, test_terminated = mandatory_expression_nodes(node.test)
+            result.extend(test_nodes)
+            if test_terminated:
+                return result, True
             truth = constant_truth(node.test)
             branch = node.orelse if truth is False else node.body if truth is True else []
             nested, terminated = normal_path_nodes(branch)
@@ -345,6 +371,10 @@ def normal_path_nodes(statements):
                 return result, True
             continue
         if isinstance(node, ast.While):
+            test_nodes, test_terminated = mandatory_expression_nodes(node.test)
+            result.extend(test_nodes)
+            if test_terminated:
+                return result, True
             truth = constant_truth(node.test)
             if truth is False:
                 nested, terminated = normal_path_nodes(node.orelse)
@@ -360,7 +390,10 @@ def normal_path_nodes(statements):
             continue
         for child in ast.iter_child_nodes(node):
             if isinstance(child, ast.expr):
-                result.extend(mandatory_expression_nodes(child))
+                nested, terminated = mandatory_expression_nodes(child)
+                result.extend(nested)
+                if terminated:
+                    return result, True
     return result, False
 
 def is_launch_subprocess(node):

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -22,6 +22,7 @@ else
 fi
 
 "${py_cmd[@]}" - "$repo_root" <<'PY'
+import ast
 import re
 import sys
 from pathlib import Path
@@ -163,6 +164,19 @@ def shell_code(content):
         cleaned.append("".join(kept))
     return "\n".join(cleaned)
 
+def shell_parser_code(content):
+    """Return shell syntax without heredoc bodies (which are data, not arms)."""
+    kept = []
+    lines = iter(content.splitlines())
+    for line in lines:
+        kept.append(line)
+        tags = re.findall(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", line)
+        for tag in tags:
+            for body_line in lines:
+                if body_line.strip() == tag:
+                    break
+    return "\n".join(kept)
+
 def caller_invokes(helper, content):
     content = shell_code(content)
     def command_uses(target, path_prefix=False):
@@ -213,14 +227,39 @@ implemented_mode_sets[graph_helper] = sorted(set(re.findall(r"--graph-[a-z0-9-]+
 rehearsal_helper = "check-authorization-binding.sh"
 rehearsal_text = (skill_root / "scripts" / rehearsal_helper).read_text(encoding="utf-8")
 rehearsal_mode = "--phase --rehearsal --launch"
-rehearsal_code = shell_code(rehearsal_text)
+rehearsal_code = shell_code(shell_parser_code(rehearsal_text))
 rehearsal_arms = all(re.search(rf"(?m)^\s*{re.escape(flag)}\)", rehearsal_code)
                      for flag in rehearsal_mode.split())
-rehearsal_transport = all((
-    re.search(r'python\s+-\s+"\$phase"\s+"\$rehearsal"\s+"\$launch"\s+<<', rehearsal_code),
-    'subprocess.run(launch["argv"]' in rehearsal_text,
-    'IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT' in rehearsal_text,
-))
+transport_match = re.search(
+    r'''(?ms)python\s+-\s+"\$phase"\s+"\$rehearsal"\s+"\$launch"\s+<<['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*\n(.*?)^\1\s*$''',
+    rehearsal_text,
+)
+def has_launch_subprocess(body):
+    if not body:
+        return False
+    try:
+        tree = ast.parse(body)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "subprocess" and node.func.attr == "run"
+                and node.args and isinstance(node.args[0], ast.Subscript)
+                and isinstance(node.args[0].value, ast.Name)
+                and node.args[0].value.id == "launch"):
+            continue
+        slice_node = node.args[0].slice
+        if isinstance(slice_node, ast.Constant) and slice_node.value == "argv":
+            return True
+    return False
+
+transport_body = transport_match.group(2) if transport_match else ""
+rehearsal_transport = (
+    has_launch_subprocess(transport_body)
+    and "mediator_thread" in transport_body
+    and "bridge_path.write_text" in transport_body
+)
 if rehearsal_arms and rehearsal_transport:
     implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]
 else:

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -54,7 +54,7 @@ mode_rows = {}
 for line_number, line in enumerate(contract_text.splitlines(), 1):
     if line.startswith("helper-mode: "):
         parts = [part.strip() for part in line.split("|")]
-        if len(parts) != 4:
+        if len(parts) not in {4, 5}:
             raise SystemExit(
                 f"check-helper-reachability: malformed helper mode at line {line_number}"
             )
@@ -62,7 +62,10 @@ for line_number, line in enumerate(contract_text.splitlines(), 1):
         key = (helper, parts[1])
         if key in mode_rows:
             raise SystemExit(f"check-helper-reachability: duplicate mode applicability row: {' '.join(key)}")
-        mode_rows[key] = {"arguments": parts[2], "boundary": parts[3]}
+        mode_rows[key] = {
+            "arguments": parts[2], "boundary": parts[3],
+            "caller": parts[4] if len(parts) == 5 else "-",
+        }
         continue
     if not line.startswith("helper-route: "):
         continue
@@ -165,7 +168,7 @@ def caller_invokes(helper, content):
     def command_uses(target, path_prefix=False):
         prefix = r'''(?:[^\s"']*/)?''' if path_prefix else ""
         operand = rf'''["']?{prefix}{target}["']?(?=\s|$)'''
-        direct = rf"(?m)^\s*(?:(?:if|while|until|!)\s+)?(?:bash|source|exec)\s+{operand}"
+        direct = rf"(?m)^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:[^\s]+|\"[^\"]*\"|'[^']*')\s+)*(?:(?:if|while|until|!)\s+)?(?:bash|source|exec)?\s*{operand}"
         substitution = rf'''(?mx)^\s*[a-z_][a-z0-9_]*\s*=\s*["']?\$\(\s*(?:bash|source|exec)\s+{operand}'''
         return bool(re.search(direct, content, re.I) or
                     re.search(substitution, content, re.I))
@@ -210,7 +213,15 @@ implemented_mode_sets[graph_helper] = sorted(set(re.findall(r"--graph-[a-z0-9-]+
 rehearsal_helper = "check-authorization-binding.sh"
 rehearsal_text = (skill_root / "scripts" / rehearsal_helper).read_text(encoding="utf-8")
 rehearsal_mode = "--phase --rehearsal --launch"
-if all(flag in shell_code(rehearsal_text) for flag in rehearsal_mode.split()):
+rehearsal_code = shell_code(rehearsal_text)
+rehearsal_arms = all(re.search(rf"(?m)^\s*{re.escape(flag)}\)", rehearsal_code)
+                     for flag in rehearsal_mode.split())
+rehearsal_transport = all((
+    re.search(r'python\s+-\s+"\$phase"\s+"\$rehearsal"\s+"\$launch"\s+<<', rehearsal_code),
+    'subprocess.run(launch["argv"]' in rehearsal_text,
+    'IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT' in rehearsal_text,
+))
+if rehearsal_arms and rehearsal_transport:
     implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]
 else:
     implemented_mode_sets[rehearsal_helper] = []
@@ -235,11 +246,6 @@ mode_owner = "\n".join(
 )
 for helper, mode in mode_rows:
     row = mode_rows[(helper, mode)]
-    mode_dispatch = shell_code((skill_root / "scripts" / helper).read_text(encoding="utf-8"))
-    if not all(flag in mode_dispatch for flag in mode.split()):
-        raise SystemExit(
-            f"check-helper-reachability: mode applicability not implemented: {helper} {mode}"
-        )
     mode_flags = mode.split()
     mode_args = row["arguments"].split()
     mode_command = f"{mode} {row['arguments']}"
@@ -259,6 +265,19 @@ for helper, mode in mode_rows:
         raise SystemExit(
             f"check-helper-reachability: mode boundary absent: {helper} {mode}"
         )
+    mode_caller = row["caller"]
+    if mode_caller != "-":
+        caller_path = packaged_path(mode_caller, helper, "mode caller")
+        caller_content = shell_code(caller_path.read_text(encoding="utf-8"))
+        if not caller_invokes(helper, caller_content):
+            raise SystemExit(
+                f"check-helper-reachability: mode caller does not invoke {helper}: {mode_caller}"
+            )
+        mode_flags = r"\s+" + r"\s+".join(re.escape(flag) + r"\s+[^\s]+" for flag in mode.split())
+        if not re.search(re.escape(helper) + r'["\']?' + mode_flags, caller_content):
+            raise SystemExit(
+                f"check-helper-reachability: mode caller does not invoke exact mode: {helper} {mode}"
+            )
 
 for helper in helpers:
     row = rows[helper]

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -234,6 +234,56 @@ transport_match = re.search(
     r'''(?ms)python\s+-\s+"\$phase"\s+"\$rehearsal"\s+"\$launch"\s+<<['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*\n(.*?)^\1\s*$''',
     rehearsal_text,
 )
+
+def constant_truth(node):
+    """Return a statically known truth value without executing source."""
+    if isinstance(node, ast.Constant):
+        return bool(node.value)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        value = constant_truth(node.operand)
+        return None if value is None else not value
+    if isinstance(node, ast.BoolOp):
+        values = [constant_truth(value) for value in node.values]
+        if isinstance(node.op, ast.And):
+            if False in values:
+                return False
+            return True if all(value is True for value in values) else None
+        if isinstance(node.op, ast.Or):
+            if True in values:
+                return True
+            return False if all(value is False for value in values) else None
+    if (isinstance(node, ast.Compare) and len(node.ops) == 1
+            and len(node.comparators) == 1
+            and isinstance(node.left, ast.Constant)
+            and isinstance(node.comparators[0], ast.Constant)):
+        left = node.left.value
+        right = node.comparators[0].value
+        if isinstance(node.ops[0], (ast.Eq, ast.Is)):
+            return left == right
+        if isinstance(node.ops[0], (ast.NotEq, ast.IsNot)):
+            return left != right
+    return None
+
+def executable_nodes(nodes):
+    """Yield mandatory-route nodes, excluding dead or conditionally optional edges."""
+    for node in nodes:
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        if isinstance(node, ast.If):
+            truth = constant_truth(node.test)
+            branches = node.orelse if truth is False else node.body if truth is True else []
+            yield from executable_nodes(branches)
+            continue
+        if isinstance(node, (ast.While, ast.For, ast.AsyncFor)):
+            if isinstance(node, ast.While):
+                truth = constant_truth(node.test)
+                branches = node.orelse if truth is False else node.body if truth is True else []
+                yield from executable_nodes(branches)
+            continue
+        for child in ast.iter_child_nodes(node):
+            yield from executable_nodes([child])
+
 def has_launch_subprocess(body):
     if not body:
         return False
@@ -241,7 +291,7 @@ def has_launch_subprocess(body):
         tree = ast.parse(body)
     except SyntaxError:
         return False
-    for node in ast.walk(tree):
+    for node in executable_nodes(tree.body):
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                 and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == "subprocess" and node.func.attr == "run"
@@ -267,28 +317,6 @@ def has_mediated_execution(body):
         return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                 and isinstance(node.func.value, ast.Name)
                 and node.func.value.id == base and node.func.attr == attribute)
-
-    def literal_truth(node):
-        return bool(node.value) if isinstance(node, ast.Constant) else None
-
-    def executable_nodes(nodes):
-        for node in nodes:
-            yield node
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-                continue
-            if isinstance(node, ast.If):
-                truth = literal_truth(node.test)
-                branches = node.orelse if truth is False else node.body if truth is True else node.body + node.orelse
-                yield from executable_nodes(branches)
-                continue
-            if isinstance(node, (ast.While, ast.For, ast.AsyncFor)):
-                if isinstance(node, ast.While) and literal_truth(node.test) is False:
-                    yield from executable_nodes(node.orelse)
-                else:
-                    yield from executable_nodes(node.body + node.orelse)
-                continue
-            for child in ast.iter_child_nodes(node):
-                yield from executable_nodes([child])
 
     live = list(executable_nodes(tree.body))
     bridge_written = any(is_call(node, "bridge_path", "write_text") for node in live)

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -267,6 +267,8 @@ def constant_truth(node):
 def terminates_route(node):
     if isinstance(node, (ast.Raise, ast.Return)):
         return True
+    if isinstance(node, ast.Assert) and constant_truth(node.test) is False:
+        return True
     if not (isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)):
         return False
     call = node.value.func
@@ -277,6 +279,37 @@ def terminates_route(node):
                 ("sys", "exit"), ("os", "_exit"),
             })
 
+def mandatory_expression_nodes(node):
+    """Return expression nodes that the normal route must evaluate."""
+    result = [node]
+    if isinstance(node, ast.Lambda):
+        return result
+    if isinstance(node, ast.IfExp):
+        result.extend(mandatory_expression_nodes(node.test))
+        truth = constant_truth(node.test)
+        branch = node.body if truth is True else node.orelse if truth is False else None
+        if branch is not None:
+            result.extend(mandatory_expression_nodes(branch))
+        return result
+    if isinstance(node, ast.BoolOp):
+        for value in node.values:
+            result.extend(mandatory_expression_nodes(value))
+            truth = constant_truth(value)
+            if isinstance(node.op, ast.And) and truth is not True:
+                break
+            if isinstance(node.op, ast.Or) and truth is not False:
+                break
+        return result
+    if isinstance(node, (ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp)):
+        for generator in node.generators:
+            result.extend(mandatory_expression_nodes(generator.iter))
+            break
+        return result
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.expr):
+            result.extend(mandatory_expression_nodes(child))
+    return result
+
 def normal_path_nodes(statements):
     """Return ordered nodes on the non-exception route and whether it terminates."""
     result = []
@@ -284,7 +317,7 @@ def normal_path_nodes(statements):
         result.append(node)
         if terminates_route(node):
             return result, True
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             continue
         if isinstance(node, ast.If):
             truth = constant_truth(node.test)
@@ -325,7 +358,9 @@ def normal_path_nodes(statements):
             continue
         if isinstance(node, (ast.For, ast.AsyncFor)):
             continue
-        result.extend(list(ast.walk(node))[1:])
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.expr):
+                result.extend(mandatory_expression_nodes(child))
     return result, False
 
 def is_launch_subprocess(node):

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -354,6 +354,8 @@ def terminates_route(node):
 
 def expression_terminates(node):
     """Return whether evaluating this expression must execute an explicit exit."""
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Lambda):
+        return expression_terminates(node.func.body)
     if isinstance(node, ast.Lambda):
         return False
     if isinstance(node, ast.GeneratorExp):
@@ -392,12 +394,27 @@ def expression_terminates(node):
             left = right
         return False
     if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp)):
-        return bool(node.generators) and expression_terminates(node.generators[0].iter)
+        if not node.generators:
+            return False
+        generator = node.generators[0]
+        if expression_terminates(generator.iter):
+            return True
+        if (len(node.generators) != 1 or generator.ifs
+                or constant_truth(generator.iter) is not True):
+            return False
+        projections = ([node.elt] if not isinstance(node, ast.DictComp)
+                       else [node.key, node.value])
+        return any(expression_terminates(item) for item in projections)
     return any(
         expression_terminates(child)
         for child in ast.iter_child_nodes(node)
         if isinstance(child, ast.expr)
     )
+
+def decorator_terminates(node):
+    """A decorator lambda is created, then immediately applied to the class/function."""
+    return (expression_terminates(node.body) if isinstance(node, ast.Lambda)
+            else expression_terminates(node))
 
 def definition_expressions(node):
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -408,13 +425,13 @@ def definition_expressions(node):
               if argument is not None and argument.annotation is not None),
         ]
         return [
-            *node.decorator_list, *node.args.defaults,
+            *node.args.defaults,
             *(item for item in node.args.kw_defaults if item is not None),
             *annotations,
             *([node.returns] if node.returns is not None else []),
         ]
     if isinstance(node, ast.ClassDef):
-        return [*node.decorator_list, *node.bases, *(item.value for item in node.keywords)]
+        return [*node.bases, *(item.value for item in node.keywords)]
     return []
 
 def normal_path_nodes(statements):
@@ -423,8 +440,13 @@ def normal_path_nodes(statements):
     for node in statements:
         result.append(node)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            if any(expression_terminates(item) for item in definition_expressions(node)):
+            if (any(decorator_terminates(item) for item in node.decorator_list)
+                    or any(expression_terminates(item) for item in definition_expressions(node))):
                 return result, True
+            if isinstance(node, ast.ClassDef):
+                _, terminated = normal_path_nodes(node.body)
+                if terminated:
+                    return result, True
             continue
         if terminates_route(node):
             return result, True
@@ -502,6 +524,8 @@ def binds_name(node, name):
         return any(target_binds(target, name) for target in node.targets)
     if isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.For, ast.AsyncFor)):
         return target_binds(node.target, name)
+    if isinstance(node, ast.Delete):
+        return any(target_binds(target, name) for target in node.targets)
     if isinstance(node, (ast.With, ast.AsyncWith)):
         return any(item.optional_vars is not None and target_binds(item.optional_vars, name)
                    for item in node.items)

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -23,7 +23,6 @@ fi
 
 "${py_cmd[@]}" - "$repo_root" <<'PY'
 import ast
-import operator
 import re
 import sys
 from pathlib import Path
@@ -237,115 +236,69 @@ transport_match = re.search(
 )
 
 UNKNOWN_CONSTANT = object()
-COMPARISON_OPERATIONS = {
-    ast.Eq: operator.eq, ast.NotEq: operator.ne,
-    ast.Is: operator.is_, ast.IsNot: operator.is_not,
-    ast.Lt: operator.lt, ast.LtE: operator.le,
-    ast.Gt: operator.gt, ast.GtE: operator.ge,
-    ast.In: lambda left, right: left in right,
-    ast.NotIn: lambda left, right: left not in right,
-}
-UNARY_OPERATIONS = {
-    ast.Not: operator.not_, ast.UAdd: operator.pos,
-    ast.USub: operator.neg, ast.Invert: operator.invert,
-}
-BINARY_OPERATIONS = {
-    ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
-    ast.Div: operator.truediv, ast.FloorDiv: operator.floordiv,
-    ast.Mod: operator.mod, ast.BitAnd: operator.and_, ast.BitOr: operator.or_,
-    ast.BitXor: operator.xor, ast.LShift: operator.lshift,
-    ast.RShift: operator.rshift,
-}
+MAX_STATIC_NUMBER = 1_000_000
 
-def compare_constants(operation, left, right):
-    function = COMPARISON_OPERATIONS.get(type(operation))
-    if function is None:
-        return UNKNOWN_CONSTANT
-    try:
-        return function(left, right)
-    except (TypeError, ValueError):
-        return UNKNOWN_CONSTANT
-
-def constant_value(node):
-    """Evaluate a bounded pure-literal expression without executing source."""
+def bounded_scalar(node):
+    """Evaluate only small scalar literals; never allocate candidate containers."""
     if isinstance(node, ast.Constant):
-        return node.value
-    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
-        values = [constant_value(item) for item in node.elts]
-        if UNKNOWN_CONSTANT in values:
-            return UNKNOWN_CONSTANT
-        if isinstance(node, ast.Tuple):
-            return tuple(values)
-        if isinstance(node, ast.List):
-            return values
-        return set(values)
-    if isinstance(node, ast.Dict):
-        keys = [constant_value(item) for item in node.keys]
-        values = [constant_value(item) for item in node.values]
-        if UNKNOWN_CONSTANT in keys or UNKNOWN_CONSTANT in values:
-            return UNKNOWN_CONSTANT
-        try:
-            return dict(zip(keys, values))
-        except (TypeError, ValueError):
-            return UNKNOWN_CONSTANT
-    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            and node.func.id in {"dict", "list", "set", "tuple"}
-            and not node.args and not node.keywords):
-        return {"dict": {}, "list": [], "set": set(), "tuple": ()}[node.func.id]
+        value = node.value
+        if isinstance(value, (str, bytes)):
+            return value if len(value) <= 256 else UNKNOWN_CONSTANT
+        if isinstance(value, (bool, int, float, complex)) or value is None:
+            return value if not isinstance(value, (int, float, complex)) or abs(value) <= MAX_STATIC_NUMBER else UNKNOWN_CONSTANT
+        return UNKNOWN_CONSTANT
     if isinstance(node, ast.UnaryOp):
-        value = constant_value(node.operand)
+        value = bounded_scalar(node.operand)
         if value is UNKNOWN_CONSTANT:
             return value
-        function = UNARY_OPERATIONS.get(type(node.op))
-        if function is None:
-            return UNKNOWN_CONSTANT
         try:
-            return function(value)
+            if isinstance(node.op, ast.Not):
+                return not value
+            if isinstance(node.op, ast.UAdd):
+                return +value
+            if isinstance(node.op, ast.USub):
+                return -value
         except (TypeError, ValueError, OverflowError):
-            return UNKNOWN_CONSTANT
+            pass
+        return UNKNOWN_CONSTANT
     if isinstance(node, ast.BinOp):
-        left = constant_value(node.left)
-        right = constant_value(node.right)
-        if UNKNOWN_CONSTANT in (left, right):
+        left, right = bounded_scalar(node.left), bounded_scalar(node.right)
+        if left is UNKNOWN_CONSTANT or right is UNKNOWN_CONSTANT:
             return UNKNOWN_CONSTANT
-        function = BINARY_OPERATIONS.get(type(node.op))
-        if function is None:
+        if not isinstance(left, (bool, int, float, complex)) or not isinstance(right, (bool, int, float, complex)):
             return UNKNOWN_CONSTANT
-        if isinstance(node.op, (ast.LShift, ast.RShift)):
-            if not isinstance(right, int) or not 0 <= right <= 64:
-                return UNKNOWN_CONSTANT
-        if isinstance(node.op, ast.Mult):
-            for value in (left, right):
-                if isinstance(value, int) and abs(value) > 10_000:
-                    return UNKNOWN_CONSTANT
         try:
-            return function(left, right)
+            if isinstance(node.op, ast.Add):
+                value = left + right
+            elif isinstance(node.op, ast.Sub):
+                value = left - right
+            elif isinstance(node.op, ast.Mult):
+                value = left * right
+            elif isinstance(node.op, ast.Div):
+                value = left / right
+            elif isinstance(node.op, ast.FloorDiv):
+                value = left // right
+            elif isinstance(node.op, ast.Mod):
+                value = left % right
+            else:
+                return UNKNOWN_CONSTANT
+            return value if abs(value) <= MAX_STATIC_NUMBER else UNKNOWN_CONSTANT
         except (TypeError, ValueError, ZeroDivisionError, OverflowError):
             return UNKNOWN_CONSTANT
-    if isinstance(node, ast.BoolOp):
-        value = UNKNOWN_CONSTANT
-        for item in node.values:
-            value = constant_value(item)
-            if value is UNKNOWN_CONSTANT:
-                return value
-            if isinstance(node.op, ast.And) and not value:
-                return value
-            if isinstance(node.op, ast.Or) and value:
-                return value
-        return value
-    if isinstance(node, ast.Compare):
-        left = constant_value(node.left)
-        if left is UNKNOWN_CONSTANT:
-            return left
-        for operation, comparator in zip(node.ops, node.comparators):
-            right = constant_value(comparator)
-            if right is UNKNOWN_CONSTANT:
-                return right
-            outcome = compare_constants(operation, left, right)
-            if outcome is UNKNOWN_CONSTANT or not outcome:
-                return outcome
-            left = right
-        return True
+    return UNKNOWN_CONSTANT
+
+def compare_scalars(operation, left, right):
+    try:
+        if isinstance(operation, ast.Eq): return left == right
+        if isinstance(operation, ast.NotEq): return left != right
+        if isinstance(operation, ast.Is): return left is right
+        if isinstance(operation, ast.IsNot): return left is not right
+        if isinstance(operation, ast.Lt): return left < right
+        if isinstance(operation, ast.LtE): return left <= right
+        if isinstance(operation, ast.Gt): return left > right
+        if isinstance(operation, ast.GtE): return left >= right
+    except (TypeError, ValueError):
+        pass
     return UNKNOWN_CONSTANT
 
 def constant_truth(node):
@@ -354,7 +307,31 @@ def constant_truth(node):
         return bool(node.elts)
     if isinstance(node, ast.Dict):
         return bool(node.keys)
-    value = constant_value(node)
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id in {"dict", "list", "set", "tuple"}
+            and not node.args and not node.keywords):
+        return False
+    if isinstance(node, ast.BoolOp):
+        values = [constant_truth(item) for item in node.values]
+        if isinstance(node.op, ast.And):
+            if False in values: return False
+            return True if all(value is True for value in values) else None
+        if True in values: return True
+        return False if all(value is False for value in values) else None
+    if isinstance(node, ast.Compare):
+        left = bounded_scalar(node.left)
+        if left is UNKNOWN_CONSTANT:
+            return None
+        for operation, comparator in zip(node.ops, node.comparators):
+            right = bounded_scalar(comparator)
+            if right is UNKNOWN_CONSTANT:
+                return None
+            outcome = compare_scalars(operation, left, right)
+            if outcome is UNKNOWN_CONSTANT or not outcome:
+                return None if outcome is UNKNOWN_CONSTANT else False
+            left = right
+        return True
+    value = bounded_scalar(node)
     return None if value is UNKNOWN_CONSTANT else bool(value)
 
 def terminating_call(node):
@@ -376,8 +353,69 @@ def terminates_route(node):
     return isinstance(node, ast.Expr) and terminating_call(node.value)
 
 def expression_terminates(node):
-    """Conservatively reject route expressions containing an explicit process exit."""
-    return any(terminating_call(item) for item in ast.walk(node))
+    """Return whether evaluating this expression must execute an explicit exit."""
+    if isinstance(node, ast.Lambda):
+        return False
+    if isinstance(node, ast.GeneratorExp):
+        return bool(node.generators) and expression_terminates(node.generators[0].iter)
+    if terminating_call(node):
+        return True
+    if isinstance(node, ast.IfExp):
+        if expression_terminates(node.test):
+            return True
+        truth = constant_truth(node.test)
+        branch = node.body if truth is True else node.orelse if truth is False else None
+        return branch is not None and expression_terminates(branch)
+    if isinstance(node, ast.BoolOp):
+        for item in node.values:
+            if expression_terminates(item):
+                return True
+            truth = constant_truth(item)
+            if isinstance(node.op, ast.And) and truth is not True:
+                break
+            if isinstance(node.op, ast.Or) and truth is not False:
+                break
+        return False
+    if isinstance(node, ast.Compare):
+        if expression_terminates(node.left):
+            return True
+        left = bounded_scalar(node.left)
+        for operation, comparator in zip(node.ops, node.comparators):
+            if expression_terminates(comparator):
+                return True
+            right = bounded_scalar(comparator)
+            if left is UNKNOWN_CONSTANT or right is UNKNOWN_CONSTANT:
+                break
+            outcome = compare_scalars(operation, left, right)
+            if outcome is not True:
+                break
+            left = right
+        return False
+    if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp)):
+        return bool(node.generators) and expression_terminates(node.generators[0].iter)
+    return any(
+        expression_terminates(child)
+        for child in ast.iter_child_nodes(node)
+        if isinstance(child, ast.expr)
+    )
+
+def definition_expressions(node):
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        annotations = [
+            *(argument.annotation for argument in [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+              if argument.annotation is not None),
+            *(argument.annotation for argument in [node.args.vararg, node.args.kwarg]
+              if argument is not None and argument.annotation is not None),
+        ]
+        return [
+            *node.decorator_list, *node.args.defaults,
+            *(item for item in node.args.kw_defaults if item is not None),
+            *annotations,
+            *([node.returns] if node.returns is not None else []),
+        ]
+    if isinstance(node, ast.ClassDef):
+        return [*node.decorator_list, *node.bases, *(item.value for item in node.keywords)]
+    return []
 
 def normal_path_nodes(statements):
     """Return ordered statements on the normal non-exception route."""
@@ -385,6 +423,8 @@ def normal_path_nodes(statements):
     for node in statements:
         result.append(node)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if any(expression_terminates(item) for item in definition_expressions(node)):
+                return result, True
             continue
         if terminates_route(node):
             return result, True
@@ -448,6 +488,31 @@ def statement_call(node):
         return node.value
     return None
 
+def target_binds(target, name):
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return any(target_binds(item, name) for item in target.elts)
+    return False
+
+def binds_name(node, name):
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return node.name == name
+    if isinstance(node, ast.Assign):
+        return any(target_binds(target, name) for target in node.targets)
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.For, ast.AsyncFor)):
+        return target_binds(node.target, name)
+    if isinstance(node, (ast.With, ast.AsyncWith)):
+        return any(item.optional_vars is not None and target_binds(item.optional_vars, name)
+                   for item in node.items)
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return any((alias.asname or alias.name.split(".")[0]) == name for alias in node.names)
+    return any(
+        isinstance(item, ast.NamedExpr) and target_binds(item.target, name)
+        for item in ast.walk(node)
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda))
+    )
+
 def is_launch_subprocess(node):
     call = statement_call(node)
     if not (call and isinstance(node, ast.Assign)
@@ -490,24 +555,26 @@ def has_mediated_execution(body):
                 and call.func.value.id == base and call.func.attr == attribute)
 
     live, _ = normal_path_nodes(tree.body)
-    bridge_position = None
-    thread_position = None
-    start_position = None
-    launch_position = None
-    join_position = None
-    thread_bound = False
-    stub_function = None
+    bridges = []
+    thread_bindings = []
+    starts = []
+    launches = []
+    joins = []
+    current_stub_function = None
     for position, node in enumerate(live):
-        if isinstance(node, ast.FunctionDef) and node.name == "run_bounded_stub":
-            stub_function = node
-        if bridge_position is None and is_call(node, "bridge_path", "write_text"):
-            bridge_position = position
-        if start_position is None and is_call(node, "mediator_thread", "start"):
-            start_position = position
-        if launch_position is None and is_launch_subprocess(node):
-            launch_position = position
-        if join_position is None and is_call(node, "mediator_thread", "join"):
-            join_position = position
+        if binds_name(node, "run_bounded_stub"):
+            current_stub_function = (
+                node if isinstance(node, ast.FunctionDef)
+                and node.name == "run_bounded_stub" else None
+            )
+        if is_call(node, "bridge_path", "write_text"):
+            bridges.append(position)
+        if is_call(node, "mediator_thread", "start"):
+            starts.append(position)
+        if is_launch_subprocess(node):
+            launches.append(position)
+        if is_call(node, "mediator_thread", "join"):
+            joins.append(position)
         if not (isinstance(node, ast.Assign) and len(node.targets) == 1
                 and isinstance(node.targets[0], ast.Name)
                 and node.targets[0].id == "mediator_thread"):
@@ -517,12 +584,22 @@ def has_mediated_execution(body):
                 and isinstance(value.func.value, ast.Name)
                 and value.func.value.id == "threading" and value.func.attr == "Thread"):
             continue
-        thread_bound = any(keyword.arg == "target"
+        target_bound = any(keyword.arg == "target"
                            and isinstance(keyword.value, ast.Name)
                            and keyword.value.id == "run_bounded_stub"
                            for keyword in value.keywords)
-        if thread_bound and thread_position is None:
-            thread_position = position
+        if target_bound and current_stub_function is not None:
+            thread_bindings.append((position, current_stub_function))
+    if not all(len(items) == 1 for items in (bridges, thread_bindings, starts, launches, joins)):
+        return False
+    bridge_position = bridges[0]
+    thread_position, stub_function = thread_bindings[0]
+    start_position = starts[0]
+    launch_position = launches[0]
+    join_position = joins[0]
+    if any(binds_name(node, "mediator_thread")
+           for node in live[thread_position + 1:join_position]):
+        return False
     stub_live, _ = normal_path_nodes(stub_function.body if stub_function else [])
     stub_runs = bool(stub_function) and any(
         isinstance(node, ast.Assign) and len(node.targets) == 1
@@ -539,9 +616,7 @@ def has_mediated_execution(body):
         launch_position, join_position,
     )
     return (
-        thread_bound and stub_runs
-        and all(position is not None for position in positions)
-        and list(positions) == sorted(positions)
+        stub_runs and list(positions) == sorted(positions)
     )
 
 transport_body = transport_match.group(2) if transport_match else ""

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -254,11 +254,62 @@ def has_launch_subprocess(body):
             return True
     return False
 
+def has_mediated_execution(body):
+    """Require executable bridge -> thread start/join -> stub-run edges."""
+    if not body:
+        return False
+    try:
+        tree = ast.parse(body)
+    except SyntaxError:
+        return False
+
+    def is_call(node, base, attribute):
+        return (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == base and node.func.attr == attribute)
+
+    bridge_written = any(is_call(node, "bridge_path", "write_text")
+                         for node in ast.walk(tree))
+    thread_bound = False
+    thread_started = False
+    thread_joined = False
+    stub_function = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_bounded_stub":
+            stub_function = node
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "mediator_thread"):
+            continue
+        value = node.value
+        if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute)
+                and isinstance(value.func.value, ast.Name)
+                and value.func.value.id == "threading" and value.func.attr == "Thread"):
+            continue
+        thread_bound = any(keyword.arg == "target"
+                           and isinstance(keyword.value, ast.Name)
+                           and keyword.value.id == "run_bounded_stub"
+                           for keyword in value.keywords)
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "mediator_thread"):
+            continue
+        thread_started = thread_started or node.func.attr == "start"
+        thread_joined = thread_joined or node.func.attr == "join"
+    stub_runs = bool(stub_function) and any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name) and node.func.value.id == "subprocess"
+        and node.func.attr == "run" and node.args
+        and isinstance(node.args[0], ast.Name) and node.args[0].id == "command"
+        for node in ast.walk(stub_function)
+    )
+    return bridge_written and thread_bound and thread_started and thread_joined and stub_runs
+
 transport_body = transport_match.group(2) if transport_match else ""
 rehearsal_transport = (
     has_launch_subprocess(transport_body)
-    and "mediator_thread" in transport_body
-    and "bridge_path.write_text" in transport_body
+    and has_mediated_execution(transport_body)
 )
 if rehearsal_arms and rehearsal_transport:
     implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -27,10 +27,44 @@ else
 fi
 
 "${py_cmd[@]}" - "$repo_root" "$BASH" "$census_only" <<'PY'
+import os
 import re
+import signal
 import subprocess
 import sys
 from pathlib import Path
+
+if os.name == "nt":
+    import ctypes
+    from ctypes import wintypes
+
+    class _BasicLimit(ctypes.Structure):
+        _fields_ = [("PerProcessUserTimeLimit", ctypes.c_longlong), ("PerJobUserTimeLimit", ctypes.c_longlong),
+                    ("LimitFlags", wintypes.DWORD), ("MinimumWorkingSetSize", ctypes.c_size_t),
+                    ("MaximumWorkingSetSize", ctypes.c_size_t), ("ActiveProcessLimit", wintypes.DWORD),
+                    ("Affinity", ctypes.c_size_t), ("PriorityClass", wintypes.DWORD), ("SchedulingClass", wintypes.DWORD)]
+    class _IoCounters(ctypes.Structure):
+        _fields_ = [(name, ctypes.c_ulonglong) for name in ("ReadOperationCount", "WriteOperationCount", "OtherOperationCount", "ReadTransferCount", "WriteTransferCount", "OtherTransferCount")]
+    class _ExtendedLimit(ctypes.Structure):
+        _fields_ = [("BasicLimitInformation", _BasicLimit), ("IoInfo", _IoCounters),
+                    ("ProcessMemoryLimit", ctypes.c_size_t), ("JobMemoryLimit", ctypes.c_size_t),
+                    ("PeakProcessMemoryUsed", ctypes.c_size_t), ("PeakJobMemoryUsed", ctypes.c_size_t)]
+    class _KillOnCloseJob:
+        def __init__(self):
+            self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            self.handle = self.kernel32.CreateJobObjectW(None, None)
+            if not self.handle: raise OSError(ctypes.get_last_error(), "CreateJobObjectW")
+            limits = _ExtendedLimit()
+            limits.BasicLimitInformation.LimitFlags = 0x00002000  # KILL_ON_JOB_CLOSE
+            if not self.kernel32.SetInformationJobObject(self.handle, 9, ctypes.byref(limits), ctypes.sizeof(limits)):
+                self.close(); raise OSError(ctypes.get_last_error(), "SetInformationJobObject")
+        def assign(self, process):
+            if not self.kernel32.AssignProcessToJobObject(self.handle, wintypes.HANDLE(process._handle)):
+                self.close(); raise OSError(ctypes.get_last_error(), "AssignProcessToJobObject")
+        def close(self):
+            if self.handle:
+                self.kernel32.CloseHandle(self.handle)
+                self.handle = None
 
 root = Path(sys.argv[1]).resolve()
 bash_runner = sys.argv[2]
@@ -261,10 +295,53 @@ if not census_only:
     r30_probe = root / "tests" / "scarce-resource-rehearsal-contract.test.sh"
     if not r30_probe.is_file():
         raise SystemExit("check-helper-reachability: missing candidate-bound R30 rehearsal probe")
-    probe = subprocess.run([bash_runner, "tests/scarce-resource-rehearsal-contract.test.sh", "--r30-probe", "--repo-root", "."],
-                           cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    probe_args = [bash_runner, "tests/scarce-resource-rehearsal-contract.test.sh", "--r30-probe", "--repo-root", "."]
+    probe_kwargs = {"cwd": root, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+    probe_job = None
+    if os.name == "nt":
+        probe_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        probe_kwargs["start_new_session"] = True
+    probe = subprocess.Popen(probe_args, **probe_kwargs)
+    if os.name == "nt":
+        probe_job = _KillOnCloseJob()
+        probe_job.assign(probe)
+    timed_out = False
+    try:
+        probe_stdout, probe_stderr = probe.communicate(timeout=12)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        if os.name == "nt":
+            probe_job.close()
+        else:
+            try:
+                os.killpg(probe.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        if os.name != "nt":
+            try: probe.kill()
+            except ProcessLookupError: pass
+        try:
+            probe_stdout, probe_stderr = probe.communicate(timeout=2)
+        except subprocess.TimeoutExpired as residual:
+            # A killed direct child can still have a pipe-owning descendant.
+            # Do not let that descendant defeat the outer cleanup deadline.
+            probe_stdout = residual.output or b""
+            probe_stderr = residual.stderr or b""
+            if probe.stdout: probe.stdout.close()
+            if probe.stderr: probe.stderr.close()
+            try: probe.wait(timeout=2)
+            except subprocess.TimeoutExpired: pass
+    if probe_job:
+        probe_job.close()
+    diagnostic = probe_stderr.decode("utf-8", errors="replace")[-8192:]
+    diagnostic = re.sub(r"(?im)^([A-Z_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z_]*=).*?$", r"\1<redacted>", diagnostic)
+    if timed_out:
+        raise SystemExit("check-helper-reachability: candidate-bound R30 rehearsal probe timed out after 12s" +
+                         ("\n" + diagnostic if diagnostic else ""))
     if probe.returncode != 0:
-        raise SystemExit("check-helper-reachability: candidate-bound R30 rehearsal probe failed")
+        raise SystemExit("check-helper-reachability: candidate-bound R30 rehearsal probe failed" +
+                         ("\n" + diagnostic if diagnostic else ""))
 
 print(("HELPER_REACHABILITY_CENSUS=PASS " if census_only else "HELPER_REACHABILITY=PASS ") +
       f"population={len(helpers)} examined={len(rows)} "

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -2,11 +2,16 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+census_only=0
+if [ "${1:-}" = "--census-only" ]; then
+  census_only=1
+  shift
+fi
 if [ "${1:-}" = "--repo-root" ]; then
-  [ "$#" -eq 2 ] || { printf 'check-helper-reachability: usage: [--repo-root <dir>]\n' >&2; exit 2; }
+  [ "$#" -eq 2 ] || { printf 'check-helper-reachability: usage: [--census-only] [--repo-root <dir>]\n' >&2; exit 2; }
   repo_root="$(cd "$2" && pwd)"
 elif [ "$#" -ne 0 ]; then
-  printf 'check-helper-reachability: usage: [--repo-root <dir>]\n' >&2
+  printf 'check-helper-reachability: usage: [--census-only] [--repo-root <dir>]\n' >&2
   exit 2
 fi
 
@@ -21,13 +26,15 @@ else
   exit 2
 fi
 
-"${py_cmd[@]}" - "$repo_root" <<'PY'
-import ast
+"${py_cmd[@]}" - "$repo_root" "$BASH" "$census_only" <<'PY'
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 root = Path(sys.argv[1]).resolve()
+bash_runner = sys.argv[2]
+census_only = sys.argv[3] == "1"
 builder = root / "scripts" / "build-release-asset.sh"
 skill_root = root / "skills" / "implementaudit"
 contract = skill_root / "references" / "repo-state-comparison.md"
@@ -39,82 +46,53 @@ builder_text = builder.read_text(encoding="utf-8")
 match = re.search(r"(?ms)^required_archive\s*=\s*\[(.*?)^\]", builder_text)
 if not match:
     raise SystemExit("check-helper-reachability: required_archive manifest is unreadable")
-
 archive_entries = re.findall(r'"([^"]+)"', match.group(1))
-helpers = sorted(
-    entry.removeprefix("scripts/")
-    for entry in archive_entries
-    if re.fullmatch(r"scripts/[^/]+\.sh", entry)
-)
+helpers = sorted(entry.removeprefix("scripts/") for entry in archive_entries
+                 if re.fullmatch(r"scripts/[^/]+\.sh", entry))
 if len(helpers) != len(set(helpers)):
     raise SystemExit("check-helper-reachability: duplicate helper in required_archive")
 
 contract_text = contract.read_text(encoding="utf-8")
-rows = {}
-mode_rows = {}
+rows, mode_rows = {}, {}
 for line_number, line in enumerate(contract_text.splitlines(), 1):
     if line.startswith("helper-mode: "):
         parts = [part.strip() for part in line.split("|")]
         if len(parts) not in {4, 5}:
-            raise SystemExit(
-                f"check-helper-reachability: malformed helper mode at line {line_number}"
-            )
+            raise SystemExit(f"check-helper-reachability: malformed helper mode at line {line_number}")
         helper = parts[0].removeprefix("helper-mode: ")
         key = (helper, parts[1])
         if key in mode_rows:
             raise SystemExit(f"check-helper-reachability: duplicate mode applicability row: {' '.join(key)}")
-        mode_rows[key] = {
-            "arguments": parts[2], "boundary": parts[3],
-            "caller": parts[4] if len(parts) == 5 else "-",
-        }
-        continue
-    if not line.startswith("helper-route: "):
-        continue
-    parts = [part.strip() for part in line.split("|")]
-    if len(parts) != 7:
-        raise SystemExit(
-            f"check-helper-reachability: malformed helper route at line {line_number}"
-        )
-    helper = parts[0].removeprefix("helper-route: ")
-    if helper in rows:
-        raise SystemExit(f"check-helper-reachability: duplicate applicability row: {helper}")
-    rows[helper] = {
-        "class": parts[1], "trigger": parts[2], "owner": parts[3],
-        "caller": parts[4], "arguments": parts[5], "boundary": parts[6],
-    }
+        mode_rows[key] = {"arguments": parts[2], "boundary": parts[3],
+                          "caller": parts[4] if len(parts) == 5 else "-"}
+    elif line.startswith("helper-route: "):
+        parts = [part.strip() for part in line.split("|")]
+        if len(parts) != 7:
+            raise SystemExit(f"check-helper-reachability: malformed helper route at line {line_number}")
+        helper = parts[0].removeprefix("helper-route: ")
+        if helper in rows:
+            raise SystemExit(f"check-helper-reachability: duplicate applicability row: {helper}")
+        rows[helper] = {"class": parts[1], "trigger": parts[2], "owner": parts[3],
+                        "caller": parts[4], "arguments": parts[5], "boundary": parts[6]}
 
-missing = sorted(set(helpers) - set(rows))
-extra = sorted(set(rows) - set(helpers))
+missing, extra = sorted(set(helpers) - set(rows)), sorted(set(rows) - set(helpers))
 if missing:
     suffix = f" (population={len(helpers)} examined={len(rows)})" if len(helpers) != len(rows) else ""
-    raise SystemExit(
-        "check-helper-reachability: missing applicability rows: "
-        + ", ".join(missing) + suffix
-    )
+    raise SystemExit("check-helper-reachability: missing applicability rows: " + ", ".join(missing) + suffix)
 if extra:
-    raise SystemExit(
-        "check-helper-reachability: applicability rows not in package: "
-        + ", ".join(extra)
-    )
+    raise SystemExit("check-helper-reachability: applicability rows not in package: " + ", ".join(extra))
 
-class_names = {
-    "A": "automatic", "R": "required-procedural", "O": "optional-advisory",
-    "S": "standalone-diagnostic", "I": "internal-library",
-}
-owner_aliases = {
-    "P": "templates/PROTOCOL.md",
-    "R": "references/repo-state-comparison.md",
-    "C": "references/child-agents.md",
-    "S": "SKILL.md",
-    "V": "scripts/validate-run-root.sh",
-}
-mandatory_re = re.compile(
-    r"(?i)(?:^|[-_ ])(?:must|mandatory|required|block|gate)(?:$|[-_ .,;:`])"
-)
+class_names = {"A": "automatic", "R": "required-procedural", "O": "optional-advisory",
+               "S": "standalone-diagnostic", "I": "internal-library"}
+owner_aliases = {"P": "templates/PROTOCOL.md", "R": "references/repo-state-comparison.md",
+                 "C": "references/child-agents.md", "S": "SKILL.md",
+                 "V": "scripts/validate-run-root.sh"}
+mandatory_re = re.compile(r"(?i)(?:^|[-_ ])(?:must|mandatory|required|block|gate)(?:$|[-_ .,;:`])")
+
 def field_is_anchored(value, content):
     for part in value.lower().replace("artefact", "artifact").split("/"):
-        words = [w for w in re.split(r"[^a-z0-9]+", part)
-                 if len(w) >= 3 and w not in {"none", "only", "never", "automatic"}]
+        words = [word for word in re.split(r"[^a-z0-9]+", part)
+                 if len(word) >= 3 and word not in {"none", "only", "never", "automatic"}]
         if words and all(word in content for word in words):
             return True
     return False
@@ -122,16 +100,12 @@ def field_is_anchored(value, content):
 def arguments_are_anchored(value, helper, content):
     token_re = re.compile(r"--[a-z0-9][a-z0-9-]*|<[^>]+>|\.\.\.|[a-z0-9][a-z0-9-]*")
     expected = [] if value.lower() == "none" else token_re.findall(value.lower())
-    candidates = re.findall(r"`([^`]*" + re.escape(helper) + r"[^`]*)`",
-                            content, re.I | re.S)
-    candidates.extend(
-        line.split("#", 1)[0] for line in content.splitlines()
-        if helper in line and "`" not in line and
-        re.match(r"\s*(?:bash|source|exec)\b", line, re.I)
-    )
+    candidates = re.findall(r"`([^`]*" + re.escape(helper) + r"[^`]*)`", content, re.I | re.S)
+    candidates.extend(line.split("#", 1)[0] for line in content.splitlines()
+                      if helper in line and "`" not in line and re.match(r"\s*(?:bash|source|exec)\b", line, re.I))
     for candidate in candidates:
-        match = re.search(re.escape(helper), candidate, re.I)
-        actual = token_re.findall(candidate[match.end():].lower()) if match else []
+        found = re.search(re.escape(helper), candidate, re.I)
+        actual = token_re.findall(candidate[found.end():].lower()) if found else []
         if actual == expected:
             return True
     return False
@@ -139,71 +113,41 @@ def arguments_are_anchored(value, helper, content):
 def shell_code(content):
     cleaned = []
     for line in content.splitlines():
-        quote = None
-        escaped = False
-        kept = []
+        quote, escaped, kept = None, False, []
         for index, char in enumerate(line):
             if escaped:
-                kept.append(char)
-                escaped = False
-                continue
+                kept.append(char); escaped = False; continue
             if char == "\\" and quote != "'":
-                kept.append(char)
-                escaped = True
-                continue
+                kept.append(char); escaped = True; continue
             if char in {"'", '"'}:
-                if quote == char:
-                    quote = None
-                elif quote is None:
-                    quote = char
-                kept.append(char)
-                continue
+                quote = None if quote == char else (char if quote is None else quote)
+                kept.append(char); continue
             if char == "#" and quote is None and (index == 0 or line[index - 1].isspace()):
                 break
             kept.append(char)
         cleaned.append("".join(kept))
     return "\n".join(cleaned)
 
-def shell_parser_code(content):
-    """Return shell syntax without heredoc bodies (which are data, not arms)."""
-    kept = []
-    lines = iter(content.splitlines())
-    for line in lines:
-        kept.append(line)
-        tags = re.findall(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", line)
-        for tag in tags:
-            for body_line in lines:
-                if body_line.strip() == tag:
-                    break
-    return "\n".join(kept)
-
 def caller_invokes(helper, content):
     content = shell_code(content)
     def command_uses(target, path_prefix=False):
-        prefix = r'''(?:[^\s"']*/)?''' if path_prefix else ""
-        operand = rf'''["']?{prefix}{target}["']?(?=\s|$)'''
+        prefix = r"(?:[^\s\"']*/)?" if path_prefix else ""
+        operand = rf"[\"']?{prefix}{target}[\"']?(?=\s|$)"
         direct = rf"(?m)^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:[^\s]+|\"[^\"]*\"|'[^']*')\s+)*(?:(?:if|while|until|!)\s+)?(?:bash|source|exec)?\s*{operand}"
-        substitution = rf'''(?mx)^\s*[a-z_][a-z0-9_]*\s*=\s*["']?\$\(\s*(?:bash|source|exec)\s+{operand}'''
-        return bool(re.search(direct, content, re.I) or
-                    re.search(substitution, content, re.I))
-
+        substitution = rf"(?mx)^\s*[a-z_][a-z0-9_]*\s*=\s*[\"']?\$\(\s*(?:bash|source|exec)\s+{operand}"
+        return bool(re.search(direct, content, re.I) or re.search(substitution, content, re.I))
     if command_uses(re.escape(helper), path_prefix=True):
         return True
     assignment = None
     for line in content.splitlines():
         candidate = re.match(r"^\s*([a-z_][a-z0-9_]*)\s*=\s*(.+?)\s*$", line, re.I)
-        if not candidate:
-            continue
-        value = candidate.group(2)
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-            value = value[1:-1]
-        if re.search(rf"(?:^|/){re.escape(helper)}$", value):
-            assignment = candidate
-            break
-    if not assignment:
-        return False
-    variable = re.escape(assignment.group(1))
-    return command_uses(rf"\${{?{variable}}}?")
+        if candidate:
+            value = candidate.group(2)
+            value = value[1:-1] if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'} else value
+            if re.search(rf"(?:^|/){re.escape(helper)}$", value):
+                assignment = candidate
+                break
+    return bool(assignment and command_uses(rf"\${{?{re.escape(assignment.group(1))}}}?"))
 
 def packaged_path(raw, helper, role):
     rel = Path(raw)
@@ -224,591 +168,106 @@ implemented_mode_sets = {}
 graph_helper = "validate-run-root.sh"
 graph_text = (skill_root / "scripts" / graph_helper).read_text(encoding="utf-8")
 implemented_mode_sets[graph_helper] = sorted(set(re.findall(r"--graph-[a-z0-9-]+", graph_text)))
-rehearsal_helper = "check-authorization-binding.sh"
-rehearsal_text = (skill_root / "scripts" / rehearsal_helper).read_text(encoding="utf-8")
-rehearsal_mode = "--phase --rehearsal --launch"
-rehearsal_code = shell_code(shell_parser_code(rehearsal_text))
-rehearsal_arms = all(re.search(rf"(?m)^\s*{re.escape(flag)}\)", rehearsal_code)
-                     for flag in rehearsal_mode.split())
-transport_match = re.search(
-    r'''(?ms)python\s+-\s+"\$phase"\s+"\$rehearsal"\s+"\$launch"\s+<<['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*\n(.*?)^\1\s*$''',
-    rehearsal_text,
-)
-
-UNKNOWN_CONSTANT = object()
-MAX_STATIC_NUMBER = 1_000_000
-
-def bounded_scalar(node):
-    """Evaluate only small scalar literals; never allocate candidate containers."""
-    if isinstance(node, ast.Constant):
-        value = node.value
-        if isinstance(value, (str, bytes)):
-            return value if len(value) <= 256 else UNKNOWN_CONSTANT
-        if isinstance(value, (bool, int, float, complex)) or value is None:
-            return value if not isinstance(value, (int, float, complex)) or abs(value) <= MAX_STATIC_NUMBER else UNKNOWN_CONSTANT
-        return UNKNOWN_CONSTANT
-    if isinstance(node, ast.UnaryOp):
-        value = bounded_scalar(node.operand)
-        if value is UNKNOWN_CONSTANT:
-            return value
-        try:
-            if isinstance(node.op, ast.Not):
-                return not value
-            if isinstance(node.op, ast.UAdd):
-                return +value
-            if isinstance(node.op, ast.USub):
-                return -value
-        except (TypeError, ValueError, OverflowError):
-            pass
-        return UNKNOWN_CONSTANT
-    if isinstance(node, ast.BinOp):
-        left, right = bounded_scalar(node.left), bounded_scalar(node.right)
-        if left is UNKNOWN_CONSTANT or right is UNKNOWN_CONSTANT:
-            return UNKNOWN_CONSTANT
-        if not isinstance(left, (bool, int, float, complex)) or not isinstance(right, (bool, int, float, complex)):
-            return UNKNOWN_CONSTANT
-        try:
-            if isinstance(node.op, ast.Add):
-                value = left + right
-            elif isinstance(node.op, ast.Sub):
-                value = left - right
-            elif isinstance(node.op, ast.Mult):
-                value = left * right
-            elif isinstance(node.op, ast.Div):
-                value = left / right
-            elif isinstance(node.op, ast.FloorDiv):
-                value = left // right
-            elif isinstance(node.op, ast.Mod):
-                value = left % right
-            else:
-                return UNKNOWN_CONSTANT
-            return value if abs(value) <= MAX_STATIC_NUMBER else UNKNOWN_CONSTANT
-        except (TypeError, ValueError, ZeroDivisionError, OverflowError):
-            return UNKNOWN_CONSTANT
-    return UNKNOWN_CONSTANT
-
-def compare_scalars(operation, left, right):
-    try:
-        if isinstance(operation, ast.Eq): return left == right
-        if isinstance(operation, ast.NotEq): return left != right
-        if isinstance(operation, ast.Is): return left is right
-        if isinstance(operation, ast.IsNot): return left is not right
-        if isinstance(operation, ast.Lt): return left < right
-        if isinstance(operation, ast.LtE): return left <= right
-        if isinstance(operation, ast.Gt): return left > right
-        if isinstance(operation, ast.GtE): return left >= right
-    except (TypeError, ValueError):
-        pass
-    return UNKNOWN_CONSTANT
-
-def constant_truth(node):
-    """Return a statically known truth value without executing source."""
-    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
-        return bool(node.elts)
-    if isinstance(node, ast.Dict):
-        return bool(node.keys)
-    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            and node.func.id in {"dict", "list", "set", "tuple"}
-            and not node.args and not node.keywords):
-        return False
-    if isinstance(node, ast.BoolOp):
-        values = [constant_truth(item) for item in node.values]
-        if isinstance(node.op, ast.And):
-            if False in values: return False
-            return True if all(value is True for value in values) else None
-        if True in values: return True
-        return False if all(value is False for value in values) else None
-    if isinstance(node, ast.Compare):
-        left = bounded_scalar(node.left)
-        if left is UNKNOWN_CONSTANT:
-            return None
-        for operation, comparator in zip(node.ops, node.comparators):
-            right = bounded_scalar(comparator)
-            if right is UNKNOWN_CONSTANT:
-                return None
-            outcome = compare_scalars(operation, left, right)
-            if outcome is UNKNOWN_CONSTANT or not outcome:
-                return None if outcome is UNKNOWN_CONSTANT else False
-            left = right
-        return True
-    value = bounded_scalar(node)
-    return None if value is UNKNOWN_CONSTANT else bool(value)
-
-def terminating_call(node):
-    if not isinstance(node, ast.Call):
-        return False
-    call = node.func
-    if isinstance(call, ast.Name):
-        return call.id in {"exit", "quit"}
-    return (isinstance(call, ast.Attribute) and isinstance(call.value, ast.Name)
-            and (call.value.id, call.attr) in {
-                ("sys", "exit"), ("os", "_exit"),
-            })
-
-def terminates_route(node):
-    if isinstance(node, (ast.Raise, ast.Return)):
-        return True
-    if isinstance(node, ast.Assert) and constant_truth(node.test) is False:
-        return True
-    return isinstance(node, ast.Expr) and terminating_call(node.value)
-
-def expression_terminates(node):
-    """Return whether evaluating this expression must execute an explicit exit."""
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Lambda):
-        return expression_terminates(node.func.body)
-    if isinstance(node, ast.Lambda):
-        return False
-    if isinstance(node, ast.GeneratorExp):
-        return bool(node.generators) and expression_terminates(node.generators[0].iter)
-    if terminating_call(node):
-        return True
-    if isinstance(node, ast.IfExp):
-        if expression_terminates(node.test):
-            return True
-        truth = constant_truth(node.test)
-        branch = node.body if truth is True else node.orelse if truth is False else None
-        return branch is not None and expression_terminates(branch)
-    if isinstance(node, ast.BoolOp):
-        for item in node.values:
-            if expression_terminates(item):
-                return True
-            truth = constant_truth(item)
-            if isinstance(node.op, ast.And) and truth is not True:
-                break
-            if isinstance(node.op, ast.Or) and truth is not False:
-                break
-        return False
-    if isinstance(node, ast.Compare):
-        if expression_terminates(node.left):
-            return True
-        left = bounded_scalar(node.left)
-        for operation, comparator in zip(node.ops, node.comparators):
-            if expression_terminates(comparator):
-                return True
-            right = bounded_scalar(comparator)
-            if left is UNKNOWN_CONSTANT or right is UNKNOWN_CONSTANT:
-                break
-            outcome = compare_scalars(operation, left, right)
-            if outcome is not True:
-                break
-            left = right
-        return False
-    if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp)):
-        if not node.generators:
-            return False
-        generator = node.generators[0]
-        if expression_terminates(generator.iter):
-            return True
-        if (len(node.generators) != 1 or generator.ifs
-                or constant_truth(generator.iter) is not True):
-            return False
-        projections = ([node.elt] if not isinstance(node, ast.DictComp)
-                       else [node.key, node.value])
-        return any(expression_terminates(item) for item in projections)
-    return any(
-        expression_terminates(child)
-        for child in ast.iter_child_nodes(node)
-        if isinstance(child, ast.expr)
-    )
-
-def decorator_terminates(node):
-    """A decorator lambda is created, then immediately applied to the class/function."""
-    return (expression_terminates(node.body) if isinstance(node, ast.Lambda)
-            else expression_terminates(node))
-
-def definition_expressions(node):
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        annotations = [
-            *(argument.annotation for argument in [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
-              if argument.annotation is not None),
-            *(argument.annotation for argument in [node.args.vararg, node.args.kwarg]
-              if argument is not None and argument.annotation is not None),
-        ]
-        return [
-            *node.args.defaults,
-            *(item for item in node.args.kw_defaults if item is not None),
-            *annotations,
-            *([node.returns] if node.returns is not None else []),
-        ]
-    if isinstance(node, ast.ClassDef):
-        return [*node.bases, *(item.value for item in node.keywords)]
-    return []
-
-def normal_path_nodes(statements):
-    """Return ordered statements on the normal non-exception route."""
-    result = []
-    for node in statements:
-        result.append(node)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            if (any(decorator_terminates(item) for item in node.decorator_list)
-                    or any(expression_terminates(item) for item in definition_expressions(node))):
-                return result, True
-            if isinstance(node, ast.ClassDef):
-                _, terminated = normal_path_nodes(node.body)
-                if terminated:
-                    return result, True
-            continue
-        if terminates_route(node):
-            return result, True
-        if isinstance(node, ast.If):
-            if expression_terminates(node.test):
-                return result, True
-            truth = constant_truth(node.test)
-            branch = node.orelse if truth is False else node.body if truth is True else []
-            nested, terminated = normal_path_nodes(branch)
-            result.extend(nested)
-            if terminated:
-                return result, True
-            continue
-        if isinstance(node, ast.Try):
-            nested, terminated = normal_path_nodes(node.body)
-            result.extend(nested)
-            if not terminated:
-                nested, terminated = normal_path_nodes(node.orelse)
-                result.extend(nested)
-            final_nodes, final_terminated = normal_path_nodes(node.finalbody)
-            result.extend(final_nodes)
-            if terminated or final_terminated:
-                return result, True
-            continue
-        if isinstance(node, (ast.With, ast.AsyncWith)):
-            if any(expression_terminates(item.context_expr) for item in node.items):
-                return result, True
-            nested, terminated = normal_path_nodes(node.body)
-            result.extend(nested)
-            if terminated:
-                return result, True
-            continue
-        if isinstance(node, ast.While):
-            if expression_terminates(node.test):
-                return result, True
-            truth = constant_truth(node.test)
-            if truth is False:
-                nested, terminated = normal_path_nodes(node.orelse)
-                result.extend(nested)
-                if terminated:
-                    return result, True
-            elif truth is True:
-                nested, _ = normal_path_nodes(node.body)
-                result.extend(nested)
-                return result, True
-            continue
-        if isinstance(node, (ast.For, ast.AsyncFor)):
-            if expression_terminates(node.iter):
-                return result, True
-            continue
-        for child in ast.iter_child_nodes(node):
-            if isinstance(child, ast.expr) and expression_terminates(child):
-                return result, True
-    return result, False
-
-def statement_call(node):
-    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
-        return node.value
-    if (isinstance(node, ast.Assign) and len(node.targets) == 1
-            and isinstance(node.value, ast.Call)):
-        return node.value
-    return None
-
-def target_binds(target, name):
-    if isinstance(target, ast.Name):
-        return target.id == name
-    if isinstance(target, (ast.Tuple, ast.List)):
-        return any(target_binds(item, name) for item in target.elts)
-    return False
-
-def binds_name(node, name):
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-        return node.name == name
-    if isinstance(node, ast.Assign):
-        return any(target_binds(target, name) for target in node.targets)
-    if isinstance(node, (ast.AnnAssign, ast.AugAssign, ast.For, ast.AsyncFor)):
-        return target_binds(node.target, name)
-    if isinstance(node, ast.Delete):
-        return any(target_binds(target, name) for target in node.targets)
-    if isinstance(node, (ast.With, ast.AsyncWith)):
-        return any(item.optional_vars is not None and target_binds(item.optional_vars, name)
-                   for item in node.items)
-    if isinstance(node, (ast.Import, ast.ImportFrom)):
-        return any((alias.asname or alias.name.split(".")[0]) == name for alias in node.names)
-    return any(
-        isinstance(item, ast.NamedExpr) and target_binds(item.target, name)
-        for item in ast.walk(node)
-        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda))
-    )
-
-def is_launch_subprocess(node):
-    call = statement_call(node)
-    if not (call and isinstance(node, ast.Assign)
-            and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id == "completed"
-            and isinstance(call.func, ast.Attribute)
-            and isinstance(call.func.value, ast.Name)
-            and call.func.value.id == "subprocess" and call.func.attr == "run"
-            and call.args and isinstance(call.args[0], ast.Subscript)
-            and isinstance(call.args[0].value, ast.Name)
-            and call.args[0].value.id == "launch"):
-        return False
-    slice_node = call.args[0].slice
-    return isinstance(slice_node, ast.Constant) and slice_node.value == "argv"
-
-def has_launch_subprocess(body):
-    if not body:
-        return False
-    try:
-        tree = ast.parse(body)
-    except SyntaxError:
-        return False
-    live, _ = normal_path_nodes(tree.body)
-    return any(is_launch_subprocess(node) for node in live)
-
-def has_mediated_execution(body):
-    """Require executable bridge -> thread start/join -> stub-run edges."""
-    if not body:
-        return False
-    try:
-        tree = ast.parse(body)
-    except SyntaxError:
-        return False
-
-    def is_call(node, base, attribute):
-        call = statement_call(node)
-        return (call is not None and isinstance(node, ast.Expr)
-                and isinstance(call.func, ast.Attribute)
-                and isinstance(call.func.value, ast.Name)
-                and call.func.value.id == base and call.func.attr == attribute)
-
-    live, _ = normal_path_nodes(tree.body)
-    bridges = []
-    thread_bindings = []
-    starts = []
-    launches = []
-    joins = []
-    current_stub_function = None
-    for position, node in enumerate(live):
-        if binds_name(node, "run_bounded_stub"):
-            current_stub_function = (
-                node if isinstance(node, ast.FunctionDef)
-                and node.name == "run_bounded_stub" else None
-            )
-        if is_call(node, "bridge_path", "write_text"):
-            bridges.append(position)
-        if is_call(node, "mediator_thread", "start"):
-            starts.append(position)
-        if is_launch_subprocess(node):
-            launches.append(position)
-        if is_call(node, "mediator_thread", "join"):
-            joins.append(position)
-        if not (isinstance(node, ast.Assign) and len(node.targets) == 1
-                and isinstance(node.targets[0], ast.Name)
-                and node.targets[0].id == "mediator_thread"):
-            continue
-        value = node.value
-        if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute)
-                and isinstance(value.func.value, ast.Name)
-                and value.func.value.id == "threading" and value.func.attr == "Thread"):
-            continue
-        target_bound = any(keyword.arg == "target"
-                           and isinstance(keyword.value, ast.Name)
-                           and keyword.value.id == "run_bounded_stub"
-                           for keyword in value.keywords)
-        if target_bound and current_stub_function is not None:
-            thread_bindings.append((position, current_stub_function))
-    if not all(len(items) == 1 for items in (bridges, thread_bindings, starts, launches, joins)):
-        return False
-    bridge_position = bridges[0]
-    thread_position, stub_function = thread_bindings[0]
-    start_position = starts[0]
-    launch_position = launches[0]
-    join_position = joins[0]
-    if any(binds_name(node, "mediator_thread")
-           for node in live[thread_position + 1:join_position]):
-        return False
-    stub_live, _ = normal_path_nodes(stub_function.body if stub_function else [])
-    stub_runs = bool(stub_function) and any(
-        isinstance(node, ast.Assign) and len(node.targets) == 1
-        and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "result"
-        and (call := statement_call(node)) is not None
-        and isinstance(call.func, ast.Attribute)
-        and isinstance(call.func.value, ast.Name) and call.func.value.id == "subprocess"
-        and call.func.attr == "run" and call.args
-        and isinstance(call.args[0], ast.Name) and call.args[0].id == "command"
-        for node in stub_live
-    )
-    positions = (
-        bridge_position, thread_position, start_position,
-        launch_position, join_position,
-    )
-    return (
-        stub_runs and list(positions) == sorted(positions)
-    )
-
-transport_body = transport_match.group(2) if transport_match else ""
-rehearsal_transport = (
-    has_launch_subprocess(transport_body)
-    and has_mediated_execution(transport_body)
-)
-if rehearsal_arms and rehearsal_transport:
-    implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]
-else:
-    implemented_mode_sets[rehearsal_helper] = []
+rehearsal_helper, rehearsal_mode = "check-authorization-binding.sh", "--phase --rehearsal --launch"
+# R32: static census records the declared mode; candidate-bound F10 below is
+# the only execution authority for its parser, mediator, wrapper, and stub.
+implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]
 
 for helper, mode in mode_rows:
     if helper not in helpers or mode not in implemented_mode_sets.get(helper, []):
-        raise SystemExit(
-            f"check-helper-reachability: mode applicability not implemented: {helper} {mode}"
-        )
+        raise SystemExit(f"check-helper-reachability: mode applicability not implemented: {helper} {mode}")
 for helper, implemented_modes in implemented_mode_sets.items():
     declared_modes = sorted(mode for row_helper, mode in mode_rows if row_helper == helper)
     missing_modes = sorted(set(implemented_modes) - set(declared_modes))
     if missing_modes:
-        raise SystemExit(
-            "check-helper-reachability: missing mode applicability rows: "
-            + ", ".join(f"{helper} {mode}" for mode in missing_modes)
-        )
+        raise SystemExit("check-helper-reachability: missing mode applicability rows: " + ", ".join(
+            f"{helper} {mode}" for mode in missing_modes))
 
-mode_owner = "\n".join(
-    line for line in contract_text.splitlines()
-    if not line.startswith(("helper-route: ", "helper-mode: "))
-)
+mode_owner = "\n".join(line for line in contract_text.splitlines()
+                       if not line.startswith(("helper-route: ", "helper-mode: ")))
 for helper, mode in mode_rows:
     row = mode_rows[(helper, mode)]
-    mode_flags = mode.split()
-    mode_args = row["arguments"].split()
+    mode_flags, mode_args = mode.split(), row["arguments"].split()
     mode_command = f"{mode} {row['arguments']}"
     if len(mode_flags) > 1:
         if len(mode_flags) != len(mode_args):
-            raise SystemExit(
-                f"check-helper-reachability: mode argument arity mismatch: {helper} {mode}"
-            )
-        mode_command = " ".join(
-            f"{flag} {argument}" for flag, argument in zip(mode_flags, mode_args)
-        )
+            raise SystemExit(f"check-helper-reachability: mode argument arity mismatch: {helper} {mode}")
+        mode_command = " ".join(f"{flag} {argument}" for flag, argument in zip(mode_flags, mode_args))
     if not arguments_are_anchored(mode_command, helper, mode_owner):
-        raise SystemExit(
-            f"check-helper-reachability: mode arguments absent: {helper} {mode}"
-        )
+        raise SystemExit(f"check-helper-reachability: mode arguments absent: {helper} {mode}")
     if not field_is_anchored(row["boundary"], mode_owner.lower()):
-        raise SystemExit(
-            f"check-helper-reachability: mode boundary absent: {helper} {mode}"
-        )
-    mode_caller = row["caller"]
-    if mode_caller != "-":
-        caller_path = packaged_path(mode_caller, helper, "mode caller")
-        caller_content = shell_code(caller_path.read_text(encoding="utf-8"))
+        raise SystemExit(f"check-helper-reachability: mode boundary absent: {helper} {mode}")
+    if row["caller"] != "-":
+        caller_content = shell_code(packaged_path(row["caller"], helper, "mode caller").read_text(encoding="utf-8"))
         if not caller_invokes(helper, caller_content):
-            raise SystemExit(
-                f"check-helper-reachability: mode caller does not invoke {helper}: {mode_caller}"
-            )
-        mode_flags = r"\s+" + r"\s+".join(re.escape(flag) + r"\s+[^\s]+" for flag in mode.split())
-        if not re.search(re.escape(helper) + r'["\']?' + mode_flags, caller_content):
-            raise SystemExit(
-                f"check-helper-reachability: mode caller does not invoke exact mode: {helper} {mode}"
-            )
+            raise SystemExit(f"check-helper-reachability: mode caller does not invoke {helper}: {row['caller']}")
+        flags = r"\s+" + r"\s+".join(re.escape(flag) + r"\s+[^\s]+" for flag in mode.split())
+        if not re.search(re.escape(helper) + r"[\"']?" + flags, caller_content):
+            raise SystemExit(f"check-helper-reachability: mode caller does not invoke exact mode: {helper} {mode}")
 
 for helper in helpers:
     row = rows[helper]
-    class_code = row["class"]
-    if class_code not in class_names:
-        raise SystemExit(
-            f"check-helper-reachability: invalid applicability class {class_code} for {helper}"
-        )
-    applicability = class_names[class_code]
+    if row["class"] not in class_names:
+        raise SystemExit(f"check-helper-reachability: invalid applicability class {row['class']} for {helper}")
+    applicability = class_names[row["class"]]
     for field in ("trigger", "arguments", "boundary"):
         if not row[field] or row[field] == "-":
             raise SystemExit(f"check-helper-reachability: empty {field} for {helper}")
-
     owner_text = owner_aliases.get(row["owner"], row["owner"])
-    owner_rel = Path(owner_text)
-    own_rel = Path("scripts") / helper
-    if owner_rel == own_rel:
-        raise SystemExit(
-            f"check-helper-reachability: dispatch owner cannot be the helper itself: {helper}"
-        )
-    owner = packaged_path(owner_text, helper, "dispatch owner")
-    owner_lines = owner.read_text(encoding="utf-8").splitlines()
+    if Path(owner_text) == Path("scripts") / helper:
+        raise SystemExit(f"check-helper-reachability: dispatch owner cannot be the helper itself: {helper}")
+    owner_lines = packaged_path(owner_text, helper, "dispatch owner").read_text(encoding="utf-8").splitlines()
     non_route_lines = [line for line in owner_lines if not line.startswith(("helper-route: ", "helper-mode: "))]
     owner_content = "\n".join(non_route_lines)
     helper_lines = [index for index, line in enumerate(non_route_lines) if helper in line]
     if not helper_lines:
-        raise SystemExit(
-            f"check-helper-reachability: dispatch owner does not name helper {helper}: {owner_text}"
-        )
+        raise SystemExit(f"check-helper-reachability: dispatch owner does not name helper {helper}: {owner_text}")
     if applicability == "required-procedural":
         action = r"(?:bash|run|supply|dispatch(?:es)?|invoke|enforce|requires?|claim(?: it)? with)"
-        contexts = ["\n".join(non_route_lines[max(0, i - 4):i + 5])
-                    for i in helper_lines]
+        contexts = ["\n".join(non_route_lines[max(0, i - 4):i + 5]) for i in helper_lines]
         procedural = [context for context in contexts if re.search(
-            rf"(?:{action}.{{0,120}}{re.escape(helper)}|{re.escape(helper)}.{{0,120}}{action})",
-            context, re.I | re.S
-        )]
+            rf"(?:{action}.{{0,120}}{re.escape(helper)}|{re.escape(helper)}.{{0,120}}{action})", context, re.I | re.S)]
         if not procedural:
-            raise SystemExit(
-                f"check-helper-reachability: procedural route absent: {helper}"
-            )
-        field_contexts = [context.lower().replace("artefact", "artifact")
-                          .replace(helper.lower(), "") for context in procedural]
+            raise SystemExit(f"check-helper-reachability: procedural route absent: {helper}")
+        field_contexts = [context.lower().replace("artefact", "artifact").replace(helper.lower(), "") for context in procedural]
         for field in ("trigger", "boundary"):
             if not any(field_is_anchored(row[field], context) for context in field_contexts):
-                raise SystemExit(
-                    f"check-helper-reachability: unanchored {field}: {helper}: {row[field]}"
-                )
-        if not any(arguments_are_anchored(row["arguments"], helper, context)
-                   for context in procedural):
-            raise SystemExit(
-                f"check-helper-reachability: unanchored arguments: {helper}: {row['arguments']}"
-            )
-        if not any(
-            field_is_anchored(row["trigger"], context.lower().replace("artefact", "artifact")
-                              .replace(helper.lower(), ""))
-            and field_is_anchored(row["boundary"], context.lower().replace("artefact", "artifact")
-                                  .replace(helper.lower(), ""))
-            and arguments_are_anchored(row["arguments"], helper, context)
-            for context in procedural
-        ):
-            raise SystemExit(
-                f"check-helper-reachability: route fields do not co-occur: {helper}"
-            )
+                raise SystemExit(f"check-helper-reachability: unanchored {field}: {helper}: {row[field]}")
+        if not any(arguments_are_anchored(row["arguments"], helper, context) for context in procedural):
+            raise SystemExit(f"check-helper-reachability: unanchored arguments: {helper}: {row['arguments']}")
+        if not any(field_is_anchored(row["trigger"], context.lower().replace("artefact", "artifact").replace(helper.lower(), ""))
+                   and field_is_anchored(row["boundary"], context.lower().replace("artefact", "artifact").replace(helper.lower(), ""))
+                   and arguments_are_anchored(row["arguments"], helper, context) for context in procedural):
+            raise SystemExit(f"check-helper-reachability: route fields do not co-occur: {helper}")
     if applicability in {"optional-advisory", "standalone-diagnostic"}:
-        advisory_text = " ".join(
-            (row["trigger"], row["arguments"], row["boundary"])
-        )
-        if mandatory_re.search(advisory_text):
-            raise SystemExit(
-                f"check-helper-reachability: advisory/standalone row implies mandatory enforcement: {helper}"
-            )
-        if any(mandatory_re.search(" ".join(non_route_lines[max(0, i - 1):i + 2]))
-               for i in helper_lines):
-            raise SystemExit(
-                f"check-helper-reachability: advisory owner overclaim: {helper}"
-            )
-
+        advisory = " ".join((row["trigger"], row["arguments"], row["boundary"]))
+        if mandatory_re.search(advisory):
+            raise SystemExit(f"check-helper-reachability: advisory/standalone row implies mandatory enforcement: {helper}")
+        if any(mandatory_re.search(" ".join(non_route_lines[max(0, i - 1):i + 2])) for i in helper_lines):
+            raise SystemExit(f"check-helper-reachability: advisory owner overclaim: {helper}")
     caller_rel = owner_aliases.get(row["caller"], row["caller"])
     if applicability in {"automatic", "internal-library"}:
         if caller_rel == "-":
-            raise SystemExit(
-                f"check-helper-reachability: {applicability} helper lacks caller: {helper}"
-            )
+            raise SystemExit(f"check-helper-reachability: {applicability} helper lacks caller: {helper}")
         caller_path = packaged_path(caller_rel, helper, "caller")
-        if not (Path(caller_rel).as_posix().startswith("scripts/") and
-                Path(caller_rel).suffix == ".sh"):
-            raise SystemExit(
-                f"check-helper-reachability: caller is not a shipped script: {helper}: {caller_rel}"
-            )
-        caller_content = caller_path.read_text(encoding="utf-8")
-        if not caller_invokes(helper, caller_content):
-            raise SystemExit(
-                f"check-helper-reachability: caller does not invoke {helper}: {caller_rel}"
-            )
+        if not (Path(caller_rel).as_posix().startswith("scripts/") and Path(caller_rel).suffix == ".sh"):
+            raise SystemExit(f"check-helper-reachability: caller is not a shipped script: {helper}: {caller_rel}")
+        if not caller_invokes(helper, caller_path.read_text(encoding="utf-8")):
+            raise SystemExit(f"check-helper-reachability: caller does not invoke {helper}: {caller_rel}")
     elif caller_rel != "-":
-        raise SystemExit(
-            f"check-helper-reachability: nonautomatic helper declares caller: {helper}"
-        )
+        raise SystemExit(f"check-helper-reachability: nonautomatic helper declares caller: {helper}")
 
-print(
-    "HELPER_REACHABILITY=PASS "
-    f"population={len(helpers)} examined={len(rows)} "
-    f"modes={len(mode_rows)}/{sum(len(modes) for modes in implemented_mode_sets.values())} "
-    "enumeration=build-release-asset.required_archive"
-)
+if not census_only:
+    r30_probe = root / "tests" / "scarce-resource-rehearsal-contract.test.sh"
+    if not r30_probe.is_file():
+        raise SystemExit("check-helper-reachability: missing candidate-bound R30 rehearsal probe")
+    probe = subprocess.run([bash_runner, "tests/scarce-resource-rehearsal-contract.test.sh", "--r30-probe", "--repo-root", "."],
+                           cwd=root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if probe.returncode != 0:
+        raise SystemExit("check-helper-reachability: candidate-bound R30 rehearsal probe failed")
+
+print(("HELPER_REACHABILITY_CENSUS=PASS " if census_only else "HELPER_REACHABILITY=PASS ") +
+      f"population={len(helpers)} examined={len(rows)} "
+      f"modes={len(mode_rows)}/{sum(len(modes) for modes in implemented_mode_sets.values())} "
+      "enumeration=build-release-asset.required_archive")
 PY

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+authority_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="$authority_root"
 census_only=0
 if [ "${1:-}" = "--census-only" ]; then
   census_only=1
@@ -26,7 +27,7 @@ else
   exit 2
 fi
 
-"${py_cmd[@]}" - "$repo_root" "$BASH" "$census_only" <<'PY'
+"${py_cmd[@]}" - "$repo_root" "$authority_root" "$BASH" "$census_only" <<'PY'
 import os
 import re
 import signal
@@ -67,8 +68,9 @@ if os.name == "nt":
                 self.handle = None
 
 root = Path(sys.argv[1]).resolve()
-bash_runner = sys.argv[2]
-census_only = sys.argv[3] == "1"
+authority_root = Path(sys.argv[2]).resolve()
+bash_runner = sys.argv[3]
+census_only = sys.argv[4] == "1"
 builder = root / "scripts" / "build-release-asset.sh"
 skill_root = root / "skills" / "implementaudit"
 contract = skill_root / "references" / "repo-state-comparison.md"
@@ -292,11 +294,13 @@ for helper in helpers:
         raise SystemExit(f"check-helper-reachability: nonautomatic helper declares caller: {helper}")
 
 if not census_only:
-    r30_probe = root / "tests" / "scarce-resource-rehearsal-contract.test.sh"
+    # The evaluated candidate supplies skills and fixtures, never the probe
+    # program.  The checker invocation root is the authority for F10 behavior.
+    r30_probe = authority_root / "tests" / "scarce-resource-rehearsal-contract.test.sh"
     if not r30_probe.is_file():
-        raise SystemExit("check-helper-reachability: missing candidate-bound R30 rehearsal probe")
-    probe_args = [bash_runner, "tests/scarce-resource-rehearsal-contract.test.sh", "--r30-probe", "--repo-root", "."]
-    probe_kwargs = {"cwd": root, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+        raise SystemExit("check-helper-reachability: missing independently rooted R30 rehearsal probe")
+    probe_args = [bash_runner, str(r30_probe), "--r30-probe", "--repo-root", str(root)]
+    probe_kwargs = {"cwd": authority_root, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
     probe_job = None
     if os.name == "nt":
         probe_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP

--- a/scripts/check-helper-reachability.sh
+++ b/scripts/check-helper-reachability.sh
@@ -203,43 +203,61 @@ def packaged_path(raw, helper, role):
         raise SystemExit(f"check-helper-reachability: missing {role}: {helper}: {raw}")
     return path
 
-mode_helper = "validate-run-root.sh"
-mode_path = skill_root / "scripts" / mode_helper
-mode_text = mode_path.read_text(encoding="utf-8")
-implemented_modes = sorted(set(re.findall(r"--graph-[a-z0-9-]+", mode_text)))
-declared_modes = sorted(mode for helper, mode in mode_rows if helper == mode_helper)
+implemented_mode_sets = {}
+graph_helper = "validate-run-root.sh"
+graph_text = (skill_root / "scripts" / graph_helper).read_text(encoding="utf-8")
+implemented_mode_sets[graph_helper] = sorted(set(re.findall(r"--graph-[a-z0-9-]+", graph_text)))
+rehearsal_helper = "check-authorization-binding.sh"
+rehearsal_text = (skill_root / "scripts" / rehearsal_helper).read_text(encoding="utf-8")
+rehearsal_mode = "--phase --rehearsal --launch"
+if all(flag in shell_code(rehearsal_text) for flag in rehearsal_mode.split()):
+    implemented_mode_sets[rehearsal_helper] = [rehearsal_mode]
+else:
+    implemented_mode_sets[rehearsal_helper] = []
+
 for helper, mode in mode_rows:
-    if helper not in helpers or helper != mode_helper or mode not in implemented_modes:
+    if helper not in helpers or mode not in implemented_mode_sets.get(helper, []):
         raise SystemExit(
             f"check-helper-reachability: mode applicability not implemented: {helper} {mode}"
         )
-missing_modes = sorted(set(implemented_modes) - set(declared_modes))
-if missing_modes:
-    raise SystemExit(
-        "check-helper-reachability: missing mode applicability rows: "
-        + ", ".join(f"{mode_helper} {mode}" for mode in missing_modes)
-    )
-mode_dispatch = shell_code(mode_text)
+for helper, implemented_modes in implemented_mode_sets.items():
+    declared_modes = sorted(mode for row_helper, mode in mode_rows if row_helper == helper)
+    missing_modes = sorted(set(implemented_modes) - set(declared_modes))
+    if missing_modes:
+        raise SystemExit(
+            "check-helper-reachability: missing mode applicability rows: "
+            + ", ".join(f"{helper} {mode}" for mode in missing_modes)
+        )
+
 mode_owner = "\n".join(
     line for line in contract_text.splitlines()
     if not line.startswith(("helper-route: ", "helper-mode: "))
 )
-for mode in declared_modes:
-    row = mode_rows[(mode_helper, mode)]
-    if not re.search(
-        rf'(?m)(?:\$\{{1:-\}}[^\n]*{re.escape(mode)}|^\s*{re.escape(mode)}(?:\||\)))',
-        mode_dispatch,
-    ):
+for helper, mode in mode_rows:
+    row = mode_rows[(helper, mode)]
+    mode_dispatch = shell_code((skill_root / "scripts" / helper).read_text(encoding="utf-8"))
+    if not all(flag in mode_dispatch for flag in mode.split()):
         raise SystemExit(
-            f"check-helper-reachability: mode applicability not implemented: {mode_helper} {mode}"
+            f"check-helper-reachability: mode applicability not implemented: {helper} {mode}"
         )
-    if not arguments_are_anchored(f"{mode} {row['arguments']}", mode_helper, mode_owner):
+    mode_flags = mode.split()
+    mode_args = row["arguments"].split()
+    mode_command = f"{mode} {row['arguments']}"
+    if len(mode_flags) > 1:
+        if len(mode_flags) != len(mode_args):
+            raise SystemExit(
+                f"check-helper-reachability: mode argument arity mismatch: {helper} {mode}"
+            )
+        mode_command = " ".join(
+            f"{flag} {argument}" for flag, argument in zip(mode_flags, mode_args)
+        )
+    if not arguments_are_anchored(mode_command, helper, mode_owner):
         raise SystemExit(
-            f"check-helper-reachability: mode arguments absent: {mode_helper} {mode}"
+            f"check-helper-reachability: mode arguments absent: {helper} {mode}"
         )
     if not field_is_anchored(row["boundary"], mode_owner.lower()):
         raise SystemExit(
-            f"check-helper-reachability: mode boundary absent: {mode_helper} {mode}"
+            f"check-helper-reachability: mode boundary absent: {helper} {mode}"
         )
 
 for helper in helpers:
@@ -344,7 +362,7 @@ for helper in helpers:
 print(
     "HELPER_REACHABILITY=PASS "
     f"population={len(helpers)} examined={len(rows)} "
-    f"modes={len(declared_modes)}/{len(implemented_modes)} "
+    f"modes={len(mode_rows)}/{sum(len(modes) for modes in implemented_mode_sets.values())} "
     "enumeration=build-release-asset.required_archive"
 )
 PY

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -294,6 +294,7 @@ require_file tests/handoff-packet-contract.test.sh
 require_file tests/closure-surface-contract.test.sh
 require_file tests/authorization-binding-contract.test.sh
 require_file tests/scarce-resource-rehearsal-contract.test.sh
+require_file tests/r11-r30-review-heldouts.test.sh
 require_file fixtures/scarce-resource-rehearsal/cases.json
 require_file tests/convergence-mode-contract.test.sh
 require_file tests/andon-escalation-judgment.test.sh
@@ -668,6 +669,7 @@ bash tests/handoff-packet-contract.test.sh
 bash tests/closure-surface-contract.test.sh
 bash tests/authorization-binding-contract.test.sh
 bash tests/scarce-resource-rehearsal-contract.test.sh
+bash tests/r11-r30-review-heldouts.test.sh
 bash tests/convergence-mode-contract.test.sh
 bash tests/andon-escalation-judgment.test.sh
 bash tests/background-chain-contract.test.sh

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -244,8 +244,9 @@ empty declared-key placeholders, and bounded rehearsal controls. During
 rehearsal the wrapper uses the non-secret
 `IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB` control path for the producer
 substitution, emits no proof or terminal, and propagates the transport result;
-the checker requires the substitute's independently observed zero-exit event
-before it authors the bound terminal. A failed rehearsal authorizes no launch. Interposed stubs make
+the wrapper receives a checker-owned mediator bridge rather than the bounded
+producer or a writable proof capability. The mediator invokes the substitute
+and retains its zero exit before the checker authors the bound terminal. A failed rehearsal authorizes no launch. Interposed stubs make
 the result `PASS_WITH_SCOPE_GAP` and every extra component is named in
 `Residual risk:`. Post-pass escalation is governed by `Countermeasure Scope And
 Verification Proportionality` in `lean-operating-discipline.md`;

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -235,26 +235,16 @@ requirement where their contexts overlap. `validate-phase.sh` enforces the
 mechanical parts; cold review owns materiality judgments.
 
 **Rule P4-11 — Scarce-resource launch rehearsal (#84).**
-Before a scarce or irreversible resource is spent, rehearse the exact
-production wrapper, argv, sorted environment-key names, transport, and terminal
-artifact path with the producer stubbed and zero metered calls. Bind the result
-to a strict terminal receipt and canonical command hash; environment values are
-never captured or inherited: the checker supplies only process essentials,
-empty declared-key placeholders, and bounded rehearsal controls. During
-rehearsal the wrapper uses the non-secret
-`IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB` control path for the producer
-substitution, emits no proof or terminal, and propagates the transport result;
-the wrapper receives a checker-owned mediator bridge rather than the bounded
-producer or a writable proof capability. The mediator invokes the substitute
-and retains its zero exit before the checker authors the bound terminal. A failed rehearsal authorizes no launch. Interposed stubs make
-the result `PASS_WITH_SCOPE_GAP` and every extra component is named in
-`Residual risk:`. Post-pass escalation is governed by `Countermeasure Scope And
-Verification Proportionality` in `lean-operating-discipline.md`;
-`PASS_WITH_SCOPE_GAP` is an input to that judgment, not automatic promotion
-into a second apparatus; any such promotion remains a cold review judgment.
-After a failure, only manual repair and re-run may
-establish a new passing receipt; the governed action must not automatically
-retry.
+Before a scarce or irreversible resource is spent, rehearse the exact production
+wrapper, argv, environment-key names, transport, and terminal path with the
+producer stubbed and zero metered calls; a strict receipt/hash binds them.
+Environment values are never captured or inherited.
+`IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB` gives the wrapper only a checker-owned
+mediator bridge, never producer/proof/terminal; its zero substitute exit lets
+the checker publish the terminal. Interposed stubs yield `PASS_WITH_SCOPE_GAP`
+and `Residual risk:` names each. A second apparatus remains a cold review
+judgment. Failure blocks launch: manual repair and re-run only; no automatic
+retry may consume the resource.
 
 **Rule P4-12 — Paired controls on free-text acceptance.**
 Any acceptance criterion that matches free text ships with two named controls

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -239,9 +239,13 @@ Before a scarce or irreversible resource is spent, rehearse the exact
 production wrapper, argv, sorted environment-key names, transport, and terminal
 artifact path with the producer stubbed and zero metered calls. Bind the result
 to a strict terminal receipt and canonical command hash; environment values are
-never captured. During rehearsal the wrapper uses the non-secret
+never captured or inherited: the checker supplies only process essentials,
+empty declared-key placeholders, and bounded rehearsal controls. During
+rehearsal the wrapper uses the non-secret
 `IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB` control path for the producer
-substitution. A failed rehearsal authorizes no launch. Interposed stubs make
+substitution, emits no proof or terminal, and propagates the transport result;
+the checker requires the substitute's independently observed zero-exit event
+before it authors the bound terminal. A failed rehearsal authorizes no launch. Interposed stubs make
 the result `PASS_WITH_SCOPE_GAP` and every extra component is named in
 `Residual risk:`. Post-pass escalation is governed by `Countermeasure Scope And
 Verification Proportionality` in `lean-operating-discipline.md`;

--- a/skills/implementaudit/references/phase-design.md
+++ b/skills/implementaudit/references/phase-design.md
@@ -239,7 +239,9 @@ Before a scarce or irreversible resource is spent, rehearse the exact
 production wrapper, argv, sorted environment-key names, transport, and terminal
 artifact path with the producer stubbed and zero metered calls. Bind the result
 to a strict terminal receipt and canonical command hash; environment values are
-never captured. A failed rehearsal authorizes no launch. Interposed stubs make
+never captured. During rehearsal the wrapper uses the non-secret
+`IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB` control path for the producer
+substitution. A failed rehearsal authorizes no launch. Interposed stubs make
 the result `PASS_WITH_SCOPE_GAP` and every extra component is named in
 `Residual risk:`. Post-pass escalation is governed by `Countermeasure Scope And
 Verification Proportionality` in `lean-operating-discipline.md`;

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -245,9 +245,12 @@ Graphify modes: `bash <skill-dir>/scripts/validate-run-root.sh --graph-freshness
 <skill-dir>/scripts/validate-run-root.sh --graph-parent <catalog> <repo> <scope>
 <reason>` revalidates then broadens/falls back.
 
+When the native audit object opens a scarce-resource phase in the source repo, invoke the source repo only checker `bash <skill-dir>/scripts/check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper executes once through the bounded producer substitute; a failed rehearsal blocks launch and requires manual repair and re-run.
+
 helper-mode: validate-run-root.sh|--graph-freshness|<graph.json> <repo-root>|stale
 helper-mode: validate-run-root.sh|--graph-scope|<catalog> <repo> <path> [path...]|smallest
 helper-mode: validate-run-root.sh|--graph-parent|<catalog> <repo> <scope> <reason>|fallback
+helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch
 
 helper-route: check-authorization-binding.sh|R|auth|P|-|--auth <a> --invocation <i> --state <s>|no-param
 helper-route: check-closure-surface.sh|R|final|P|-|<closure-record> --superseded-plan <each-replaced-plan> --steer-dir <run-root> --plan-cycle-record <each-cycle-accounted-plan>|inputs

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -245,12 +245,12 @@ Graphify modes: `bash <skill-dir>/scripts/validate-run-root.sh --graph-freshness
 <skill-dir>/scripts/validate-run-root.sh --graph-parent <catalog> <repo> <scope>
 <reason>` revalidates then broadens/falls back.
 
-When the native audit object opens a scarce-resource phase in the source repo, invoke the source repo only checker `bash <skill-dir>/scripts/check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper executes once through the bounded producer substitute; a failed rehearsal blocks launch and requires manual repair and re-run.
+When the native audit object opens a scarce-resource phase in the source repo, `validate-phase.sh` consumes its declared rehearsal receipt, launch, producer stub, command hash, environment-key names, and terminal path, then invokes the source repo only checker `check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper executes once through the bounded producer substitute; its independently observed stub event must exit zero before the checker authors the bound terminal. A failed rehearsal blocks launch and requires manual repair and re-run.
 
 helper-mode: validate-run-root.sh|--graph-freshness|<graph.json> <repo-root>|stale
 helper-mode: validate-run-root.sh|--graph-scope|<catalog> <repo> <path> [path...]|smallest
 helper-mode: validate-run-root.sh|--graph-parent|<catalog> <repo> <scope> <reason>|fallback
-helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch
+helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh
 
 helper-route: check-authorization-binding.sh|R|auth|P|-|--auth <a> --invocation <i> --state <s>|no-param
 helper-route: check-closure-surface.sh|R|final|P|-|<closure-record> --superseded-plan <each-replaced-plan> --steer-dir <run-root> --plan-cycle-record <each-cycle-accounted-plan>|inputs

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -245,7 +245,7 @@ Graphify modes: `bash <skill-dir>/scripts/validate-run-root.sh --graph-freshness
 <skill-dir>/scripts/validate-run-root.sh --graph-parent <catalog> <repo> <scope>
 <reason>` revalidates then broadens/falls back.
 
-When the native audit object opens a scarce-resource phase in the source repo, `validate-phase.sh` consumes its declared rehearsal receipt, launch, producer stub, command hash, environment-key names, and terminal path, then invokes the source repo only checker `check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper traverses a checker-owned mediator bridge; that mediator invokes the bounded producer substitute and retains its zero exit before the checker authors the bound terminal. A failed rehearsal blocks launch and requires manual repair and re-run.
+When the native audit object opens a scarce-resource phase, `validate-phase.sh` consumes its receipt, launch, stub, hash, environment-key names, and terminal then invokes `check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>`. The wrapper crosses a checker-owned mediator to the bounded producer; its zero exit precedes checker terminal publication. A failed rehearsal blocks launch; repair/re-run stays manual.
 
 helper-mode: validate-run-root.sh|--graph-freshness|<graph.json> <repo-root>|stale
 helper-mode: validate-run-root.sh|--graph-scope|<catalog> <repo> <path> [path...]|smallest

--- a/skills/implementaudit/references/repo-state-comparison.md
+++ b/skills/implementaudit/references/repo-state-comparison.md
@@ -245,7 +245,7 @@ Graphify modes: `bash <skill-dir>/scripts/validate-run-root.sh --graph-freshness
 <skill-dir>/scripts/validate-run-root.sh --graph-parent <catalog> <repo> <scope>
 <reason>` revalidates then broadens/falls back.
 
-When the native audit object opens a scarce-resource phase in the source repo, `validate-phase.sh` consumes its declared rehearsal receipt, launch, producer stub, command hash, environment-key names, and terminal path, then invokes the source repo only checker `check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper executes once through the bounded producer substitute; its independently observed stub event must exit zero before the checker authors the bound terminal. A failed rehearsal blocks launch and requires manual repair and re-run.
+When the native audit object opens a scarce-resource phase in the source repo, `validate-phase.sh` consumes its declared rehearsal receipt, launch, producer stub, command hash, environment-key names, and terminal path, then invokes the source repo only checker `check-authorization-binding.sh --phase <phase> --rehearsal <receipt> --launch <launch>` at the rehearsal boundary. The declared production wrapper traverses a checker-owned mediator bridge; that mediator invokes the bounded producer substitute and retains its zero exit before the checker authors the bound terminal. A failed rehearsal blocks launch and requires manual repair and re-run.
 
 helper-mode: validate-run-root.sh|--graph-freshness|<graph.json> <repo-root>|stale
 helper-mode: validate-run-root.sh|--graph-scope|<catalog> <repo> <path> [path...]|smallest

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -1,23 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Parameter-bound authorization drift check (#12). Read-only. Compares a
-# runtime invocation's consequential parameters against the parameters an
-# authorization record binds.
-#
-#   check-authorization-binding.sh --auth <auth-file> --invocation <inv-file>
-#
-# Both files are `key: value` lists. The auth file declares:
-#   binds: <k1>,<k2>,...        (the consequential parameters governed)
-#   <k>: <value-or-range>       (bound value; a range like 1..1000 or a set
-#                                a|b|c is honored)
-# The invocation file supplies actual runtime `<k>: <value>` lines.
-#
-# AUTHORITY DRIFT (exit 1) when a consequential parameter present in the
-# invocation is NOT in `binds`, or its value conflicts with the bound
-# value/range. A matching invocation exits 0 with no added ceremony. If the
-# auth binds nothing (no `binds:` line), any consequential invocation
-# parameter is unbound => drift.
+# Parameter-bound authorization drift (#12): auth `binds:` values/ranges must
+# cover every consequential invocation parameter or the action default-denies.
 
 fail() { printf 'check-authorization-binding: %s\n' "$*" >&2; exit 1; }
 drift() {
@@ -25,10 +10,7 @@ drift() {
   exit 1
 }
 
-# Scarce-resource preflight rehearsal (#84). This mode is deliberately
-# separate from the legacy authorization-record comparison below. It executes
-# the declared production wrapper once, but only after replacing its producer
-# endpoint with the bounded substitute supplied by the caller.
+# Scarce-resource preflight rehearsal (#84).
 if [ "${1:-}" = "--phase" ]; then
   phase=""; rehearsal=""; launch=""
   while [ "$#" -gt 0 ]; do
@@ -41,220 +23,121 @@ if [ "${1:-}" = "--phase" ]; then
   done
   [ -f "$phase" ] || fail "phase file not found: $phase"
   python - "$phase" "$rehearsal" "$launch" <<'PY'
-import datetime
-import hashlib
-import json
-import os
-import pathlib
-import re
-import socket
-import stat
-import subprocess
-import sys
-import tempfile
-import threading
+import datetime as dt,hashlib,json,os
+from pathlib import Path as P
+import re,socket,stat,subprocess,sys,tempfile,threading
 
 def fail(message):
-    print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr)
-    raise SystemExit(1)
+    print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr); raise SystemExit(1)
+
+def require(value, label):
+    if not value: fail(label)
 
 phase_path, rehearsal_path, launch_path = sys.argv[1:]
-phase_text = pathlib.Path(phase_path).read_text(encoding="utf-8")
+phase_text = P(phase_path).read_text(encoding="utf-8")
 
 def phase_value(name):
     values = re.findall(rf"(?mi)^{re.escape(name)}:[ \\t]*(.*?)[ \\t]*$", phase_text)
-    if len(values) != 1:
-        fail(f"phase must contain exactly one {name} field")
-    value = values[0]
-    if not value or value.casefold() == "none":
-        fail(f"non-none budget requires {name}")
-    return value
+    require(len(values) == 1 and values[0] and values[0].casefold() != "none", f"invalid {name}")
+    return values[0]
 
 budget_lines = re.findall(r"(?mi)^Scarce resource budget:[ \t]*(.*?)[ \t]*$", phase_text)
-if len(budget_lines) != 1:
-    fail("phase must contain exactly one Scarce resource budget field")
+require(len(budget_lines) == 1, "invalid Scarce resource budget")
 budget = budget_lines[0]
 if budget == "none":
     if rehearsal_path or launch_path:
         fail("a none budget accepts no rehearsal or launch artifact")
     print("check-authorization-binding: ok — scarce resource budget is none")
     raise SystemExit(0)
-if not re.fullmatch(r"[1-9][0-9]* [^\s]+", budget):
-    fail("budget must be 'none' or 'N <resource>' with positive N")
-if not rehearsal_path or not launch_path:
-    fail("non-none budget requires --rehearsal and --launch")
+require(re.fullmatch(r"[1-9][0-9]* [^\s]+", budget), "invalid budget")
+require(rehearsal_path and launch_path, "missing rehearsal or launch")
 
-# The phase is the native audit object.  Bind the caller-supplied records to
-# its declared wrapper identity before a process can be started, so a
-# self-consistent replacement receipt/launch pair cannot silently move the
-# audit boundary.
-phase_rehearsal = phase_value("Rehearsal receipt")
-phase_launch = phase_value("Rehearsal launch")
-phase_stub = phase_value("Rehearsal producer stub")
-phase_command_hash = phase_value("Rehearsal command hash")
-phase_terminal = phase_value("Rehearsal terminal artifact")
-phase_env_keys = phase_value("Rehearsal environment keys")
-if pathlib.Path(rehearsal_path).resolve() != pathlib.Path(phase_rehearsal).resolve():
-    fail("rehearsal path does not match the phase audit object")
-if pathlib.Path(launch_path).resolve() != pathlib.Path(phase_launch).resolve():
-    fail("launch path does not match the phase audit object")
+R,L,S,H,T,E = (
+    phase_value(name) for name in ("Rehearsal receipt", "Rehearsal launch", "Rehearsal producer stub", "Rehearsal command hash", "Rehearsal terminal artifact", "Rehearsal environment keys"))
+require(P(rehearsal_path).resolve() == P(R).resolve(), "rehearsal path differs from phase")
+require(P(launch_path).resolve() == P(L).resolve(), "launch path differs from phase")
 
 def load_object(path, label):
     def reject_duplicate_members(pairs):
         value = {}
         for key, item in pairs:
-            if key in value:
-                raise ValueError(f"duplicate object member {key!r}")
+            require(key not in value, f"duplicate {key}")
             value[key] = item
         return value
-    try:
-        value = json.loads(
-            pathlib.Path(path).read_text(encoding="utf-8"),
-            object_pairs_hook=reject_duplicate_members,
-        )
-    except (OSError, UnicodeError, ValueError) as exc:
-        fail(f"invalid {label} JSON: {exc}")
-    if type(value) is not dict:
-        fail(f"{label} must be one JSON object")
+    try: value = json.loads(P(path).read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_members)
+    except (OSError, UnicodeError, ValueError) as exc: fail(f"invalid {label}: {exc}")
+    require(type(value) is dict, f"invalid {label}")
     return value
 
-receipt = load_object(rehearsal_path, "REHEARSAL_TERMINAL")
+r = load_object(rehearsal_path, "REHEARSAL_TERMINAL")
 launch = load_object(launch_path, "launch record")
-receipt_keys = {
-    "rehearsed_command_hash", "stub_identity", "stubbed_components",
-    "env_keys_present", "terminal_artifact_path", "exit_code",
-    "disposition", "timestamp",
-}
-launch_keys = {
-    "argv", "env_keys_present", "terminal_artifact_path",
-    "launch_records", "metered_calls",
-}
-if set(receipt) != receipt_keys:
-    fail(f"REHEARSAL_TERMINAL fields must be exactly {sorted(receipt_keys)}")
-if set(launch) != launch_keys:
-    fail(f"launch record fields must be exactly {sorted(launch_keys)}")
+require(set(r) == set("rehearsed_command_hash stub_identity stubbed_components env_keys_present terminal_artifact_path exit_code disposition timestamp".split()), "invalid REHEARSAL_TERMINAL fields")
+require(set(launch) == set("argv env_keys_present terminal_artifact_path launch_records metered_calls".split()), "invalid launch fields")
 
-def nonempty_string(value, label):
-    if type(value) is not str or not value:
-        fail(f"{label} must be a nonempty string")
+def text(value): return type(value) is str and bool(value)
+def strings(value): return type(value) is list and bool(value) and all(text(item) for item in value)
+def env(value): return strings(value) and value == sorted(value) and len(value) == len(set(value)) and all(re.fullmatch(r"[A-Z_][A-Z0-9_]*", item) for item in value)
 
-def string_array(value, label, *, nonempty=True):
-    if type(value) is not list or (nonempty and not value):
-        fail(f"{label} must be a nonempty string array")
-    if any(type(item) is not str or not item for item in value):
-        fail(f"{label} contains an invalid string")
-
-def env_keys(value, label):
-    string_array(value, label)
-    if value != sorted(value) or len(value) != len(set(value)):
-        fail(f"{label} must be sorted and unique")
-    if any(not re.fullmatch(r"[A-Z_][A-Z0-9_]*", item) for item in value):
-        fail(f"{label} may contain environment key names only")
-
-nonempty_string(receipt["rehearsed_command_hash"], "rehearsed_command_hash")
-if not re.fullmatch(r"[0-9a-f]{64}", receipt["rehearsed_command_hash"]):
-    fail("rehearsed_command_hash must be lowercase SHA-256")
-nonempty_string(receipt["stub_identity"], "stub_identity")
-string_array(receipt["stubbed_components"], "stubbed_components")
-if len(receipt["stubbed_components"]) != len(set(receipt["stubbed_components"])):
-    fail("stubbed_components must be unique")
-env_keys(receipt["env_keys_present"], "receipt env_keys_present")
-nonempty_string(receipt["terminal_artifact_path"], "receipt terminal_artifact_path")
-if type(receipt["exit_code"]) is not int:
-    fail("exit_code must be an integer")
-if receipt["disposition"] not in {"PASS", "PASS_WITH_SCOPE_GAP", "FAIL"}:
-    fail("invalid disposition")
-nonempty_string(receipt["timestamp"], "timestamp")
-if not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", receipt["timestamp"]):
-    fail("timestamp must be UTC ISO-8601 ending Z")
+require(text(r["rehearsed_command_hash"]) and re.fullmatch(r"[0-9a-f]{64}", r["rehearsed_command_hash"]), "invalid rehearsed_command_hash")
+require(text(r["stub_identity"]), "invalid stub_identity")
+require(strings(r["stubbed_components"]) and len(r["stubbed_components"]) == len(set(r["stubbed_components"])), "invalid stubbed_components")
+require(env(r["env_keys_present"]), "invalid receipt env_keys_present")
+require(text(r["terminal_artifact_path"]), "invalid receipt terminal_artifact_path")
+require(type(r["exit_code"]) is int, "invalid exit_code")
+require(r["disposition"] in {"PASS", "PASS_WITH_SCOPE_GAP", "FAIL"}, "invalid disposition")
+require(text(r["timestamp"]) and re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", r["timestamp"]), "invalid timestamp")
 try:
-    datetime.datetime.fromisoformat(receipt["timestamp"].replace("Z", "+00:00"))
+    dt.datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00"))
 except ValueError:
-    fail("timestamp is not a real UTC instant")
+    fail("invalid timestamp")
 
-string_array(launch["argv"], "argv")
-nonempty_string(launch["argv"][0], "production wrapper argv[0]")
-env_keys(launch["env_keys_present"], "launch env_keys_present")
-nonempty_string(launch["terminal_artifact_path"], "launch terminal_artifact_path")
+require(strings(launch["argv"]), "invalid argv")
+require(env(launch["env_keys_present"]), "invalid launch env_keys_present")
+require(text(launch["terminal_artifact_path"]), "invalid launch terminal_artifact_path")
 for key in ("launch_records", "metered_calls"):
-    if type(launch[key]) is not int or launch[key] < 0:
-        fail(f"{key} must be a nonnegative integer")
-if launch["metered_calls"] != 0:
-    fail("a rehearsal must consume zero metered calls")
+    require(type(launch[key]) is int and launch[key] >= 0, f"invalid {key}")
+require(launch["metered_calls"] == 0, "rehearsal must consume zero metered calls")
 
-if receipt["env_keys_present"] != launch["env_keys_present"]:
-    fail("receipt and launch environment-key sets differ")
-if receipt["terminal_artifact_path"] != launch["terminal_artifact_path"]:
-    fail("receipt and launch terminal artifact paths differ")
-preimage = json.dumps(
-    {"argv": launch["argv"], "env_keys_present": sorted(launch["env_keys_present"])},
-    ensure_ascii=False,
-    separators=(",", ":"),
-).encode("utf-8")
-actual_hash = hashlib.sha256(preimage).hexdigest()
-if receipt["rehearsed_command_hash"] != actual_hash:
-    fail("rehearsed command hash does not match exact argv/environment-key identity")
-if phase_command_hash != actual_hash:
-    fail("rehearsed command hash does not match the phase audit object")
-if pathlib.Path(phase_terminal).resolve() != pathlib.Path(launch["terminal_artifact_path"]).resolve():
-    fail("terminal artifact path does not match the phase audit object")
-if phase_env_keys != ",".join(launch["env_keys_present"]):
-    fail("environment-key identity does not match the phase audit object")
-if receipt["exit_code"] != 0 or receipt["disposition"] == "FAIL":
-    fail("nonzero or FAIL rehearsal never authorizes launch")
+if r["env_keys_present"] != launch["env_keys_present"] or r["terminal_artifact_path"] != launch["terminal_artifact_path"]: fail("receipt/launch identity mismatch")
+h = hashlib.sha256(json.dumps({"argv": launch["argv"], "env_keys_present": sorted(launch["env_keys_present"])}, ensure_ascii=False, separators=(",", ":")).encode("utf-8")).hexdigest()
+if r["rehearsed_command_hash"] != h or H != h: fail("command hash mismatch")
+if P(T).resolve() != P(launch["terminal_artifact_path"]).resolve() or E != ",".join(launch["env_keys_present"]): fail("phase identity mismatch")
+if r["exit_code"] != 0 or r["disposition"] == "FAIL": fail("nonzero or failed rehearsal")
 
-components = receipt["stubbed_components"]
-if "producer" not in components:
-    fail("producer must be stubbed")
+components = r["stubbed_components"]
+if "producer" not in components: fail("producer not stubbed")
 extras = [item for item in components if item != "producer"]
 if not extras:
-    if receipt["disposition"] != "PASS" or components != ["producer"]:
-        fail("PASS requires exactly the producer stub")
+    if r["disposition"] != "PASS" or components != ["producer"]: fail("invalid PASS components")
 else:
-    if receipt["disposition"] != "PASS_WITH_SCOPE_GAP":
-        fail("interposed stubs require PASS_WITH_SCOPE_GAP")
+    if r["disposition"] != "PASS_WITH_SCOPE_GAP": fail("scope-gap disposition required")
     residuals = re.findall(r"(?mi)^Residual risk:[ \t]*(.*?)[ \t]*$", phase_text)
     missing = [item for item in extras if not any(item in line for line in residuals)]
-    if missing:
-        fail(f"Residual risk must name every interposed stub: {missing}")
+    if missing: fail(f"residual risk omits {missing}")
 
-# A receipt/launch pair is only a declaration until the declared wrapper has
-# traversed its real transport with a substitute producer. The substitute is
-# supplied out of band so neither a secret nor a producer endpoint is captured
-# in the receipt. The wrapper receives only bounded control paths and the
-# already-derived non-secret identity fields below.
 stub_raw = os.environ.get("IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB")
-if not stub_raw:
-    fail("missing bounded producer stub environment")
-stub_path = pathlib.Path(stub_raw)
-if stub_path.resolve() != pathlib.Path(phase_stub).resolve():
-    fail("bounded producer stub does not match the phase audit object")
-if not stub_path.is_file() or not os.access(stub_path, os.X_OK):
-    fail("bounded producer stub must be an executable regular file")
-stub_identity = "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest()
-if receipt["stub_identity"] != stub_identity:
-    fail("receipt stub identity does not match bounded producer stub")
+if not stub_raw: fail("missing producer stub")
+s = P(stub_raw)
+if s.resolve() != P(S).resolve(): fail("producer stub differs from phase")
+if not s.is_file() or not os.access(s, os.X_OK): fail("invalid producer stub")
+if r["stub_identity"] != "sha256:" + hashlib.sha256(s.read_bytes()).hexdigest(): fail("producer identity mismatch")
 
-terminal_path = pathlib.Path(launch["terminal_artifact_path"])
-if not terminal_path.parent.is_dir():
-    fail("terminal artifact parent directory does not exist")
+t = P(launch["terminal_artifact_path"])
+if not t.parent.is_dir(): fail("missing terminal parent")
 
 def require_absent_terminal(stage):
     try:
-        existing = terminal_path.lstat()
+        existing = t.lstat()
     except FileNotFoundError:
         return
     kind = "symlink" if stat.S_ISLNK(existing.st_mode) else "existing owner"
-    fail(f"terminal artifact must be absent {stage}; found {kind}")
+    fail(f"terminal exists {stage}: {kind}")
 
 require_absent_terminal("before wrapper execution")
 
-bridge_fd, bridge_raw = tempfile.mkstemp(
-    prefix=".implementaudit-rehearsal-mediator-bridge-",
-    dir=terminal_path.parent,
-)
+bridge_fd, bridge_raw = tempfile.mkstemp(prefix=".implementaudit-rehearsal-mediator-bridge-", dir=t.parent)
 os.close(bridge_fd)
-bridge_path = pathlib.Path(bridge_raw)
+bridge_path = P(bridge_raw)
 
 mediator = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 mediator.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -262,17 +145,13 @@ mediator.bind(("127.0.0.1", 0))
 mediator.listen(1)
 mediator.settimeout(2)
 mediator_endpoint = f"127.0.0.1:{mediator.getsockname()[1]}"
-bridge_path.write_text(f"""#!/usr/bin/env python3
-import json
-import socket
-import sys
-
-host, port = {mediator_endpoint!r}.rsplit(\":\", 1)
-with socket.create_connection((host, int(port)), timeout=2) as connection:
-    connection.sendall(b\"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\\n\")
-    reply = json.loads(connection.recv(1024).decode(\"utf-8\"))
-raise SystemExit(reply[\"exit_code\"])
-""", encoding="utf-8")
+bridge_path.write_text(f'''#!/usr/bin/env python3
+import json,socket
+h,p={mediator_endpoint!r}.rsplit(":",1)
+with socket.create_connection((h,int(p)),timeout=2) as c:
+ c.sendall(b"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\\n");r=json.loads(c.recv(1024))
+raise SystemExit(r["exit_code"])
+''', encoding="utf-8")
 bridge_path.chmod(0o700)
 mediated = {}
 
@@ -281,30 +160,18 @@ def run_bounded_stub():
         connection, _ = mediator.accept()
         with connection:
             if connection.recv(64) != b"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\n":
-                raise ValueError("invalid producer-mediator request")
-            command = ([sys.executable, str(stub_path)]
-                       if stub_path.suffix.casefold() == ".py" else [str(stub_path)])
+                raise ValueError("invalid mediator request")
+            command = ([sys.executable, str(s)] if s.suffix.casefold() == ".py" else [str(s)])
             result = subprocess.run(command, env=stub_env, check=False)
             mediated["exit_code"] = result.returncode
             connection.sendall(json.dumps({"exit_code": result.returncode}).encode("utf-8"))
     except Exception as exc:
         mediated["error"] = str(exc)
 
-# The producer path seen by the candidate wrapper is this bridge, never the
-# bounded producer nor a writable proof capability.  Only a bridge request can
-# cause this checker-owned mediator to run the actual substitute and retain its
-# exit status.
 mediator_thread = threading.Thread(target=run_bounded_stub, daemon=True)
 mediator_thread.start()
 
-# The wrapper receives only process essentials, declared key *names* with
-# empty values, and the bounded rehearsal controls.  In particular it never
-# inherits caller credentials or an artifact path with which it could author
-# a terminal record.
-safe_parent_keys = {
-    "COMSPEC", "PATH", "PATHEXT", "SYSTEMROOT", "SystemDrive", "SystemRoot",
-    "TEMP", "TMP", "WINDIR",
-}
+safe_parent_keys = {"COMSPEC", "PATH", "PATHEXT", "SYSTEMROOT", "SystemDrive", "SystemRoot", "TEMP", "TMP", "WINDIR"}
 run_env = {key: os.environ[key] for key in safe_parent_keys if key in os.environ}
 for key in launch["env_keys_present"]:
     run_env[key] = ""
@@ -317,42 +184,26 @@ try:
 except OSError as exc:
     mediator.close()
     bridge_path.unlink(missing_ok=True)
-    fail(f"production wrapper could not execute: {exc}")
+    fail(f"wrapper could not execute: {exc}")
 
 mediator_thread.join(3)
 mediator.close()
 bridge_path.unlink(missing_ok=True)
-if mediator_thread.is_alive():
-    fail("production wrapper did not traverse the checker-owned producer mediator")
-if "error" in mediated:
-    fail(f"bounded producer mediator failed: {mediated['error']}")
-if "exit_code" not in mediated:
-    fail("production wrapper did not traverse the checker-owned producer mediator")
-if mediated["exit_code"] != 0:
-    fail(f"bounded producer stub exited {mediated['exit_code']}")
-if completed.returncode != 0:
-    fail(f"production wrapper exited {completed.returncode}")
+if mediator_thread.is_alive() or "exit_code" not in mediated: fail("wrapper did not traverse mediator")
+if "error" in mediated: fail(f"mediator failed: {mediated['error']}")
+if mediated["exit_code"] != 0: fail(f"producer exited {mediated['exit_code']}")
+if completed.returncode != 0: fail(f"wrapper exited {completed.returncode}")
 
-# The checker, not the wrapper, is the only terminal author.  Re-check with
-# lstat after the untrusted wrapper completes, then use exclusive creation so
-# an alias/hardlink/nonterminal owner cannot be followed or overwritten.
 require_absent_terminal("when publishing the rehearsal terminal")
 try:
-    terminal_fd = os.open(
-        terminal_path,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-        0o600,
-    )
-except FileExistsError:
-    fail("terminal artifact appeared before exclusive publication")
+    terminal_fd = os.open(t, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+except FileExistsError: fail("terminal appeared before publication")
 with os.fdopen(terminal_fd, "w", encoding="utf-8") as terminal_file:
-    terminal_file.write(json.dumps(receipt, indent=2) + "\n")
-published = terminal_path.lstat()
-if not stat.S_ISREG(published.st_mode) or published.st_nlink != 1:
-    fail("checker-owned terminal publication lost exclusive regular-file identity")
-observed = load_object(str(terminal_path), "execution terminal")
-if observed != receipt:
-    fail("execution terminal does not match the supplied rehearsal receipt")
+    terminal_file.write(json.dumps(r, indent=2) + "\n")
+published = t.lstat()
+if not stat.S_ISREG(published.st_mode) or published.st_nlink != 1: fail("terminal lost exclusive identity")
+observed = load_object(str(t), "execution terminal")
+if observed != r: fail("terminal receipt mismatch")
 
 print("check-authorization-binding: ok — wrapper transport, mediated stub, and terminal receipt are bound")
 PY
@@ -388,14 +239,8 @@ fi
 [ -f "$auth" ] || fail "auth file not found: $auth"
 [ -f "$inv" ] || fail "invocation file not found: $inv"
 
-# An absent key (e.g. no `binds:` line) is a real case that must be
-# EVALUATED (unbound => drift), not an early script death under
-# `set -euo pipefail`. Swallow grep's no-match to empty output.
 val() { { grep -iE "^$2:" "$1" || true; } | head -n1 | sed "s/^[^:]*: *//" | tr -d '\r' | sed 's/[[:space:]]*$//'; }
 
-# Duplicate keys in the AUTHORIZATION record are ambiguous authority —
-# a permissive spec listed first would silently shadow a stricter one
-# (Fable review of PR #32). One value per key, malformed otherwise.
 dup_check() {
   n="$({ grep -ciE "^$1:" "$auth" || true; })"
   [ "${n:-0}" -le 1 ] || fail "malformed authorization: key '$1' appears $n times — one value per key"
@@ -463,13 +308,7 @@ in_range() {  # value, spec
   esac
 }
 
-# Every consequential parameter the INVOCATION supplies must be bound and
-# in-range. Consequential params are those the invocation marks with a
-# leading `param.` prefix (so ordinary metadata lines are ignored).
 drifted=""
-# `|| [ -n "$line" ]` keeps a final line WITHOUT a trailing newline in
-# scope — a drifting parameter on an unterminated last line was silently
-# dropped by plain `while read` (Fable review of PR #32).
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in param.*) : ;; *) continue;; esac
   key="$(printf '%s' "$line" | sed -n 's/^\(param\.[a-zA-Z0-9_-]*\):.*/\1/p')"
@@ -485,10 +324,6 @@ while IFS= read -r line || [ -n "$line" ]; do
   fi
 done < "$inv"
 
-# Every parameter the authorization BINDS must actually be supplied by
-# the invocation: a bound-but-unsupplied parameter means the governed
-# action would run on a source/tool default the owner never saw —
-# defaults are never implicitly adopted (Fable review of PR #32).
 for k in $(printf '%s' "$binds" | tr ',' ' '); do
   grep -qiE "^param\.$k:" "$inv" \
     || drifted="$drifted $k(bound-but-unsupplied — runtime value unknown; defaults are never implicitly adopted)"

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -25,7 +25,7 @@ if [ "${1:-}" = "--phase" ]; then
   python - "$phase" "$rehearsal" "$launch" <<'PY'
 import datetime as dt,hashlib,json,os
 from pathlib import Path as P
-import re,socket,stat,subprocess,sys,tempfile,threading
+import re,signal,socket,stat,subprocess,sys,tempfile,threading
 
 def fail(message):
     print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr); raise SystemExit(1)
@@ -135,6 +135,37 @@ def require_absent_terminal(stage):
 
 require_absent_terminal("before wrapper execution")
 
+# Both untrusted transport legs share one cleanup budget.  Their process trees
+# are isolated so a timeout cannot strand a wrapper or substitutable producer.
+PROCESS_TIMEOUT_SECONDS = 5
+
+def bounded_diagnostic(raw):
+    text = raw.decode("utf-8", errors="replace")[-4096:]
+    return re.sub(r"(?im)^([A-Z_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z_]*=).*?$", r"\1<redacted>", text)
+
+def terminate_process_tree(process):
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    else:
+        try: os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError: pass
+
+class BoundedProcessTimeout(Exception): pass
+
+def run_bounded_process(command, env, label, timeout=PROCESS_TIMEOUT_SECONDS):
+    options = {"env": env, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+    if os.name == "nt": options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else: options["start_new_session"] = True
+    process = subprocess.Popen(command, **options)
+    try:
+        _, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        terminate_process_tree(process)
+        _, stderr = process.communicate()
+        detail = bounded_diagnostic(stderr)
+        raise BoundedProcessTimeout(f"{label} timed out after {timeout}s" + (f": {detail}" if detail else ""))
+    return process.returncode, stderr
+
 bridge_fd, bridge_raw = tempfile.mkstemp(prefix=".implementaudit-rehearsal-mediator-bridge-", dir=t.parent)
 os.close(bridge_fd)
 bridge_path = P(bridge_raw)
@@ -143,12 +174,13 @@ mediator = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 mediator.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 mediator.bind(("127.0.0.1", 0))
 mediator.listen(1)
-mediator.settimeout(2)
+mediator.settimeout(PROCESS_TIMEOUT_SECONDS + 1)
 mediator_endpoint = f"127.0.0.1:{mediator.getsockname()[1]}"
 bridge_path.write_text(f'''#!/usr/bin/env python3
 import json,socket
 h,p={mediator_endpoint!r}.rsplit(":",1)
-with socket.create_connection((h,int(p)),timeout=2) as c:
+with socket.create_connection((h,int(p)),timeout={PROCESS_TIMEOUT_SECONDS + 1}) as c:
+ c.settimeout({PROCESS_TIMEOUT_SECONDS + 1})
  c.sendall(b"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\\n");r=json.loads(c.recv(1024))
 raise SystemExit(r["exit_code"])
 ''', encoding="utf-8")
@@ -159,12 +191,13 @@ def run_bounded_stub():
     try:
         connection, _ = mediator.accept()
         with connection:
+            connection.settimeout(PROCESS_TIMEOUT_SECONDS + 1)
             if connection.recv(64) != b"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\n":
                 raise ValueError("invalid mediator request")
             command = ([sys.executable, str(s)] if s.suffix.casefold() == ".py" else [str(s)])
-            result = subprocess.run(command, env=stub_env, check=False)
-            mediated["exit_code"] = result.returncode
-            connection.sendall(json.dumps({"exit_code": result.returncode}).encode("utf-8"))
+            result, _ = run_bounded_process(command, stub_env, "producer")
+            mediated["exit_code"] = result
+            connection.sendall(json.dumps({"exit_code": result}).encode("utf-8"))
     except Exception as exc:
         mediated["error"] = str(exc)
 
@@ -180,19 +213,22 @@ run_env.update({
     "IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB": str(bridge_path),
 })
 try:
-    completed = subprocess.run(launch["argv"], env=run_env, check=False)
-except OSError as exc:
+    try:
+        completed, wrapper_stderr = run_bounded_process(launch["argv"], run_env, "wrapper", PROCESS_TIMEOUT_SECONDS + 2)
+    except BoundedProcessTimeout as exc:
+        fail(str(exc))
+    except OSError as exc:
+        fail(f"wrapper could not execute: {exc}")
+finally:
+    mediator_thread.join(PROCESS_TIMEOUT_SECONDS + 1)
     mediator.close()
     bridge_path.unlink(missing_ok=True)
-    fail(f"wrapper could not execute: {exc}")
-
-mediator_thread.join(3)
-mediator.close()
-bridge_path.unlink(missing_ok=True)
-if mediator_thread.is_alive() or "exit_code" not in mediated: fail("wrapper did not traverse mediator")
 if "error" in mediated: fail(f"mediator failed: {mediated['error']}")
+if mediator_thread.is_alive() or "exit_code" not in mediated: fail("wrapper did not traverse mediator")
 if mediated["exit_code"] != 0: fail(f"producer exited {mediated['exit_code']}")
-if completed.returncode != 0: fail(f"wrapper exited {completed.returncode}")
+if completed != 0:
+    detail = bounded_diagnostic(wrapper_stderr)
+    fail(f"wrapper exited {completed}" + (f": {detail}" if detail else ""))
 
 require_absent_terminal("when publishing the rehearsal terminal")
 try:

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -26,9 +26,9 @@ drift() {
 }
 
 # Scarce-resource preflight rehearsal (#84). This mode is deliberately
-# separate from the legacy authorization-record comparison below: it validates
-# inert artifacts and never launches the recorded argv or reads environment
-# values.
+# separate from the legacy authorization-record comparison below. It executes
+# the declared production wrapper once, but only after replacing its producer
+# endpoint with the bounded substitute supplied by the caller.
 if [ "${1:-}" = "--phase" ]; then
   phase=""; rehearsal=""; launch=""
   while [ "$#" -gt 0 ]; do
@@ -44,9 +44,12 @@ if [ "${1:-}" = "--phase" ]; then
 import datetime
 import hashlib
 import json
+import os
 import pathlib
 import re
+import subprocess
 import sys
+import tempfile
 
 def fail(message):
     print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr)
@@ -180,6 +183,64 @@ else:
     missing = [item for item in extras if not any(item in line for line in residuals)]
     if missing:
         fail(f"Residual risk must name every interposed stub: {missing}")
+
+# A receipt/launch pair is only a declaration until the declared wrapper has
+# traversed its real transport with a substitute producer. The substitute is
+# supplied out of band so neither a secret nor a producer endpoint is captured
+# in the receipt. The wrapper receives only bounded control paths and the
+# already-derived non-secret identity fields below.
+stub_raw = os.environ.get("IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB")
+if not stub_raw:
+    fail("missing bounded producer stub environment")
+stub_path = pathlib.Path(stub_raw)
+if not stub_path.is_file() or not os.access(stub_path, os.X_OK):
+    fail("bounded producer stub must be an executable regular file")
+stub_identity = "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest()
+if receipt["stub_identity"] != stub_identity:
+    fail("receipt stub identity does not match bounded producer stub")
+
+for key in launch["env_keys_present"]:
+    if key not in os.environ:
+        fail(f"declared environment key is absent for rehearsal: {key}")
+
+terminal_path = pathlib.Path(launch["terminal_artifact_path"])
+if not terminal_path.parent.is_dir():
+    fail("terminal artifact parent directory does not exist")
+if terminal_path.exists() or terminal_path.is_symlink():
+    fail("terminal artifact must be absent before wrapper execution")
+
+proof_fd, proof_raw = tempfile.mkstemp(
+    prefix=".implementaudit-rehearsal-stub-",
+    dir=terminal_path.parent,
+)
+os.close(proof_fd)
+proof_path = pathlib.Path(proof_raw)
+proof_path.unlink()
+
+run_env = os.environ.copy()
+run_env.update({
+    "IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB": str(stub_path.resolve()),
+    "IMPLEMENTAUDIT_REHEARSAL_TERMINAL": launch["terminal_artifact_path"],
+    "IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF": str(proof_path),
+    "IMPLEMENTAUDIT_REHEARSAL_COMMAND_HASH": actual_hash,
+    "IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY": stub_identity,
+    "IMPLEMENTAUDIT_REHEARSAL_ENV_KEYS": json.dumps(
+        launch["env_keys_present"], separators=(",", ":")
+    ),
+})
+try:
+    completed = subprocess.run(launch["argv"], env=run_env, check=False)
+except OSError as exc:
+    fail(f"production wrapper could not execute: {exc}")
+if completed.returncode != 0:
+    fail(f"production wrapper exited {completed.returncode}")
+if not proof_path.is_file() or proof_path.read_text(encoding="utf-8") != stub_identity + "\n":
+    fail("bounded producer stub did not produce its identity proof")
+if not terminal_path.is_file() or terminal_path.is_symlink():
+    fail("production wrapper did not produce the declared terminal artifact")
+observed = load_object(str(terminal_path), "execution terminal")
+if observed != receipt:
+    fail("execution terminal does not match the supplied rehearsal receipt")
 
 print("check-authorization-binding: ok — rehearsal identity and terminal receipt are bound")
 PY

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -46,11 +46,12 @@ import hashlib
 import json
 import os
 import pathlib
-import secrets
 import re
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 
 def fail(message):
     print(f"check-authorization-binding: rehearsal rejected ({message})", file=sys.stderr)
@@ -239,14 +240,53 @@ if not terminal_path.parent.is_dir():
 if terminal_path.exists() or terminal_path.is_symlink():
     fail("terminal artifact must be absent before wrapper execution")
 
-event_fd, event_raw = tempfile.mkstemp(
-    prefix=".implementaudit-rehearsal-stub-event-",
+bridge_fd, bridge_raw = tempfile.mkstemp(
+    prefix=".implementaudit-rehearsal-mediator-bridge-",
     dir=terminal_path.parent,
 )
-os.close(event_fd)
-event_path = pathlib.Path(event_raw)
-event_path.unlink()
-event_nonce = secrets.token_hex(32)
+os.close(bridge_fd)
+bridge_path = pathlib.Path(bridge_raw)
+
+mediator = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+mediator.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+mediator.bind(("127.0.0.1", 0))
+mediator.listen(1)
+mediator.settimeout(2)
+mediator_endpoint = f"127.0.0.1:{mediator.getsockname()[1]}"
+bridge_path.write_text(f"""#!/usr/bin/env python3
+import json
+import socket
+import sys
+
+host, port = {mediator_endpoint!r}.rsplit(\":\", 1)
+with socket.create_connection((host, int(port)), timeout=2) as connection:
+    connection.sendall(b\"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\\n\")
+    reply = json.loads(connection.recv(1024).decode(\"utf-8\"))
+raise SystemExit(reply[\"exit_code\"])
+""", encoding="utf-8")
+bridge_path.chmod(0o700)
+mediated = {}
+
+def run_bounded_stub():
+    try:
+        connection, _ = mediator.accept()
+        with connection:
+            if connection.recv(64) != b"IMPLEMENTAUDIT_REHEARSAL_MEDIATOR\n":
+                raise ValueError("invalid producer-mediator request")
+            command = ([sys.executable, str(stub_path)]
+                       if stub_path.suffix.casefold() == ".py" else [str(stub_path)])
+            result = subprocess.run(command, env=stub_env, check=False)
+            mediated["exit_code"] = result.returncode
+            connection.sendall(json.dumps({"exit_code": result.returncode}).encode("utf-8"))
+    except Exception as exc:
+        mediated["error"] = str(exc)
+
+# The producer path seen by the candidate wrapper is this bridge, never the
+# bounded producer nor a writable proof capability.  Only a bridge request can
+# cause this checker-owned mediator to run the actual substitute and retain its
+# exit status.
+mediator_thread = threading.Thread(target=run_bounded_stub, daemon=True)
+mediator_thread.start()
 
 # The wrapper receives only process essentials, declared key *names* with
 # empty values, and the bounded rehearsal controls.  In particular it never
@@ -259,36 +299,40 @@ safe_parent_keys = {
 run_env = {key: os.environ[key] for key in safe_parent_keys if key in os.environ}
 for key in launch["env_keys_present"]:
     run_env[key] = ""
+stub_env = dict(run_env)
 run_env.update({
-    "IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB": str(stub_path.resolve()),
-    "IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT": str(event_path),
-    "IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE": event_nonce,
+    "IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB": str(bridge_path),
 })
 try:
     completed = subprocess.run(launch["argv"], env=run_env, check=False)
 except OSError as exc:
+    mediator.close()
+    bridge_path.unlink(missing_ok=True)
     fail(f"production wrapper could not execute: {exc}")
+
+mediator_thread.join(3)
+mediator.close()
+bridge_path.unlink(missing_ok=True)
+if mediator_thread.is_alive():
+    fail("production wrapper did not traverse the checker-owned producer mediator")
+if "error" in mediated:
+    fail(f"bounded producer mediator failed: {mediated['error']}")
+if "exit_code" not in mediated:
+    fail("production wrapper did not traverse the checker-owned producer mediator")
+if mediated["exit_code"] != 0:
+    fail(f"bounded producer stub exited {mediated['exit_code']}")
 if completed.returncode != 0:
     fail(f"production wrapper exited {completed.returncode}")
-if not event_path.is_file() or event_path.is_symlink():
-    fail("bounded producer stub did not produce an execution event")
-event = load_object(str(event_path), "bounded producer execution event")
-if set(event) != {"stub_identity", "nonce", "exit_code"}:
-    fail("bounded producer execution event fields are invalid")
-if event["stub_identity"] != stub_identity or event["nonce"] != event_nonce:
-    fail("bounded producer execution event identity does not match")
-if type(event["exit_code"]) is not int or event["exit_code"] != 0:
-    fail("bounded producer stub exited nonzero")
 
 # The checker, not the wrapper, is the only terminal author.  The terminal is
-# written only after the independently observed zero-meter stub event binds to
-# the declared wrapper/launch identity above.
+# written only after the checker-owned mediator has observed the zero-meter
+# producer exit during the wrapper traversal above.
 terminal_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
 observed = load_object(str(terminal_path), "execution terminal")
 if observed != receipt:
     fail("execution terminal does not match the supplied rehearsal receipt")
 
-print("check-authorization-binding: ok — wrapper transport, stub event, and terminal receipt are bound")
+print("check-authorization-binding: ok — wrapper transport, mediated stub, and terminal receipt are bound")
 PY
   exit $?
 fi

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -46,6 +46,7 @@ import hashlib
 import json
 import os
 import pathlib
+import secrets
 import re
 import subprocess
 import sys
@@ -57,6 +58,16 @@ def fail(message):
 
 phase_path, rehearsal_path, launch_path = sys.argv[1:]
 phase_text = pathlib.Path(phase_path).read_text(encoding="utf-8")
+
+def phase_value(name):
+    values = re.findall(rf"(?mi)^{re.escape(name)}:[ \\t]*(.*?)[ \\t]*$", phase_text)
+    if len(values) != 1:
+        fail(f"phase must contain exactly one {name} field")
+    value = values[0]
+    if not value or value.casefold() == "none":
+        fail(f"non-none budget requires {name}")
+    return value
+
 budget_lines = re.findall(r"(?mi)^Scarce resource budget:[ \t]*(.*?)[ \t]*$", phase_text)
 if len(budget_lines) != 1:
     fail("phase must contain exactly one Scarce resource budget field")
@@ -70,6 +81,21 @@ if not re.fullmatch(r"[1-9][0-9]* [^\s]+", budget):
     fail("budget must be 'none' or 'N <resource>' with positive N")
 if not rehearsal_path or not launch_path:
     fail("non-none budget requires --rehearsal and --launch")
+
+# The phase is the native audit object.  Bind the caller-supplied records to
+# its declared wrapper identity before a process can be started, so a
+# self-consistent replacement receipt/launch pair cannot silently move the
+# audit boundary.
+phase_rehearsal = phase_value("Rehearsal receipt")
+phase_launch = phase_value("Rehearsal launch")
+phase_stub = phase_value("Rehearsal producer stub")
+phase_command_hash = phase_value("Rehearsal command hash")
+phase_terminal = phase_value("Rehearsal terminal artifact")
+phase_env_keys = phase_value("Rehearsal environment keys")
+if pathlib.Path(rehearsal_path).resolve() != pathlib.Path(phase_rehearsal).resolve():
+    fail("rehearsal path does not match the phase audit object")
+if pathlib.Path(launch_path).resolve() != pathlib.Path(phase_launch).resolve():
+    fail("launch path does not match the phase audit object")
 
 def load_object(path, label):
     def reject_duplicate_members(pairs):
@@ -166,6 +192,12 @@ preimage = json.dumps(
 actual_hash = hashlib.sha256(preimage).hexdigest()
 if receipt["rehearsed_command_hash"] != actual_hash:
     fail("rehearsed command hash does not match exact argv/environment-key identity")
+if phase_command_hash != actual_hash:
+    fail("rehearsed command hash does not match the phase audit object")
+if pathlib.Path(phase_terminal).resolve() != pathlib.Path(launch["terminal_artifact_path"]).resolve():
+    fail("terminal artifact path does not match the phase audit object")
+if phase_env_keys != ",".join(launch["env_keys_present"]):
+    fail("environment-key identity does not match the phase audit object")
 if receipt["exit_code"] != 0 or receipt["disposition"] == "FAIL":
     fail("nonzero or FAIL rehearsal never authorizes launch")
 
@@ -193,15 +225,13 @@ stub_raw = os.environ.get("IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB")
 if not stub_raw:
     fail("missing bounded producer stub environment")
 stub_path = pathlib.Path(stub_raw)
+if stub_path.resolve() != pathlib.Path(phase_stub).resolve():
+    fail("bounded producer stub does not match the phase audit object")
 if not stub_path.is_file() or not os.access(stub_path, os.X_OK):
     fail("bounded producer stub must be an executable regular file")
 stub_identity = "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest()
 if receipt["stub_identity"] != stub_identity:
     fail("receipt stub identity does not match bounded producer stub")
-
-for key in launch["env_keys_present"]:
-    if key not in os.environ:
-        fail(f"declared environment key is absent for rehearsal: {key}")
 
 terminal_path = pathlib.Path(launch["terminal_artifact_path"])
 if not terminal_path.parent.is_dir():
@@ -209,24 +239,30 @@ if not terminal_path.parent.is_dir():
 if terminal_path.exists() or terminal_path.is_symlink():
     fail("terminal artifact must be absent before wrapper execution")
 
-proof_fd, proof_raw = tempfile.mkstemp(
-    prefix=".implementaudit-rehearsal-stub-",
+event_fd, event_raw = tempfile.mkstemp(
+    prefix=".implementaudit-rehearsal-stub-event-",
     dir=terminal_path.parent,
 )
-os.close(proof_fd)
-proof_path = pathlib.Path(proof_raw)
-proof_path.unlink()
+os.close(event_fd)
+event_path = pathlib.Path(event_raw)
+event_path.unlink()
+event_nonce = secrets.token_hex(32)
 
-run_env = os.environ.copy()
+# The wrapper receives only process essentials, declared key *names* with
+# empty values, and the bounded rehearsal controls.  In particular it never
+# inherits caller credentials or an artifact path with which it could author
+# a terminal record.
+safe_parent_keys = {
+    "COMSPEC", "PATH", "PATHEXT", "SYSTEMROOT", "SystemDrive", "SystemRoot",
+    "TEMP", "TMP", "WINDIR",
+}
+run_env = {key: os.environ[key] for key in safe_parent_keys if key in os.environ}
+for key in launch["env_keys_present"]:
+    run_env[key] = ""
 run_env.update({
     "IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB": str(stub_path.resolve()),
-    "IMPLEMENTAUDIT_REHEARSAL_TERMINAL": launch["terminal_artifact_path"],
-    "IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF": str(proof_path),
-    "IMPLEMENTAUDIT_REHEARSAL_COMMAND_HASH": actual_hash,
-    "IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY": stub_identity,
-    "IMPLEMENTAUDIT_REHEARSAL_ENV_KEYS": json.dumps(
-        launch["env_keys_present"], separators=(",", ":")
-    ),
+    "IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT": str(event_path),
+    "IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE": event_nonce,
 })
 try:
     completed = subprocess.run(launch["argv"], env=run_env, check=False)
@@ -234,15 +270,25 @@ except OSError as exc:
     fail(f"production wrapper could not execute: {exc}")
 if completed.returncode != 0:
     fail(f"production wrapper exited {completed.returncode}")
-if not proof_path.is_file() or proof_path.read_text(encoding="utf-8") != stub_identity + "\n":
-    fail("bounded producer stub did not produce its identity proof")
-if not terminal_path.is_file() or terminal_path.is_symlink():
-    fail("production wrapper did not produce the declared terminal artifact")
+if not event_path.is_file() or event_path.is_symlink():
+    fail("bounded producer stub did not produce an execution event")
+event = load_object(str(event_path), "bounded producer execution event")
+if set(event) != {"stub_identity", "nonce", "exit_code"}:
+    fail("bounded producer execution event fields are invalid")
+if event["stub_identity"] != stub_identity or event["nonce"] != event_nonce:
+    fail("bounded producer execution event identity does not match")
+if type(event["exit_code"]) is not int or event["exit_code"] != 0:
+    fail("bounded producer stub exited nonzero")
+
+# The checker, not the wrapper, is the only terminal author.  The terminal is
+# written only after the independently observed zero-meter stub event binds to
+# the declared wrapper/launch identity above.
+terminal_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
 observed = load_object(str(terminal_path), "execution terminal")
 if observed != receipt:
     fail("execution terminal does not match the supplied rehearsal receipt")
 
-print("check-authorization-binding: ok — rehearsal identity and terminal receipt are bound")
+print("check-authorization-binding: ok — wrapper transport, stub event, and terminal receipt are bound")
 PY
   exit $?
 fi

--- a/skills/implementaudit/scripts/check-authorization-binding.sh
+++ b/skills/implementaudit/scripts/check-authorization-binding.sh
@@ -48,6 +48,7 @@ import os
 import pathlib
 import re
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -237,8 +238,16 @@ if receipt["stub_identity"] != stub_identity:
 terminal_path = pathlib.Path(launch["terminal_artifact_path"])
 if not terminal_path.parent.is_dir():
     fail("terminal artifact parent directory does not exist")
-if terminal_path.exists() or terminal_path.is_symlink():
-    fail("terminal artifact must be absent before wrapper execution")
+
+def require_absent_terminal(stage):
+    try:
+        existing = terminal_path.lstat()
+    except FileNotFoundError:
+        return
+    kind = "symlink" if stat.S_ISLNK(existing.st_mode) else "existing owner"
+    fail(f"terminal artifact must be absent {stage}; found {kind}")
+
+require_absent_terminal("before wrapper execution")
 
 bridge_fd, bridge_raw = tempfile.mkstemp(
     prefix=".implementaudit-rehearsal-mediator-bridge-",
@@ -324,10 +333,23 @@ if mediated["exit_code"] != 0:
 if completed.returncode != 0:
     fail(f"production wrapper exited {completed.returncode}")
 
-# The checker, not the wrapper, is the only terminal author.  The terminal is
-# written only after the checker-owned mediator has observed the zero-meter
-# producer exit during the wrapper traversal above.
-terminal_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+# The checker, not the wrapper, is the only terminal author.  Re-check with
+# lstat after the untrusted wrapper completes, then use exclusive creation so
+# an alias/hardlink/nonterminal owner cannot be followed or overwritten.
+require_absent_terminal("when publishing the rehearsal terminal")
+try:
+    terminal_fd = os.open(
+        terminal_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+except FileExistsError:
+    fail("terminal artifact appeared before exclusive publication")
+with os.fdopen(terminal_fd, "w", encoding="utf-8") as terminal_file:
+    terminal_file.write(json.dumps(receipt, indent=2) + "\n")
+published = terminal_path.lstat()
+if not stat.S_ISREG(published.st_mode) or published.st_nlink != 1:
+    fail("checker-owned terminal publication lost exclusive regular-file identity")
 observed = load_object(str(terminal_path), "execution terminal")
 if observed != receipt:
     fail("execution terminal does not match the supplied rehearsal receipt")

--- a/skills/implementaudit/scripts/validate-phase.sh
+++ b/skills/implementaudit/scripts/validate-phase.sh
@@ -52,6 +52,7 @@ EXPLAIN
 fi
 
 [ -f "$phase_file" ] || fail "phase file not found: $phase_file"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 errors=0
 
@@ -932,6 +933,31 @@ fi
 if (( errors > 0 )); then
   printf 'validate-phase: %d error(s); see templates/phase-goal.txt in the skill directory for the canonical filled shape\n' "$errors" >&2
   exit 1
+fi
+
+# Scarce-resource rehearsal is consumed here, from the same phase spec that
+# names the audit object.  This is an explicit execution boundary, not a
+# prose-only route: any failure stops phase validation and leaves repair/re-run
+# manual for the operator.
+budget="$(sed -nE 's/^Scarce resource budget:[[:space:]]*(.*[^[:space:]])?[[:space:]]*$/\1/p' "$phase_file")"
+if [ -n "$budget" ] && [ "$budget" != "none" ]; then
+  phase_field() {
+    local name="$1" values
+    values="$(sed -nE "s/^${name}:[[:space:]]*(.*[^[:space:]])?[[:space:]]*$/\\1/p" "$phase_file")"
+    [ "$(printf '%s\n' "$values" | sed '/^$/d' | wc -l)" -eq 1 ] || fail "non-none scarce budget requires exactly one ${name} field"
+    values="$(printf '%s\n' "$values" | sed '/^$/d')"
+    [ "$values" != "none" ] || fail "non-none scarce budget requires ${name}"
+    printf '%s\n' "$values"
+  }
+  rehearsal="$(phase_field 'Rehearsal receipt')"
+  launch="$(phase_field 'Rehearsal launch')"
+  producer_stub="$(phase_field 'Rehearsal producer stub')"
+  phase_field 'Rehearsal command hash' >/dev/null
+  phase_field 'Rehearsal terminal artifact' >/dev/null
+  phase_field 'Rehearsal environment keys' >/dev/null
+  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$producer_stub" \
+    "$script_dir/check-authorization-binding.sh" --phase "$phase_file" --rehearsal "$rehearsal" --launch "$launch" ||
+    fail "scarce-resource rehearsal failed; repair manually and re-run validation"
 fi
 
 printf 'validate-phase: ok\n'

--- a/skills/implementaudit/scripts/validate-phase.sh
+++ b/skills/implementaudit/scripts/validate-phase.sh
@@ -935,16 +935,12 @@ if (( errors > 0 )); then
   exit 1
 fi
 
-# Scarce-resource rehearsal is consumed here, from the same phase spec that
-# names the audit object.  This is an explicit execution boundary, not a
-# prose-only route: any failure stops phase validation and leaves repair/re-run
-# manual for the operator.
 budget="$(sed -nE 's/^Scarce resource budget:[[:space:]]*(.*[^[:space:]])?[[:space:]]*$/\1/p' "$phase_file")"
 if [ -n "$budget" ] && [ "$budget" != "none" ]; then
   phase_field() {
     local name="$1" values
     values="$(sed -nE "s/^${name}:[[:space:]]*(.*[^[:space:]])?[[:space:]]*$/\\1/p" "$phase_file")"
-    [ "$(printf '%s\n' "$values" | sed '/^$/d' | wc -l)" -eq 1 ] || fail "non-none scarce budget requires exactly one ${name} field"
+    [ "$(printf '%s\n' "$values" | sed '/^$/d' | wc -l)" -eq 1 ] || fail "non-none budget requires one ${name}"
     values="$(printf '%s\n' "$values" | sed '/^$/d')"
     [ "$values" != "none" ] || fail "non-none scarce budget requires ${name}"
     printf '%s\n' "$values"
@@ -952,12 +948,10 @@ if [ -n "$budget" ] && [ "$budget" != "none" ]; then
   rehearsal="$(phase_field 'Rehearsal receipt')"
   launch="$(phase_field 'Rehearsal launch')"
   producer_stub="$(phase_field 'Rehearsal producer stub')"
-  phase_field 'Rehearsal command hash' >/dev/null
-  phase_field 'Rehearsal terminal artifact' >/dev/null
-  phase_field 'Rehearsal environment keys' >/dev/null
+  for field in 'Rehearsal command hash' 'Rehearsal terminal artifact' 'Rehearsal environment keys'; do phase_field "$field" >/dev/null; done
   IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$producer_stub" \
     "$script_dir/check-authorization-binding.sh" --phase "$phase_file" --rehearsal "$rehearsal" --launch "$launch" ||
-    fail "scarce-resource rehearsal failed; repair manually and re-run validation"
+    fail "rehearsal failed; repair manually and re-run"
 fi
 
 printf 'validate-phase: ok\n'

--- a/skills/implementaudit/templates/phase-goal.txt
+++ b/skills/implementaudit/templates/phase-goal.txt
@@ -27,6 +27,12 @@ Terminal object state to prove: {{WHAT_MUST_BE_TRUE_WHEN_DONE}}
 Thinking ref: <run-root>/THINKING.md
 Mandatory commands: {{COMMANDS_CSV}}
 Scarce resource budget: {{N <resource> | none}}
+Rehearsal receipt: {{PATH | none}}
+Rehearsal launch: {{PATH | none}}
+Rehearsal producer stub: {{PATH | none}}
+Rehearsal command hash: {{SHA-256 | none}}
+Rehearsal terminal artifact: {{PATH | none}}
+Rehearsal environment keys: {{COMMA_SEPARATED_UPPERCASE_KEYS | none}}
 Acceptance criteria: {{CRIT_COUNT}}
 Evidence required: {{EVIDENCE_CSV}}
 Depends on phases: {{DEPS}}

--- a/tests/helper-reachability.test.sh
+++ b/tests/helper-reachability.test.sh
@@ -74,9 +74,23 @@ PY
 }
 
 positive_output="$(bash "$checker" --repo-root "$repo_root")"
-grep -Fq 'HELPER_REACHABILITY=PASS population=18 examined=18 modes=3/3 enumeration=build-release-asset.required_archive' \
+grep -Fq 'HELPER_REACHABILITY=PASS population=18 examined=18 modes=4/4 enumeration=build-release-asset.required_archive' \
   <<<"$positive_output" || {
     printf 'helper-reachability.test: live positive census did not prove 18/18\n%s\n' "$positive_output" >&2
+    exit 1
+  }
+
+# R30 must count the scarce-resource rehearsal as a distinct governed mode,
+# rather than treating the authorization-record mode as its proxy.
+grep -Fqx \
+  'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch' \
+  "$repo_root/skills/implementaudit/references/repo-state-comparison.md" || {
+    printf 'helper-reachability.test: R30 rehearsal mode is missing from the route population\n' >&2
+    exit 1
+  }
+grep -Fq 'native audit object opens a scarce-resource phase' \
+  "$repo_root/skills/implementaudit/references/repo-state-comparison.md" || {
+    printf 'helper-reachability.test: R30 rehearsal caller/trigger is missing\n' >&2
     exit 1
   }
 
@@ -101,6 +115,13 @@ sed -i 's/--graph-scope <catalog> <repo> <path> \[path\.\.\.\]/--graph-scope is 
 expect_fail R30-M3 \
   'mode arguments absent: validate-run-root.sh --graph-scope' \
   "$missing_mode_dispatch"
+
+missing_rehearsal_mode="$(make_candidate missing-rehearsal-mode)"
+sed -i '/^helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|/d' \
+  "$missing_rehearsal_mode/skills/implementaudit/references/repo-state-comparison.md"
+expect_fail R30-M4 \
+  'missing mode applicability rows: check-authorization-binding.sh --phase --rehearsal --launch' \
+  "$missing_rehearsal_mode"
 grep -Fq 'One audit object; no event, no sweep.' \
   "$repo_root/skills/implementaudit/references/repo-state-comparison.md" || {
     printf 'helper-reachability.test: same-object/no-event contract is missing\n' >&2
@@ -332,4 +353,4 @@ printf '%s\n' \
   >>"$extra_row/skills/implementaudit/references/repo-state-comparison.md"
 expect_fail R30-F11 'applicability rows not in package: ghost-helper.sh' "$extra_row"
 
-printf 'helper-reachability.test: ok (derived 18/18 + modes 3/3 + R30-F1-F5/F8/F11/F20/M1-M3 controls)\n'
+printf 'helper-reachability.test: ok (derived 18/18 + modes 4/4 + R30-F1-F5/F8/F11/F20/M1-M4 controls)\n'

--- a/tests/helper-reachability.test.sh
+++ b/tests/helper-reachability.test.sh
@@ -15,15 +15,22 @@ trap 'rm -rf -- "$tmp"' EXIT
 make_candidate() {
   local name="$1"
   local candidate="$tmp/$name"
-  mkdir -p "$candidate/scripts"
+  mkdir -p "$candidate/scripts" "$candidate/tests" \
+    "$candidate/fixtures/scarce-resource-rehearsal" \
+    "$candidate/fixtures/run-root-example/phases"
   cp -R "$repo_root/skills" "$candidate/skills"
   cp "$repo_root/scripts/build-release-asset.sh" "$candidate/scripts/build-release-asset.sh"
+  cp "$repo_root/tests/scarce-resource-rehearsal-contract.test.sh" "$candidate/tests/"
+  cp "$repo_root/fixtures/scarce-resource-rehearsal/cases.json" \
+    "$candidate/fixtures/scarce-resource-rehearsal/"
+  cp "$repo_root/fixtures/run-root-example/phases/phase-1.md" \
+    "$candidate/fixtures/run-root-example/phases/"
   printf '%s\n' "$candidate"
 }
 
 expect_fail() {
   local label="$1" pattern="$2" candidate="$3" output
-  if output="$(bash "$checker" --repo-root "$candidate" 2>&1)"; then
+  if output="$(bash "$checker" --census-only --repo-root "$candidate" 2>&1)"; then
     printf 'helper-reachability.test: %s unexpectedly passed\n' "$label" >&2
     exit 1
   fi
@@ -77,6 +84,13 @@ positive_output="$(bash "$checker" --repo-root "$repo_root")"
 grep -Fq 'HELPER_REACHABILITY=PASS population=18 examined=18 modes=4/4 enumeration=build-release-asset.required_archive' \
   <<<"$positive_output" || {
     printf 'helper-reachability.test: live positive census did not prove 18/18\n%s\n' "$positive_output" >&2
+    exit 1
+}
+
+census_output="$(bash "$checker" --census-only --repo-root "$repo_root")"
+grep -Fq 'HELPER_REACHABILITY_CENSUS=PASS population=18 examined=18 modes=4/4 enumeration=build-release-asset.required_archive' \
+  <<<"$census_output" || {
+    printf 'helper-reachability.test: census-only result was not distinctly nonterminal\n%s\n' "$census_output" >&2
     exit 1
   }
 

--- a/tests/helper-reachability.test.sh
+++ b/tests/helper-reachability.test.sh
@@ -83,7 +83,7 @@ grep -Fq 'HELPER_REACHABILITY=PASS population=18 examined=18 modes=4/4 enumerati
 # R30 must count the scarce-resource rehearsal as a distinct governed mode,
 # rather than treating the authorization-record mode as its proxy.
 grep -Fqx \
-  'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch' \
+  'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   "$repo_root/skills/implementaudit/references/repo-state-comparison.md" || {
     printf 'helper-reachability.test: R30 rehearsal mode is missing from the route population\n' >&2
     exit 1

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -20,6 +20,9 @@ root = pathlib.Path(sys.argv[1])
 stub = root / "producer-stub.py"
 stub.write_text("#!/usr/bin/env python3\nraise SystemExit(23)\n", encoding="utf-8")
 stub.chmod(0o755)
+success_stub = root / "producer-success.py"
+success_stub.write_text("#!/usr/bin/env python3\nraise SystemExit(0)\n", encoding="utf-8")
+success_stub.chmod(0o755)
 
 def wrapper(name, body):
     path = root / name
@@ -50,18 +53,25 @@ pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(json.
   "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
   "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"], "exit_code": 0}), encoding="utf-8")
 ''')
+victim = root / "hardlink-victim.txt"
+victim.write_text("do-not-overwrite\n", encoding="utf-8")
+hardlinking = wrapper("hardlinking-wrapper.py", f'''import os, pathlib, subprocess, sys
+target = pathlib.Path(sys.argv[sys.argv.index("--terminal") + 1])
+subprocess.run([sys.executable, os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]], check=True)
+os.link({str(victim)!r}, target)
+''')
 
 def canonical_hash(argv, env_keys):
     return hashlib.sha256(json.dumps(
         {"argv": argv, "env_keys_present": sorted(env_keys)},
         separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
 
-def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"]):
+def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"], stub_path=stub, extra_argv=[]):
     terminal = root / f"terminal-{suffix}.json"
-    argv = [sys.executable, str(wrapper_path), "--input", argv_suffix]
+    argv = [sys.executable, str(wrapper_path), "--input", argv_suffix] + extra_argv
     receipt = {
         "rehearsed_command_hash": canonical_hash(argv, env_keys),
-        "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+        "stub_identity": "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest(),
         "stubbed_components": ["producer"], "env_keys_present": env_keys,
         "terminal_artifact_path": str(terminal), "exit_code": 0,
         "disposition": "PASS", "timestamp": "2026-08-11T12:00:00Z",
@@ -74,12 +84,12 @@ def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKE
     launch_path.write_text(json.dumps(launch), encoding="utf-8")
     return receipt, receipt_path, launch_path
 
-def complete_phase(name, receipt, receipt_path, launch_path):
+def complete_phase(name, receipt, receipt_path, launch_path, stub_path=stub):
     base = pathlib.Path("fixtures/run-root-example/phases/phase-1.md").read_text(encoding="utf-8")
     fields = (
         "Scarce resource budget: 1 model-call\n"
         f"Rehearsal receipt: {receipt_path}\nRehearsal launch: {launch_path}\n"
-        f"Rehearsal producer stub: {stub}\n"
+        f"Rehearsal producer stub: {stub_path}\n"
         f"Rehearsal command hash: {receipt['rehearsed_command_hash']}\n"
         f"Rehearsal terminal artifact: {receipt['terminal_artifact_path']}\n"
         f"Rehearsal environment keys: {','.join(receipt['env_keys_present'])}\n"
@@ -92,17 +102,22 @@ forged, forged_receipt, forged_launch = payload("forged", forging)
 ignored, ignored_receipt, ignored_launch = payload("ignored", ignoring)
 inherited, inherited_receipt, inherited_launch = payload("inherited", leaking)
 changed, changed_receipt, changed_launch = payload("changed", forging, "changed-fixture.txt", ["ALT_TOKEN"])
+hardlinked, hardlinked_receipt, hardlinked_launch = payload(
+    "hardlinked", hardlinking, stub_path=success_stub,
+    extra_argv=["--terminal", str(root / "terminal-hardlinked.json")],
+)
 complete_phase("phase-forged.md", forged, forged_receipt, forged_launch)
 complete_phase("phase-ignored.md", ignored, ignored_receipt, ignored_launch)
 complete_phase("phase-inherited.md", inherited, inherited_receipt, inherited_launch)
+complete_phase("phase-hardlinked.md", hardlinked, hardlinked_receipt, hardlinked_launch, success_stub)
 PY
 
 heldout_passes() {
-  local phase="$1" receipt="$2" launch="$3" marker="${4:-}"
+  local phase="$1" receipt="$2" launch="$3" marker="${4:-}" stub_path="${5:-$tmp/producer-stub.py}"
   API_TOKEN=real-api-token MODEL=real-model-token ALT_TOKEN=real-alt-token \
   HELDOUT_CREDENTIAL_SENTINEL=must-not-reach-wrapper \
   IMPLEMENTAUDIT_TEST_INHERITED_MARKER="$marker" \
-  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
+  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$stub_path" \
   bash "$checker" --phase "$phase" --rehearsal "$receipt" --launch "$launch" \
     >/dev/null 2>&1
 }
@@ -120,6 +135,12 @@ if heldout_passes "$tmp/phase-inherited.md" "$tmp/receipt-inherited.json" "$tmp/
     && [ -f "$tmp/inherited-marker" ]; then
   failures+=("undeclared-credential-sentinel-reaches-wrapper")
 fi
+if heldout_passes "$tmp/phase-hardlinked.md" "$tmp/receipt-hardlinked.json" "$tmp/launch-hardlinked.json" "" "$tmp/producer-success.py"; then
+  failures+=("hardlink-terminal-alias-passes")
+fi
+if [ "$(<"$tmp/hardlink-victim.txt")" != "do-not-overwrite" ]; then
+  failures+=("hardlink-terminal-alias-overwrites-victim")
+fi
 
 candidate="$tmp/reachability"
 mkdir -p "$candidate/scripts"
@@ -136,6 +157,16 @@ INERT_MODE
 EOF
 if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then
   failures+=("inert-heredoc-literal-counts-as-parser-arm")
+fi
+
+inert_mediator="$tmp/inert-mediator"
+mkdir -p "$inert_mediator/scripts"
+cp -R skills "$inert_mediator/skills"
+cp scripts/build-release-asset.sh "$inert_mediator/scripts/build-release-asset.sh"
+sed -i 's/^[[:space:]]*mediator_thread\.start()/# mediator_thread.start()/' \
+  "$inert_mediator/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$inert_mediator" >/dev/null 2>&1; then
+  failures+=("inert-mediator-comment-counts-as-transport")
 fi
 
 if ! grep -Fqx \

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -169,10 +169,36 @@ if bash "$reachability" --repo-root "$inert_mediator" >/dev/null 2>&1; then
   failures+=("inert-mediator-comment-counts-as-transport")
 fi
 
+dead_start="$tmp/dead-start"
+mkdir -p "$dead_start/scripts"
+cp -R skills "$dead_start/skills"
+cp scripts/build-release-asset.sh "$dead_start/scripts/build-release-asset.sh"
+sed -i 's/^[[:space:]]*mediator_thread\.start()/if False: mediator_thread.start()/' \
+  "$dead_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_start" >/dev/null 2>&1; then
+  failures+=("dead-start-control-flow-counts-as-transport")
+fi
+
+dead_join="$tmp/dead-join"
+mkdir -p "$dead_join/scripts"
+cp -R skills "$dead_join/skills"
+cp scripts/build-release-asset.sh "$dead_join/scripts/build-release-asset.sh"
+sed -i 's/^[[:space:]]*mediator_thread\.join(3)/if False: mediator_thread.join(3)/' \
+  "$dead_join/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_join" >/dev/null 2>&1; then
+  failures+=("dead-join-control-flow-counts-as-transport")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then
   failures+=("rehearsal-route-is-generic-prose-and-direct-test-only")
+fi
+
+asset_dir="$tmp/r33-asset"
+bash scripts/build-release-asset.sh "$asset_dir" >/dev/null
+if [ "$(wc -c < "$asset_dir/IMPLEMENTAUDIT.skill")" -gt 228000 ]; then
+  failures+=("r33-package-capacity-over-228000")
 fi
 
 if [ "${#failures[@]}" -gt 0 ]; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -405,6 +405,46 @@ if bash "$reachability" --repo-root "$assigned_exit_before_producer" >/dev/null 
   failures+=("assigned-exit-before-producer-counts-as-live-stub")
 fi
 
+short_circuit_compare_start="$tmp/short-circuit-compare-start"
+mkdir -p "$short_circuit_compare_start/scripts"
+cp -R skills "$short_circuit_compare_start/skills"
+cp scripts/build-release-asset.sh "$short_circuit_compare_start/scripts/build-release-asset.sh"
+sed -i 's/^mediator_thread\.start()$/0 == 1 == mediator_thread.start()/' \
+  "$short_circuit_compare_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$short_circuit_compare_start" >/dev/null 2>&1; then
+  failures+=("short-circuit-comparison-start-counts-as-transport")
+fi
+
+short_circuit_compare_launch="$tmp/short-circuit-compare-launch"
+mkdir -p "$short_circuit_compare_launch/scripts"
+cp -R skills "$short_circuit_compare_launch/skills"
+cp scripts/build-release-asset.sh "$short_circuit_compare_launch/scripts/build-release-asset.sh"
+sed -i 's/completed = subprocess\.run(launch\["argv"\], env=run_env, check=False)/completed = (0 == 1 == subprocess.run(launch["argv"], env=run_env, check=False))/' \
+  "$short_circuit_compare_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$short_circuit_compare_launch" >/dev/null 2>&1; then
+  failures+=("short-circuit-comparison-launch-counts-as-transport")
+fi
+
+short_circuit_compare_producer="$tmp/short-circuit-compare-producer"
+mkdir -p "$short_circuit_compare_producer/scripts"
+cp -R skills "$short_circuit_compare_producer/skills"
+cp scripts/build-release-asset.sh "$short_circuit_compare_producer/scripts/build-release-asset.sh"
+sed -i 's/result = subprocess\.run(command, env=stub_env, check=False)/result = (0 == 1 == subprocess.run(command, env=stub_env, check=False))/' \
+  "$short_circuit_compare_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$short_circuit_compare_producer" >/dev/null 2>&1; then
+  failures+=("short-circuit-comparison-producer-counts-as-live-stub")
+fi
+
+constant_assert_before_start="$tmp/constant-assert-before-start"
+mkdir -p "$constant_assert_before_start/scripts"
+cp -R skills "$constant_assert_before_start/skills"
+cp scripts/build-release-asset.sh "$constant_assert_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i assert 1 - 1\nassert 1 == 1 == 2' \
+  "$constant_assert_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$constant_assert_before_start" >/dev/null 2>&1; then
+  failures+=("constant-expression-assert-before-start-counts-as-transport")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -259,6 +259,62 @@ if bash "$reachability" --repo-root "$conditional_launch" >/dev/null 2>&1; then
   failures+=("conditional-launch-counts-as-mandatory-transport")
 fi
 
+terminated_before_start="$tmp/terminated-before-start"
+mkdir -p "$terminated_before_start/scripts"
+cp -R skills "$terminated_before_start/skills"
+cp scripts/build-release-asset.sh "$terminated_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i raise SystemExit(0)' \
+  "$terminated_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$terminated_before_start" >/dev/null 2>&1; then
+  failures+=("terminated-path-before-start-counts-as-transport")
+fi
+
+exited_before_start="$tmp/exited-before-start"
+mkdir -p "$exited_before_start/scripts"
+cp -R skills "$exited_before_start/skills"
+cp scripts/build-release-asset.sh "$exited_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i sys.exit(0)' \
+  "$exited_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$exited_before_start" >/dev/null 2>&1; then
+  failures+=("system-exit-before-start-counts-as-transport")
+fi
+
+terminated_before_launch="$tmp/terminated-before-launch"
+mkdir -p "$terminated_before_launch/scripts"
+cp -R skills "$terminated_before_launch/skills"
+cp scripts/build-release-asset.sh "$terminated_before_launch/scripts/build-release-asset.sh"
+sed -i '/completed = subprocess\.run(launch/i\    raise SystemExit(0)' \
+  "$terminated_before_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$terminated_before_launch" >/dev/null 2>&1; then
+  failures+=("terminated-path-before-launch-counts-as-transport")
+fi
+
+reversed_sequence="$tmp/reversed-sequence"
+mkdir -p "$reversed_sequence/scripts"
+cp -R skills "$reversed_sequence/skills"
+cp scripts/build-release-asset.sh "$reversed_sequence/scripts/build-release-asset.sh"
+sed -i 's/^mediator_thread\.start()$/IMPLEMENTAUDIT_SWAP_START/' \
+  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
+sed -i 's/^mediator_thread\.join(3)$/mediator_thread.start()/' \
+  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
+sed -i 's/^IMPLEMENTAUDIT_SWAP_START$/mediator_thread.join(3)/' \
+  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$reversed_sequence" >/dev/null 2>&1; then
+  failures+=("reversed-start-join-counts-as-transport")
+fi
+
+split_error_path="$tmp/split-error-path"
+mkdir -p "$split_error_path/scripts"
+cp -R skills "$split_error_path/skills"
+cp scripts/build-release-asset.sh "$split_error_path/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.join(3)$/d' \
+  "$split_error_path/skills/implementaudit/scripts/check-authorization-binding.sh"
+sed -i '/^except OSError as exc:$/a\    mediator_thread.join(3)' \
+  "$split_error_path/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$split_error_path" >/dev/null 2>&1; then
+  failures+=("normal-start-error-only-join-counts-as-transport")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -189,6 +189,76 @@ if bash "$reachability" --repo-root "$dead_join" >/dev/null 2>&1; then
   failures+=("dead-join-control-flow-counts-as-transport")
 fi
 
+dead_not_start="$tmp/dead-not-start"
+mkdir -p "$dead_not_start/scripts"
+cp -R skills "$dead_not_start/skills"
+cp scripts/build-release-asset.sh "$dead_not_start/scripts/build-release-asset.sh"
+sed -i 's/^[[:space:]]*mediator_thread\.start()/if not True: mediator_thread.start()/' \
+  "$dead_not_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_not_start" >/dev/null 2>&1; then
+  failures+=("dead-not-start-control-flow-counts-as-transport")
+fi
+
+dead_not_join="$tmp/dead-not-join"
+mkdir -p "$dead_not_join/scripts"
+cp -R skills "$dead_not_join/skills"
+cp scripts/build-release-asset.sh "$dead_not_join/scripts/build-release-asset.sh"
+sed -i 's/^[[:space:]]*mediator_thread\.join(3)/if not True: mediator_thread.join(3)/' \
+  "$dead_not_join/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_not_join" >/dev/null 2>&1; then
+  failures+=("dead-not-join-control-flow-counts-as-transport")
+fi
+
+dead_launch="$tmp/dead-launch"
+mkdir -p "$dead_launch/scripts"
+cp -R skills "$dead_launch/skills"
+cp scripts/build-release-asset.sh "$dead_launch/scripts/build-release-asset.sh"
+sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if False: /' \
+  "$dead_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_launch" >/dev/null 2>&1; then
+  failures+=("dead-launch-control-flow-counts-as-transport")
+fi
+
+dead_not_launch="$tmp/dead-not-launch"
+mkdir -p "$dead_not_launch/scripts"
+cp -R skills "$dead_not_launch/skills"
+cp scripts/build-release-asset.sh "$dead_not_launch/scripts/build-release-asset.sh"
+sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if not True: /' \
+  "$dead_not_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_not_launch" >/dev/null 2>&1; then
+  failures+=("dead-not-launch-control-flow-counts-as-transport")
+fi
+
+dead_not_producer="$tmp/dead-not-producer"
+mkdir -p "$dead_not_producer/scripts"
+cp -R skills "$dead_not_producer/skills"
+cp scripts/build-release-asset.sh "$dead_not_producer/scripts/build-release-asset.sh"
+sed -E -i '/result = subprocess\.run\(command/ s/^([[:space:]]*)/\1if not True: /' \
+  "$dead_not_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$dead_not_producer" >/dev/null 2>&1; then
+  failures+=("dead-not-producer-control-flow-counts-as-transport")
+fi
+
+conditional_start="$tmp/conditional-start"
+mkdir -p "$conditional_start/scripts"
+cp -R skills "$conditional_start/skills"
+cp scripts/build-release-asset.sh "$conditional_start/scripts/build-release-asset.sh"
+sed -E -i '/mediator_thread\.start\(\)/ s/^([[:space:]]*)/\1if os.environ.get("OPTIONAL_MEDIATOR"): /' \
+  "$conditional_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$conditional_start" >/dev/null 2>&1; then
+  failures+=("conditional-start-counts-as-mandatory-transport")
+fi
+
+conditional_launch="$tmp/conditional-launch"
+mkdir -p "$conditional_launch/scripts"
+cp -R skills "$conditional_launch/skills"
+cp scripts/build-release-asset.sh "$conditional_launch/scripts/build-release-asset.sh"
+sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if os.environ.get("OPTIONAL_LAUNCH"): /' \
+  "$conditional_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$conditional_launch" >/dev/null 2>&1; then
+  failures+=("conditional-launch-counts-as-mandatory-transport")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+checker="skills/implementaudit/scripts/check-authorization-binding.sh"
+reachability="scripts/check-helper-reachability.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+failures=()
+
+python - "$tmp" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+stub = root / "producer-stub.py"
+stub.write_text("#!/usr/bin/env python3\nraise SystemExit(23)\n", encoding="utf-8")
+stub.chmod(0o755)
+
+wrapper = root / "forging-wrapper.py"
+wrapper.write_text('''#!/usr/bin/env python3
+import json, os, pathlib
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF"]).write_text(
+    os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"] + "\\n", encoding="utf-8")
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_TERMINAL"]).write_text(
+    os.environ["IMPLEMENTAUDIT_TEST_RECEIPT"] + "\\n", encoding="utf-8")
+if os.environ.get("HELDOUT_CREDENTIAL_SENTINEL"):
+    pathlib.Path(os.environ["IMPLEMENTAUDIT_TEST_INHERITED_MARKER"]).write_text("visible\\n", encoding="utf-8")
+''', encoding="utf-8")
+wrapper.chmod(0o755)
+
+def payload(suffix, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"]):
+    terminal = root / f"terminal-{suffix}.json"
+    argv = [sys.executable, str(wrapper), "--input", argv_suffix]
+    command_hash = hashlib.sha256(json.dumps(
+        {"argv": argv, "env_keys_present": sorted(env_keys)},
+        separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+    receipt = {
+        "rehearsed_command_hash": command_hash,
+        "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+        "stubbed_components": ["producer"],
+        "env_keys_present": env_keys,
+        "terminal_artifact_path": str(terminal),
+        "exit_code": 0,
+        "disposition": "PASS",
+        "timestamp": "2026-08-11T12:00:00Z",
+    }
+    launch = {
+        "argv": argv,
+        "env_keys_present": env_keys,
+        "terminal_artifact_path": str(terminal),
+        "launch_records": 1,
+        "metered_calls": 0,
+    }
+    (root / f"receipt-{suffix}.json").write_text(json.dumps(receipt), encoding="utf-8")
+    (root / f"launch-{suffix}.json").write_text(json.dumps(launch), encoding="utf-8")
+    return receipt
+
+(root / "phase.md").write_text("Scarce resource budget: 1 model-call\nResidual risk: none\n", encoding="utf-8")
+for suffix, argv_suffix, keys in (
+    ("forged", "fixture.txt", ["API_TOKEN", "MODEL"]),
+    ("changed", "changed-fixture.txt", ["ALT_TOKEN"]),
+    ("nonzero", "fixture.txt", ["API_TOKEN", "MODEL"]),
+    ("inherited", "fixture.txt", ["API_TOKEN", "MODEL"]),
+):
+    receipt = payload(suffix, argv_suffix, keys)
+    (root / f"receipt-env-{suffix}.txt").write_text(json.dumps(receipt), encoding="utf-8")
+PY
+
+heldout_passes() {
+  local suffix="$1" marker="${2:-}"
+  local receipt
+  receipt="$(<"$tmp/receipt-env-$suffix.txt")"
+  API_TOKEN=real-api-token MODEL=real-model-token ALT_TOKEN=real-alt-token \
+  HELDOUT_CREDENTIAL_SENTINEL=must-not-reach-wrapper \
+  IMPLEMENTAUDIT_TEST_INHERITED_MARKER="$marker" \
+  IMPLEMENTAUDIT_TEST_RECEIPT="$receipt" \
+  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
+  bash "$checker" --phase "$tmp/phase.md" \
+    --rehearsal "$tmp/receipt-$suffix.json" --launch "$tmp/launch-$suffix.json" \
+    >/dev/null 2>&1
+}
+
+if heldout_passes forged "$tmp/forged-inherited"; then
+  failures+=("wrapper-forges-proof-and-terminal-without-stub")
+fi
+if heldout_passes changed "$tmp/changed-inherited"; then
+  failures+=("self-consistent-changed-argv-env-terminal-pass")
+fi
+if heldout_passes nonzero "$tmp/nonzero-inherited"; then
+  failures+=("stub-exit-23-ignored-by-wrapper-passes")
+fi
+if heldout_passes inherited "$tmp/inherited-marker" \
+    && [ -f "$tmp/inherited-marker" ]; then
+  failures+=("undeclared-credential-sentinel-reaches-wrapper")
+fi
+
+candidate="$tmp/reachability"
+mkdir -p "$candidate/scripts"
+cp -R skills "$candidate/skills"
+cp scripts/build-release-asset.sh "$candidate/scripts/build-release-asset.sh"
+sed -i 's/--rehearsal)/--receipt)/' \
+  "$candidate/skills/implementaudit/scripts/check-authorization-binding.sh"
+printf '\n# inert --rehearsal literal retained by a comment\n' \
+  >>"$candidate/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then
+  failures+=("inert-rehearsal-literal-counts-as-implemented-mode")
+fi
+
+if ! grep -Fqx \
+  'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
+  skills/implementaudit/references/repo-state-comparison.md; then
+  failures+=("rehearsal-route-is-generic-prose-and-direct-test-only")
+fi
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  printf 'r11-r30-review-heldouts: GAP-REVISE reproduced: %s\n' "${failures[*]}" >&2
+  exit 1
+fi
+printf 'r11-r30-review-heldouts: ok\n'

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -365,6 +365,46 @@ if bash "$reachability" --repo-root "$conditional_expression_launch" >/dev/null 
   failures+=("conditional-expression-launch-counts-as-transport")
 fi
 
+assigned_exit_before_start="$tmp/assigned-exit-before-start"
+mkdir -p "$assigned_exit_before_start/scripts"
+cp -R skills "$assigned_exit_before_start/skills"
+cp scripts/build-release-asset.sh "$assigned_exit_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i terminated = sys.exit(0)' \
+  "$assigned_exit_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$assigned_exit_before_start" >/dev/null 2>&1; then
+  failures+=("assigned-exit-before-start-counts-as-transport")
+fi
+
+exit_test_before_start="$tmp/exit-test-before-start"
+mkdir -p "$exit_test_before_start/scripts"
+cp -R skills "$exit_test_before_start/skills"
+cp scripts/build-release-asset.sh "$exit_test_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i if sys.exit(0): pass' \
+  "$exit_test_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$exit_test_before_start" >/dev/null 2>&1; then
+  failures+=("terminating-if-test-before-start-counts-as-transport")
+fi
+
+empty_assert_before_start="$tmp/empty-assert-before-start"
+mkdir -p "$empty_assert_before_start/scripts"
+cp -R skills "$empty_assert_before_start/skills"
+cp scripts/build-release-asset.sh "$empty_assert_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i assert ()\nassert []' \
+  "$empty_assert_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$empty_assert_before_start" >/dev/null 2>&1; then
+  failures+=("empty-literal-assert-before-start-counts-as-transport")
+fi
+
+assigned_exit_before_producer="$tmp/assigned-exit-before-producer"
+mkdir -p "$assigned_exit_before_producer/scripts"
+cp -R skills "$assigned_exit_before_producer/skills"
+cp scripts/build-release-asset.sh "$assigned_exit_before_producer/scripts/build-release-asset.sh"
+sed -i '/result = subprocess\.run(command/i\            terminated = sys.exit(0)' \
+  "$assigned_exit_before_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$assigned_exit_before_producer" >/dev/null 2>&1; then
+  failures+=("assigned-exit-before-producer-counts-as-live-stub")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -465,6 +465,96 @@ if bash "$reachability" --repo-root "$class_base_exit" >/dev/null 2>&1; then
   failures+=("class-base-exit-counts-as-transport")
 fi
 
+class_body_exit="$tmp/class-body-exit"
+mkdir -p "$class_body_exit/scripts"
+cp -R skills "$class_body_exit/skills"
+cp scripts/build-release-asset.sh "$class_body_exit/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i class Deferred:\n    sys.exit(0)' \
+  "$class_body_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$class_body_exit" >/dev/null 2>&1; then
+  failures+=("class-suite-exit-counts-as-transport")
+fi
+
+eager_list="$tmp/eager-list"
+mkdir -p "$eager_list/scripts"
+cp -R skills "$eager_list/skills"
+cp scripts/build-release-asset.sh "$eager_list/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i [sys.exit(0) for _ in [0]]' \
+  "$eager_list/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$eager_list" >/dev/null 2>&1; then
+  failures+=("eager-listcomp-element-exit-counts-as-transport")
+fi
+
+eager_set="$tmp/eager-set"
+mkdir -p "$eager_set/scripts"
+cp -R skills "$eager_set/skills"
+cp scripts/build-release-asset.sh "$eager_set/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i {sys.exit(0) for _ in [0]}' \
+  "$eager_set/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$eager_set" >/dev/null 2>&1; then
+  failures+=("eager-setcomp-element-exit-counts-as-transport")
+fi
+
+eager_dict_key="$tmp/eager-dict-key"
+mkdir -p "$eager_dict_key/scripts"
+cp -R skills "$eager_dict_key/skills"
+cp scripts/build-release-asset.sh "$eager_dict_key/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i {sys.exit(0): 0 for _ in [0]}' \
+  "$eager_dict_key/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$eager_dict_key" >/dev/null 2>&1; then
+  failures+=("eager-dictcomp-key-exit-counts-as-transport")
+fi
+
+eager_dict_value="$tmp/eager-dict-value"
+mkdir -p "$eager_dict_value/scripts"
+cp -R skills "$eager_dict_value/skills"
+cp scripts/build-release-asset.sh "$eager_dict_value/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i {0: sys.exit(0) for _ in [0]}' \
+  "$eager_dict_value/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$eager_dict_value" >/dev/null 2>&1; then
+  failures+=("eager-dictcomp-value-exit-counts-as-transport")
+fi
+
+eager_decorator="$tmp/eager-decorator"
+mkdir -p "$eager_decorator/scripts"
+cp -R skills "$eager_decorator/skills"
+cp scripts/build-release-asset.sh "$eager_decorator/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i @(lambda fn: sys.exit(0))\ndef Deferred(): pass' \
+  "$eager_decorator/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$eager_decorator" >/dev/null 2>&1; then
+  failures+=("decorator-application-exit-counts-as-transport")
+fi
+
+deleted_stub="$tmp/deleted-stub"
+mkdir -p "$deleted_stub/scripts"
+cp -R skills "$deleted_stub/skills"
+cp scripts/build-release-asset.sh "$deleted_stub/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread = threading\.Thread/i del run_bounded_stub' \
+  "$deleted_stub/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$deleted_stub" >/dev/null 2>&1; then
+  failures+=("deleted-stub-definition-counts-as-live-producer")
+fi
+
+deleted_thread="$tmp/deleted-thread"
+mkdir -p "$deleted_thread/scripts"
+cp -R skills "$deleted_thread/skills"
+cp scripts/build-release-asset.sh "$deleted_thread/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i del mediator_thread' \
+  "$deleted_thread/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$deleted_thread" >/dev/null 2>&1; then
+  failures+=("deleted-thread-binding-counts-as-live-transport")
+fi
+
+empty_list="$tmp/empty-list"
+mkdir -p "$empty_list/scripts"
+cp -R skills "$empty_list/skills"
+cp scripts/build-release-asset.sh "$empty_list/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i [sys.exit(0) for _ in []]' \
+  "$empty_list/skills/implementaudit/scripts/check-authorization-binding.sh"
+if ! bash "$reachability" --repo-root "$empty_list" >/dev/null 2>&1; then
+  failures+=("empty-listcomp-body-rejects-live-route")
+fi
+
 overwritten_stub="$tmp/overwritten-stub"
 mkdir -p "$overwritten_stub/scripts"
 cp -R skills "$overwritten_stub/skills"

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+outer_timeout_only=0
+windows_custody_only=0
+case "${1:-}" in
+  --outer-timeout-heldout) outer_timeout_only=1; shift;;
+  --windows-custody-reproducer) windows_custody_only=1; shift;;
+esac
+[ "$#" -eq 0 ] || { printf 'usage: r11-r30-review-heldouts.test.sh [--outer-timeout-heldout]\n' >&2; exit 2; }
 cd "$repo_root"
 
 checker="skills/implementaudit/scripts/check-authorization-binding.sh"
@@ -9,6 +16,49 @@ reachability="scripts/check-helper-reachability.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 failures=()
+
+if [ "$windows_custody_only" -eq 1 ]; then
+  candidate="$tmp/windows-custody-candidate"
+  mkdir -p "$candidate/tests"
+  cp tests/scarce-resource-rehearsal-contract.test.sh "$candidate/tests/"
+  sed -i '/^checker=/i sleep 60 \&\nprintf "%s\\n" "$!" > "$PWD/.windows-custody-child.pid"\nwait' \
+    "$candidate/tests/scarce-resource-rehearsal-contract.test.sh"
+  python - "$BASH" "$candidate" <<'PY'
+import os, subprocess, sys, time
+from pathlib import Path
+
+bash, candidate = sys.argv[1:]
+process = subprocess.Popen([bash, "tests/scarce-resource-rehearsal-contract.test.sh", "--r30-probe", "--repo-root", "."],
+    cwd=candidate, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+pid_file = Path(candidate) / ".windows-custody-child.pid"
+deadline = time.monotonic() + 3
+while not pid_file.exists() and time.monotonic() < deadline:
+    time.sleep(.02)
+if not pid_file.exists():
+    process.kill(); process.communicate(); raise SystemExit("windows-custody: child PID was not recorded")
+child = int(pid_file.read_text(encoding="utf-8"))
+try:
+    process.communicate(timeout=1)
+except subprocess.TimeoutExpired:
+    subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    try: process.kill()
+    except ProcessLookupError: pass
+    try: process.communicate(timeout=1)
+    except subprocess.TimeoutExpired:
+        if process.stdout: process.stdout.close()
+        if process.stderr: process.stderr.close()
+        try: process.wait(timeout=1)
+        except subprocess.TimeoutExpired: pass
+listed = subprocess.run(["tasklist", "/FI", f"PID eq {child}", "/FO", "CSV", "/NH"], capture_output=True, text=True, check=False)
+alive = str(child) in listed.stdout
+if alive:
+    subprocess.run(["taskkill", "/PID", str(child), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+raise SystemExit("windows-custody: launcher=%s child=%s survived=%s" % (process.pid, child, alive) if alive else 0)
+PY
+  printf 'r11-r30-review-heldouts: windows-custody reproducer unexpectedly cleaned child\n' >&2
+  exit 1
+fi
 
 python - "$tmp" <<'PY'
 import hashlib
@@ -133,6 +183,53 @@ expect_rejected() {
   local label="$1" candidate="$2"
   if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then failures+=("$label"); fi
 }
+expect_rejected_with_diagnostic() {
+  local label="$1" expected="$2" candidate="$3" output
+  if output="$(bash "$reachability" --repo-root "$candidate" 2>&1)"; then
+    failures+=("$label")
+  elif ! grep -Fq "$expected" <<<"$output"; then
+    failures+=("$label-diagnostic-lost")
+  fi
+}
+expect_no_pid() {
+  local label="$1" pid_file="$2"
+  python - "$pid_file" <<'PY' || failures+=("$label-child-survived")
+import os, subprocess, sys
+from pathlib import Path
+
+pid = int(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if os.name == "nt":
+    result = subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    raise SystemExit(1 if result.returncode == 0 else 0)
+try: os.kill(pid, 0)
+except OSError: raise SystemExit(0)
+os.kill(pid, 9)
+raise SystemExit(1)
+PY
+}
+if [ "$outer_timeout_only" -eq 1 ]; then
+  stalled_consumer="$(seed_candidate stalled-consumer)"
+  python - "$stalled_consumer/tests/scarce-resource-rehearsal-contract.test.sh" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+injection = 'printf "outer-timeout-diagnostic\\n" >&2\nsleep 60 &\nprintf "%s\\n" "$!" > "$PWD/.outer-timeout-child.pid"\nwait\n'
+if text.count("checker=") != 1:
+    raise SystemExit("expected one checker binding")
+path.write_text(text.replace("checker=", injection + "checker="), encoding="utf-8")
+PY
+  expect_rejected_with_diagnostic stalled-candidate-process-tree \
+    'outer-timeout-diagnostic' "$stalled_consumer"
+  expect_no_pid stalled-candidate-process-tree "$stalled_consumer/.outer-timeout-child.pid"
+  if [ "${#failures[@]}" -gt 0 ]; then
+    printf 'r11-r30-review-heldouts: GAP-REVISE reproduced: %s\n' "${failures[*]}" >&2
+    exit 1
+  fi
+  printf 'r11-r30-review-heldouts: outer-timeout heldout ok\n'
+  exit 0
+fi
 
 # R32 authority is the actual candidate F10 route.  These mutations collapse
 # the prior AST syntax corpus into execution-state controls.
@@ -171,6 +268,29 @@ expect_rejected handler-only-start "$handler_only"
 decorated="$(seed_candidate decorated-noop)"
 sed -i '/^def run_bounded_stub()/i def nullify(fn): return lambda: None\n@nullify' "$decorated/skills/implementaudit/scripts/check-authorization-binding.sh"
 expect_rejected decorated-noop-stub "$decorated"
+
+dead_consumer="$(seed_candidate dead-consumer)"
+python - "$dead_consumer/skills/implementaudit/scripts/validate-phase.sh" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = '  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$producer_stub" \\\n+'
+needle = '  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$producer_stub" ' + chr(92) + '\n'
+replacement = '  cp "$rehearsal" "$(phase_field \'Rehearsal terminal artifact\')"\n  exit 0\n' + needle
+if text.count(needle) != 1:
+    raise SystemExit("expected one native rehearsal invocation")
+path.write_text(text.replace(needle, replacement), encoding="utf-8")
+PY
+expect_rejected_with_diagnostic dead-static-invocation-with-copied-terminal \
+  'R30 native phase route did not invoke the declared helper' "$dead_consumer"
+
+stalled_consumer="$(seed_candidate stalled-consumer)"
+sed -i '/^checker=/i printf "outer-timeout-diagnostic\\n" >&2\nsleep 60' \
+  "$stalled_consumer/tests/scarce-resource-rehearsal-contract.test.sh"
+expect_rejected_with_diagnostic stalled-candidate-process-tree \
+  'outer-timeout-diagnostic' "$stalled_consumer"
 
 inert="$(seed_candidate inert-deferred)"
 sed -i '/^mediator_thread\.start()$/i deferred_lambda = lambda: sys.exit(0)\ndeferred_generator = (sys.exit(0) for _ in ())\n[sys.exit(0) for _ in []]' "$inert/skills/implementaudit/scripts/check-authorization-binding.sh"

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -445,6 +445,46 @@ if bash "$reachability" --repo-root "$constant_assert_before_start" >/dev/null 2
   failures+=("constant-expression-assert-before-start-counts-as-transport")
 fi
 
+function_default_exit="$tmp/function-default-exit"
+mkdir -p "$function_default_exit/scripts"
+cp -R skills "$function_default_exit/skills"
+cp scripts/build-release-asset.sh "$function_default_exit/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i def deferred(value=sys.exit(0)): pass' \
+  "$function_default_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$function_default_exit" >/dev/null 2>&1; then
+  failures+=("function-default-exit-counts-as-transport")
+fi
+
+class_base_exit="$tmp/class-base-exit"
+mkdir -p "$class_base_exit/scripts"
+cp -R skills "$class_base_exit/skills"
+cp scripts/build-release-asset.sh "$class_base_exit/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i class Deferred(sys.exit(0)): pass' \
+  "$class_base_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$class_base_exit" >/dev/null 2>&1; then
+  failures+=("class-base-exit-counts-as-transport")
+fi
+
+overwritten_stub="$tmp/overwritten-stub"
+mkdir -p "$overwritten_stub/scripts"
+cp -R skills "$overwritten_stub/skills"
+cp scripts/build-release-asset.sh "$overwritten_stub/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread = threading\.Thread/i run_bounded_stub = lambda: None' \
+  "$overwritten_stub/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$overwritten_stub" >/dev/null 2>&1; then
+  failures+=("overwritten-stub-definition-counts-as-live-producer")
+fi
+
+inert_deferred_bodies="$tmp/inert-deferred-bodies"
+mkdir -p "$inert_deferred_bodies/scripts"
+cp -R skills "$inert_deferred_bodies/skills"
+cp scripts/build-release-asset.sh "$inert_deferred_bodies/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i deferred_lambda = lambda: sys.exit(0)\ndeferred_generator = (sys.exit(0) for _ in ())' \
+  "$inert_deferred_bodies/skills/implementaudit/scripts/check-authorization-binding.sh"
+if ! bash "$reachability" --repo-root "$inert_deferred_bodies" >/dev/null 2>&1; then
+  failures+=("inert-lambda-or-generator-body-rejects-live-route")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -315,6 +315,56 @@ if bash "$reachability" --repo-root "$split_error_path" >/dev/null 2>&1; then
   failures+=("normal-start-error-only-join-counts-as-transport")
 fi
 
+conditional_expression_start="$tmp/conditional-expression-start"
+mkdir -p "$conditional_expression_start/scripts"
+cp -R skills "$conditional_expression_start/skills"
+cp scripts/build-release-asset.sh "$conditional_expression_start/scripts/build-release-asset.sh"
+sed -i 's/^mediator_thread\.start()$/mediator_thread.start() if OPTIONAL else None/' \
+  "$conditional_expression_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$conditional_expression_start" >/dev/null 2>&1; then
+  failures+=("conditional-expression-start-counts-as-transport")
+fi
+
+short_circuit_start="$tmp/short-circuit-start"
+mkdir -p "$short_circuit_start/scripts"
+cp -R skills "$short_circuit_start/skills"
+cp scripts/build-release-asset.sh "$short_circuit_start/scripts/build-release-asset.sh"
+sed -i 's/^mediator_thread\.start()$/OPTIONAL and mediator_thread.start()/' \
+  "$short_circuit_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$short_circuit_start" >/dev/null 2>&1; then
+  failures+=("short-circuit-start-counts-as-transport")
+fi
+
+inert_class_start="$tmp/inert-class-start"
+mkdir -p "$inert_class_start/scripts"
+cp -R skills "$inert_class_start/skills"
+cp scripts/build-release-asset.sh "$inert_class_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/c\class DeferredStart:\n    def run(self):\n        mediator_thread.start()' \
+  "$inert_class_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$inert_class_start" >/dev/null 2>&1; then
+  failures+=("uninstantiated-class-method-counts-as-transport")
+fi
+
+asserted_before_start="$tmp/asserted-before-start"
+mkdir -p "$asserted_before_start/scripts"
+cp -R skills "$asserted_before_start/skills"
+cp scripts/build-release-asset.sh "$asserted_before_start/scripts/build-release-asset.sh"
+sed -i '/^mediator_thread\.start()$/i assert False' \
+  "$asserted_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$asserted_before_start" >/dev/null 2>&1; then
+  failures+=("assert-false-before-start-counts-as-transport")
+fi
+
+conditional_expression_launch="$tmp/conditional-expression-launch"
+mkdir -p "$conditional_expression_launch/scripts"
+cp -R skills "$conditional_expression_launch/skills"
+cp scripts/build-release-asset.sh "$conditional_expression_launch/scripts/build-release-asset.sh"
+sed -i 's/completed = subprocess\.run(launch\["argv"\], env=run_env, check=False)/completed = subprocess.run(launch["argv"], env=run_env, check=False) if OPTIONAL else None/' \
+  "$conditional_expression_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
+if bash "$reachability" --repo-root "$conditional_expression_launch" >/dev/null 2>&1; then
+  failures+=("conditional-expression-launch-counts-as-transport")
+fi
+
 if ! grep -Fqx \
   'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
   skills/implementaudit/references/repo-state-comparison.md; then

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -30,8 +30,6 @@ def wrapper(name, body):
     path.chmod(0o755)
     return path
 
-# This candidate never invokes its declared producer.  On ada87d it can forge
-# the wrapper-visible event path/nonce and thereby falsely pass.
 forging = wrapper("forging-wrapper.py", '''import hashlib, json, os, pathlib
 stub = pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"])
 pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(json.dumps({
@@ -62,23 +60,19 @@ os.link({str(victim)!r}, target)
 ''')
 
 def canonical_hash(argv, env_keys):
-    return hashlib.sha256(json.dumps(
-        {"argv": argv, "env_keys_present": sorted(env_keys)},
+    return hashlib.sha256(json.dumps({"argv": argv, "env_keys_present": sorted(env_keys)},
         separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
 
 def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"], stub_path=stub, extra_argv=[]):
     terminal = root / f"terminal-{suffix}.json"
     argv = [sys.executable, str(wrapper_path), "--input", argv_suffix] + extra_argv
-    receipt = {
-        "rehearsed_command_hash": canonical_hash(argv, env_keys),
-        "stub_identity": "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest(),
-        "stubbed_components": ["producer"], "env_keys_present": env_keys,
-        "terminal_artifact_path": str(terminal), "exit_code": 0,
-        "disposition": "PASS", "timestamp": "2026-08-11T12:00:00Z",
-    }
-    launch = {"argv": argv, "env_keys_present": env_keys,
-              "terminal_artifact_path": str(terminal), "launch_records": 1,
-              "metered_calls": 0}
+    receipt = {"rehearsed_command_hash": canonical_hash(argv, env_keys),
+      "stub_identity": "sha256:" + hashlib.sha256(stub_path.read_bytes()).hexdigest(),
+      "stubbed_components": ["producer"], "env_keys_present": env_keys,
+      "terminal_artifact_path": str(terminal), "exit_code": 0, "disposition": "PASS",
+      "timestamp": "2026-08-11T12:00:00Z"}
+    launch = {"argv": argv, "env_keys_present": env_keys, "terminal_artifact_path": str(terminal),
+              "launch_records": 1, "metered_calls": 0}
     receipt_path, launch_path = root / f"receipt-{suffix}.json", root / f"launch-{suffix}.json"
     receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
     launch_path.write_text(json.dumps(launch), encoding="utf-8")
@@ -86,14 +80,11 @@ def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKE
 
 def complete_phase(name, receipt, receipt_path, launch_path, stub_path=stub):
     base = pathlib.Path("fixtures/run-root-example/phases/phase-1.md").read_text(encoding="utf-8")
-    fields = (
-        "Scarce resource budget: 1 model-call\n"
-        f"Rehearsal receipt: {receipt_path}\nRehearsal launch: {launch_path}\n"
-        f"Rehearsal producer stub: {stub_path}\n"
-        f"Rehearsal command hash: {receipt['rehearsed_command_hash']}\n"
-        f"Rehearsal terminal artifact: {receipt['terminal_artifact_path']}\n"
-        f"Rehearsal environment keys: {','.join(receipt['env_keys_present'])}\n"
-    )
+    fields = ("Scarce resource budget: 1 model-call\n"
+      f"Rehearsal receipt: {receipt_path}\nRehearsal launch: {launch_path}\n"
+      f"Rehearsal producer stub: {stub_path}\nRehearsal command hash: {receipt['rehearsed_command_hash']}\n"
+      f"Rehearsal terminal artifact: {receipt['terminal_artifact_path']}\n"
+      f"Rehearsal environment keys: {','.join(receipt['env_keys_present'])}\n")
     path = root / name
     path.write_text(base.replace("Depends on phases: none\n", "Depends on phases: none\n" + fields), encoding="utf-8")
     return path
@@ -102,490 +93,94 @@ forged, forged_receipt, forged_launch = payload("forged", forging)
 ignored, ignored_receipt, ignored_launch = payload("ignored", ignoring)
 inherited, inherited_receipt, inherited_launch = payload("inherited", leaking)
 changed, changed_receipt, changed_launch = payload("changed", forging, "changed-fixture.txt", ["ALT_TOKEN"])
-hardlinked, hardlinked_receipt, hardlinked_launch = payload(
-    "hardlinked", hardlinking, stub_path=success_stub,
-    extra_argv=["--terminal", str(root / "terminal-hardlinked.json")],
-)
-complete_phase("phase-forged.md", forged, forged_receipt, forged_launch)
-complete_phase("phase-ignored.md", ignored, ignored_receipt, ignored_launch)
-complete_phase("phase-inherited.md", inherited, inherited_receipt, inherited_launch)
-complete_phase("phase-hardlinked.md", hardlinked, hardlinked_receipt, hardlinked_launch, success_stub)
+hardlinked, hardlinked_receipt, hardlinked_launch = payload("hardlinked", hardlinking, stub_path=success_stub,
+    extra_argv=["--terminal", str(root / "terminal-hardlinked.json")])
+for name, receipt, receipt_path, launch_path, stub_path in (
+    ("phase-forged.md", forged, forged_receipt, forged_launch, stub),
+    ("phase-ignored.md", ignored, ignored_receipt, ignored_launch, stub),
+    ("phase-inherited.md", inherited, inherited_receipt, inherited_launch, stub),
+    ("phase-hardlinked.md", hardlinked, hardlinked_receipt, hardlinked_launch, success_stub),
+):
+    complete_phase(name, receipt, receipt_path, launch_path, stub_path)
 PY
 
 heldout_passes() {
   local phase="$1" receipt="$2" launch="$3" marker="${4:-}" stub_path="${5:-$tmp/producer-stub.py}"
   API_TOKEN=real-api-token MODEL=real-model-token ALT_TOKEN=real-alt-token \
-  HELDOUT_CREDENTIAL_SENTINEL=must-not-reach-wrapper \
-  IMPLEMENTAUDIT_TEST_INHERITED_MARKER="$marker" \
+  HELDOUT_CREDENTIAL_SENTINEL=must-not-reach-wrapper IMPLEMENTAUDIT_TEST_INHERITED_MARKER="$marker" \
   IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$stub_path" \
-  bash "$checker" --phase "$phase" --rehearsal "$receipt" --launch "$launch" \
-    >/dev/null 2>&1
+  bash "$checker" --phase "$phase" --rehearsal "$receipt" --launch "$launch" >/dev/null 2>&1
 }
 
-if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-forged.json" "$tmp/launch-forged.json"; then
-  failures+=("wrapper-forges-wrapper-visible-event-without-stub")
-fi
-if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-changed.json" "$tmp/launch-changed.json"; then
-  failures+=("self-consistent-changed-argv-env-terminal-pass")
-fi
-if heldout_passes "$tmp/phase-ignored.md" "$tmp/receipt-ignored.json" "$tmp/launch-ignored.json"; then
-  failures+=("stub-exit-23-ignored-by-wrapper-passes")
-fi
-if heldout_passes "$tmp/phase-inherited.md" "$tmp/receipt-inherited.json" "$tmp/launch-inherited.json" "$tmp/inherited-marker" \
-    && [ -f "$tmp/inherited-marker" ]; then
-  failures+=("undeclared-credential-sentinel-reaches-wrapper")
-fi
-if heldout_passes "$tmp/phase-hardlinked.md" "$tmp/receipt-hardlinked.json" "$tmp/launch-hardlinked.json" "" "$tmp/producer-success.py"; then
-  failures+=("hardlink-terminal-alias-passes")
-fi
-if [ "$(<"$tmp/hardlink-victim.txt")" != "do-not-overwrite" ]; then
-  failures+=("hardlink-terminal-alias-overwrites-victim")
-fi
+if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-forged.json" "$tmp/launch-forged.json"; then failures+=("wrapper-forges-wrapper-visible-event-without-stub"); fi
+if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-changed.json" "$tmp/launch-changed.json"; then failures+=("self-consistent-changed-argv-env-terminal-pass"); fi
+if heldout_passes "$tmp/phase-ignored.md" "$tmp/receipt-ignored.json" "$tmp/launch-ignored.json"; then failures+=("stub-exit-23-ignored-by-wrapper-passes"); fi
+if heldout_passes "$tmp/phase-inherited.md" "$tmp/receipt-inherited.json" "$tmp/launch-inherited.json" "$tmp/inherited-marker" && [ -f "$tmp/inherited-marker" ]; then failures+=("undeclared-credential-sentinel-reaches-wrapper"); fi
+if heldout_passes "$tmp/phase-hardlinked.md" "$tmp/receipt-hardlinked.json" "$tmp/launch-hardlinked.json" "" "$tmp/producer-success.py"; then failures+=("hardlink-terminal-alias-passes"); fi
+if [ "$(<"$tmp/hardlink-victim.txt")" != "do-not-overwrite" ]; then failures+=("hardlink-terminal-alias-overwrites-victim"); fi
 
-candidate="$tmp/reachability"
-mkdir -p "$candidate/scripts"
-cp -R skills "$candidate/skills"
-cp scripts/build-release-asset.sh "$candidate/scripts/build-release-asset.sh"
-sed -i 's/--rehearsal)/--receipt)/' \
-  "$candidate/skills/implementaudit/scripts/check-authorization-binding.sh"
-cat >>"$candidate/skills/implementaudit/scripts/check-authorization-binding.sh" <<'EOF'
-cat <<'INERT_MODE'
---phase)
---rehearsal)
---launch)
-INERT_MODE
-EOF
-if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then
-  failures+=("inert-heredoc-literal-counts-as-parser-arm")
-fi
+seed_candidate() {
+  local candidate="$tmp/$1"
+  mkdir -p "$candidate/scripts" "$candidate/tests" "$candidate/fixtures/scarce-resource-rehearsal" "$candidate/fixtures/run-root-example/phases"
+  cp -R skills "$candidate/skills"
+  cp scripts/build-release-asset.sh "$candidate/scripts/build-release-asset.sh"
+  cp tests/scarce-resource-rehearsal-contract.test.sh "$candidate/tests/"
+  cp fixtures/scarce-resource-rehearsal/cases.json "$candidate/fixtures/scarce-resource-rehearsal/"
+  cp fixtures/run-root-example/phases/phase-1.md "$candidate/fixtures/run-root-example/phases/"
+  printf '%s\n' "$candidate"
+}
+expect_rejected() {
+  local label="$1" candidate="$2"
+  if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then failures+=("$label"); fi
+}
 
-inert_mediator="$tmp/inert-mediator"
-mkdir -p "$inert_mediator/scripts"
-cp -R skills "$inert_mediator/skills"
-cp scripts/build-release-asset.sh "$inert_mediator/scripts/build-release-asset.sh"
-sed -i 's/^[[:space:]]*mediator_thread\.start()/# mediator_thread.start()/' \
-  "$inert_mediator/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$inert_mediator" >/dev/null 2>&1; then
-  failures+=("inert-mediator-comment-counts-as-transport")
-fi
+# R32 authority is the actual candidate F10 route.  These mutations collapse
+# the prior AST syntax corpus into execution-state controls.
+missing="$(seed_candidate missing)"
+sed -i 's/--rehearsal)/--receipt)/' "$missing/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected missing-parser-arm "$missing"
 
-dead_start="$tmp/dead-start"
-mkdir -p "$dead_start/scripts"
-cp -R skills "$dead_start/skills"
-cp scripts/build-release-asset.sh "$dead_start/scripts/build-release-asset.sh"
-sed -i 's/^[[:space:]]*mediator_thread\.start()/if False: mediator_thread.start()/' \
-  "$dead_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_start" >/dev/null 2>&1; then
-  failures+=("dead-start-control-flow-counts-as-transport")
-fi
+optional="$(seed_candidate optional)"
+sed -i 's/^mediator_thread\.start()$/if os.environ.get("R30_OPTIONAL"): mediator_thread.start()/' "$optional/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected optional-start-not-traversed "$optional"
 
-dead_join="$tmp/dead-join"
-mkdir -p "$dead_join/scripts"
-cp -R skills "$dead_join/skills"
-cp scripts/build-release-asset.sh "$dead_join/scripts/build-release-asset.sh"
-sed -i 's/^[[:space:]]*mediator_thread\.join(3)/if False: mediator_thread.join(3)/' \
-  "$dead_join/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_join" >/dev/null 2>&1; then
-  failures+=("dead-join-control-flow-counts-as-transport")
-fi
+dead="$(seed_candidate dead)"
+sed -i 's/^mediator_thread\.start()$/if False: mediator_thread.start()/' "$dead/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected dead-start-not-traversed "$dead"
 
-dead_not_start="$tmp/dead-not-start"
-mkdir -p "$dead_not_start/scripts"
-cp -R skills "$dead_not_start/skills"
-cp scripts/build-release-asset.sh "$dead_not_start/scripts/build-release-asset.sh"
-sed -i 's/^[[:space:]]*mediator_thread\.start()/if not True: mediator_thread.start()/' \
-  "$dead_not_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_not_start" >/dev/null 2>&1; then
-  failures+=("dead-not-start-control-flow-counts-as-transport")
-fi
+reordered="$(seed_candidate reordered)"
+sed -i 's/^mediator_thread\.start()$/mediator_thread.join()/' "$reordered/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected reordered-start-join "$reordered"
 
-dead_not_join="$tmp/dead-not-join"
-mkdir -p "$dead_not_join/scripts"
-cp -R skills "$dead_not_join/skills"
-cp scripts/build-release-asset.sh "$dead_not_join/scripts/build-release-asset.sh"
-sed -i 's/^[[:space:]]*mediator_thread\.join(3)/if not True: mediator_thread.join(3)/' \
-  "$dead_not_join/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_not_join" >/dev/null 2>&1; then
-  failures+=("dead-not-join-control-flow-counts-as-transport")
-fi
+rebound="$(seed_candidate rebound)"
+sed -i '/^mediator_thread = threading\.Thread/i run_bounded_stub = lambda: None' "$rebound/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected rebound-stub "$rebound"
 
-dead_launch="$tmp/dead-launch"
-mkdir -p "$dead_launch/scripts"
-cp -R skills "$dead_launch/skills"
-cp scripts/build-release-asset.sh "$dead_launch/scripts/build-release-asset.sh"
-sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if False: /' \
-  "$dead_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_launch" >/dev/null 2>&1; then
-  failures+=("dead-launch-control-flow-counts-as-transport")
-fi
+deleted="$(seed_candidate deleted)"
+sed -i '/^mediator_thread = threading\.Thread/i del run_bounded_stub' "$deleted/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected deleted-stub "$deleted"
 
-dead_not_launch="$tmp/dead-not-launch"
-mkdir -p "$dead_not_launch/scripts"
-cp -R skills "$dead_not_launch/skills"
-cp scripts/build-release-asset.sh "$dead_not_launch/scripts/build-release-asset.sh"
-sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if not True: /' \
-  "$dead_not_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_not_launch" >/dev/null 2>&1; then
-  failures+=("dead-not-launch-control-flow-counts-as-transport")
-fi
+deferred="$(seed_candidate deferred)"
+sed -i 's/^mediator_thread\.start()$/def deferred_start(): mediator_thread.start()/' "$deferred/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected deferred-start "$deferred"
 
-dead_not_producer="$tmp/dead-not-producer"
-mkdir -p "$dead_not_producer/scripts"
-cp -R skills "$dead_not_producer/skills"
-cp scripts/build-release-asset.sh "$dead_not_producer/scripts/build-release-asset.sh"
-sed -E -i '/result = subprocess\.run\(command/ s/^([[:space:]]*)/\1if not True: /' \
-  "$dead_not_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$dead_not_producer" >/dev/null 2>&1; then
-  failures+=("dead-not-producer-control-flow-counts-as-transport")
-fi
+handler_only="$(seed_candidate handler-only)"
+sed -i 's/^mediator_thread\.start()$/try: pass\nexcept RuntimeError: mediator_thread.start()/' "$handler_only/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected handler-only-start "$handler_only"
 
-conditional_start="$tmp/conditional-start"
-mkdir -p "$conditional_start/scripts"
-cp -R skills "$conditional_start/skills"
-cp scripts/build-release-asset.sh "$conditional_start/scripts/build-release-asset.sh"
-sed -E -i '/mediator_thread\.start\(\)/ s/^([[:space:]]*)/\1if os.environ.get("OPTIONAL_MEDIATOR"): /' \
-  "$conditional_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$conditional_start" >/dev/null 2>&1; then
-  failures+=("conditional-start-counts-as-mandatory-transport")
-fi
+decorated="$(seed_candidate decorated-noop)"
+sed -i '/^def run_bounded_stub()/i def nullify(fn): return lambda: None\n@nullify' "$decorated/skills/implementaudit/scripts/check-authorization-binding.sh"
+expect_rejected decorated-noop-stub "$decorated"
 
-conditional_launch="$tmp/conditional-launch"
-mkdir -p "$conditional_launch/scripts"
-cp -R skills "$conditional_launch/skills"
-cp scripts/build-release-asset.sh "$conditional_launch/scripts/build-release-asset.sh"
-sed -E -i '/completed = subprocess\.run\(launch/ s/^([[:space:]]*)/\1if os.environ.get("OPTIONAL_LAUNCH"): /' \
-  "$conditional_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$conditional_launch" >/dev/null 2>&1; then
-  failures+=("conditional-launch-counts-as-mandatory-transport")
-fi
+inert="$(seed_candidate inert-deferred)"
+sed -i '/^mediator_thread\.start()$/i deferred_lambda = lambda: sys.exit(0)\ndeferred_generator = (sys.exit(0) for _ in ())\n[sys.exit(0) for _ in []]' "$inert/skills/implementaudit/scripts/check-authorization-binding.sh"
+if ! bash "$reachability" --repo-root "$inert" >/dev/null 2>&1; then failures+=("inert-lambda-generator-empty-listcomp-rejects-live-route"); fi
 
-terminated_before_start="$tmp/terminated-before-start"
-mkdir -p "$terminated_before_start/scripts"
-cp -R skills "$terminated_before_start/skills"
-cp scripts/build-release-asset.sh "$terminated_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i raise SystemExit(0)' \
-  "$terminated_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$terminated_before_start" >/dev/null 2>&1; then
-  failures+=("terminated-path-before-start-counts-as-transport")
-fi
-
-exited_before_start="$tmp/exited-before-start"
-mkdir -p "$exited_before_start/scripts"
-cp -R skills "$exited_before_start/skills"
-cp scripts/build-release-asset.sh "$exited_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i sys.exit(0)' \
-  "$exited_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$exited_before_start" >/dev/null 2>&1; then
-  failures+=("system-exit-before-start-counts-as-transport")
-fi
-
-terminated_before_launch="$tmp/terminated-before-launch"
-mkdir -p "$terminated_before_launch/scripts"
-cp -R skills "$terminated_before_launch/skills"
-cp scripts/build-release-asset.sh "$terminated_before_launch/scripts/build-release-asset.sh"
-sed -i '/completed = subprocess\.run(launch/i\    raise SystemExit(0)' \
-  "$terminated_before_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$terminated_before_launch" >/dev/null 2>&1; then
-  failures+=("terminated-path-before-launch-counts-as-transport")
-fi
-
-reversed_sequence="$tmp/reversed-sequence"
-mkdir -p "$reversed_sequence/scripts"
-cp -R skills "$reversed_sequence/skills"
-cp scripts/build-release-asset.sh "$reversed_sequence/scripts/build-release-asset.sh"
-sed -i 's/^mediator_thread\.start()$/IMPLEMENTAUDIT_SWAP_START/' \
-  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
-sed -i 's/^mediator_thread\.join(3)$/mediator_thread.start()/' \
-  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
-sed -i 's/^IMPLEMENTAUDIT_SWAP_START$/mediator_thread.join(3)/' \
-  "$reversed_sequence/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$reversed_sequence" >/dev/null 2>&1; then
-  failures+=("reversed-start-join-counts-as-transport")
-fi
-
-split_error_path="$tmp/split-error-path"
-mkdir -p "$split_error_path/scripts"
-cp -R skills "$split_error_path/skills"
-cp scripts/build-release-asset.sh "$split_error_path/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.join(3)$/d' \
-  "$split_error_path/skills/implementaudit/scripts/check-authorization-binding.sh"
-sed -i '/^except OSError as exc:$/a\    mediator_thread.join(3)' \
-  "$split_error_path/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$split_error_path" >/dev/null 2>&1; then
-  failures+=("normal-start-error-only-join-counts-as-transport")
-fi
-
-conditional_expression_start="$tmp/conditional-expression-start"
-mkdir -p "$conditional_expression_start/scripts"
-cp -R skills "$conditional_expression_start/skills"
-cp scripts/build-release-asset.sh "$conditional_expression_start/scripts/build-release-asset.sh"
-sed -i 's/^mediator_thread\.start()$/mediator_thread.start() if OPTIONAL else None/' \
-  "$conditional_expression_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$conditional_expression_start" >/dev/null 2>&1; then
-  failures+=("conditional-expression-start-counts-as-transport")
-fi
-
-short_circuit_start="$tmp/short-circuit-start"
-mkdir -p "$short_circuit_start/scripts"
-cp -R skills "$short_circuit_start/skills"
-cp scripts/build-release-asset.sh "$short_circuit_start/scripts/build-release-asset.sh"
-sed -i 's/^mediator_thread\.start()$/OPTIONAL and mediator_thread.start()/' \
-  "$short_circuit_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$short_circuit_start" >/dev/null 2>&1; then
-  failures+=("short-circuit-start-counts-as-transport")
-fi
-
-inert_class_start="$tmp/inert-class-start"
-mkdir -p "$inert_class_start/scripts"
-cp -R skills "$inert_class_start/skills"
-cp scripts/build-release-asset.sh "$inert_class_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/c\class DeferredStart:\n    def run(self):\n        mediator_thread.start()' \
-  "$inert_class_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$inert_class_start" >/dev/null 2>&1; then
-  failures+=("uninstantiated-class-method-counts-as-transport")
-fi
-
-asserted_before_start="$tmp/asserted-before-start"
-mkdir -p "$asserted_before_start/scripts"
-cp -R skills "$asserted_before_start/skills"
-cp scripts/build-release-asset.sh "$asserted_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i assert False' \
-  "$asserted_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$asserted_before_start" >/dev/null 2>&1; then
-  failures+=("assert-false-before-start-counts-as-transport")
-fi
-
-conditional_expression_launch="$tmp/conditional-expression-launch"
-mkdir -p "$conditional_expression_launch/scripts"
-cp -R skills "$conditional_expression_launch/skills"
-cp scripts/build-release-asset.sh "$conditional_expression_launch/scripts/build-release-asset.sh"
-sed -i 's/completed = subprocess\.run(launch\["argv"\], env=run_env, check=False)/completed = subprocess.run(launch["argv"], env=run_env, check=False) if OPTIONAL else None/' \
-  "$conditional_expression_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$conditional_expression_launch" >/dev/null 2>&1; then
-  failures+=("conditional-expression-launch-counts-as-transport")
-fi
-
-assigned_exit_before_start="$tmp/assigned-exit-before-start"
-mkdir -p "$assigned_exit_before_start/scripts"
-cp -R skills "$assigned_exit_before_start/skills"
-cp scripts/build-release-asset.sh "$assigned_exit_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i terminated = sys.exit(0)' \
-  "$assigned_exit_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$assigned_exit_before_start" >/dev/null 2>&1; then
-  failures+=("assigned-exit-before-start-counts-as-transport")
-fi
-
-exit_test_before_start="$tmp/exit-test-before-start"
-mkdir -p "$exit_test_before_start/scripts"
-cp -R skills "$exit_test_before_start/skills"
-cp scripts/build-release-asset.sh "$exit_test_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i if sys.exit(0): pass' \
-  "$exit_test_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$exit_test_before_start" >/dev/null 2>&1; then
-  failures+=("terminating-if-test-before-start-counts-as-transport")
-fi
-
-empty_assert_before_start="$tmp/empty-assert-before-start"
-mkdir -p "$empty_assert_before_start/scripts"
-cp -R skills "$empty_assert_before_start/skills"
-cp scripts/build-release-asset.sh "$empty_assert_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i assert ()\nassert []' \
-  "$empty_assert_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$empty_assert_before_start" >/dev/null 2>&1; then
-  failures+=("empty-literal-assert-before-start-counts-as-transport")
-fi
-
-assigned_exit_before_producer="$tmp/assigned-exit-before-producer"
-mkdir -p "$assigned_exit_before_producer/scripts"
-cp -R skills "$assigned_exit_before_producer/skills"
-cp scripts/build-release-asset.sh "$assigned_exit_before_producer/scripts/build-release-asset.sh"
-sed -i '/result = subprocess\.run(command/i\            terminated = sys.exit(0)' \
-  "$assigned_exit_before_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$assigned_exit_before_producer" >/dev/null 2>&1; then
-  failures+=("assigned-exit-before-producer-counts-as-live-stub")
-fi
-
-short_circuit_compare_start="$tmp/short-circuit-compare-start"
-mkdir -p "$short_circuit_compare_start/scripts"
-cp -R skills "$short_circuit_compare_start/skills"
-cp scripts/build-release-asset.sh "$short_circuit_compare_start/scripts/build-release-asset.sh"
-sed -i 's/^mediator_thread\.start()$/0 == 1 == mediator_thread.start()/' \
-  "$short_circuit_compare_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$short_circuit_compare_start" >/dev/null 2>&1; then
-  failures+=("short-circuit-comparison-start-counts-as-transport")
-fi
-
-short_circuit_compare_launch="$tmp/short-circuit-compare-launch"
-mkdir -p "$short_circuit_compare_launch/scripts"
-cp -R skills "$short_circuit_compare_launch/skills"
-cp scripts/build-release-asset.sh "$short_circuit_compare_launch/scripts/build-release-asset.sh"
-sed -i 's/completed = subprocess\.run(launch\["argv"\], env=run_env, check=False)/completed = (0 == 1 == subprocess.run(launch["argv"], env=run_env, check=False))/' \
-  "$short_circuit_compare_launch/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$short_circuit_compare_launch" >/dev/null 2>&1; then
-  failures+=("short-circuit-comparison-launch-counts-as-transport")
-fi
-
-short_circuit_compare_producer="$tmp/short-circuit-compare-producer"
-mkdir -p "$short_circuit_compare_producer/scripts"
-cp -R skills "$short_circuit_compare_producer/skills"
-cp scripts/build-release-asset.sh "$short_circuit_compare_producer/scripts/build-release-asset.sh"
-sed -i 's/result = subprocess\.run(command, env=stub_env, check=False)/result = (0 == 1 == subprocess.run(command, env=stub_env, check=False))/' \
-  "$short_circuit_compare_producer/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$short_circuit_compare_producer" >/dev/null 2>&1; then
-  failures+=("short-circuit-comparison-producer-counts-as-live-stub")
-fi
-
-constant_assert_before_start="$tmp/constant-assert-before-start"
-mkdir -p "$constant_assert_before_start/scripts"
-cp -R skills "$constant_assert_before_start/skills"
-cp scripts/build-release-asset.sh "$constant_assert_before_start/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i assert 1 - 1\nassert 1 == 1 == 2' \
-  "$constant_assert_before_start/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$constant_assert_before_start" >/dev/null 2>&1; then
-  failures+=("constant-expression-assert-before-start-counts-as-transport")
-fi
-
-function_default_exit="$tmp/function-default-exit"
-mkdir -p "$function_default_exit/scripts"
-cp -R skills "$function_default_exit/skills"
-cp scripts/build-release-asset.sh "$function_default_exit/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i def deferred(value=sys.exit(0)): pass' \
-  "$function_default_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$function_default_exit" >/dev/null 2>&1; then
-  failures+=("function-default-exit-counts-as-transport")
-fi
-
-class_base_exit="$tmp/class-base-exit"
-mkdir -p "$class_base_exit/scripts"
-cp -R skills "$class_base_exit/skills"
-cp scripts/build-release-asset.sh "$class_base_exit/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i class Deferred(sys.exit(0)): pass' \
-  "$class_base_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$class_base_exit" >/dev/null 2>&1; then
-  failures+=("class-base-exit-counts-as-transport")
-fi
-
-class_body_exit="$tmp/class-body-exit"
-mkdir -p "$class_body_exit/scripts"
-cp -R skills "$class_body_exit/skills"
-cp scripts/build-release-asset.sh "$class_body_exit/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i class Deferred:\n    sys.exit(0)' \
-  "$class_body_exit/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$class_body_exit" >/dev/null 2>&1; then
-  failures+=("class-suite-exit-counts-as-transport")
-fi
-
-eager_list="$tmp/eager-list"
-mkdir -p "$eager_list/scripts"
-cp -R skills "$eager_list/skills"
-cp scripts/build-release-asset.sh "$eager_list/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i [sys.exit(0) for _ in [0]]' \
-  "$eager_list/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$eager_list" >/dev/null 2>&1; then
-  failures+=("eager-listcomp-element-exit-counts-as-transport")
-fi
-
-eager_set="$tmp/eager-set"
-mkdir -p "$eager_set/scripts"
-cp -R skills "$eager_set/skills"
-cp scripts/build-release-asset.sh "$eager_set/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i {sys.exit(0) for _ in [0]}' \
-  "$eager_set/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$eager_set" >/dev/null 2>&1; then
-  failures+=("eager-setcomp-element-exit-counts-as-transport")
-fi
-
-eager_dict_key="$tmp/eager-dict-key"
-mkdir -p "$eager_dict_key/scripts"
-cp -R skills "$eager_dict_key/skills"
-cp scripts/build-release-asset.sh "$eager_dict_key/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i {sys.exit(0): 0 for _ in [0]}' \
-  "$eager_dict_key/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$eager_dict_key" >/dev/null 2>&1; then
-  failures+=("eager-dictcomp-key-exit-counts-as-transport")
-fi
-
-eager_dict_value="$tmp/eager-dict-value"
-mkdir -p "$eager_dict_value/scripts"
-cp -R skills "$eager_dict_value/skills"
-cp scripts/build-release-asset.sh "$eager_dict_value/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i {0: sys.exit(0) for _ in [0]}' \
-  "$eager_dict_value/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$eager_dict_value" >/dev/null 2>&1; then
-  failures+=("eager-dictcomp-value-exit-counts-as-transport")
-fi
-
-eager_decorator="$tmp/eager-decorator"
-mkdir -p "$eager_decorator/scripts"
-cp -R skills "$eager_decorator/skills"
-cp scripts/build-release-asset.sh "$eager_decorator/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i @(lambda fn: sys.exit(0))\ndef Deferred(): pass' \
-  "$eager_decorator/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$eager_decorator" >/dev/null 2>&1; then
-  failures+=("decorator-application-exit-counts-as-transport")
-fi
-
-deleted_stub="$tmp/deleted-stub"
-mkdir -p "$deleted_stub/scripts"
-cp -R skills "$deleted_stub/skills"
-cp scripts/build-release-asset.sh "$deleted_stub/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread = threading\.Thread/i del run_bounded_stub' \
-  "$deleted_stub/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$deleted_stub" >/dev/null 2>&1; then
-  failures+=("deleted-stub-definition-counts-as-live-producer")
-fi
-
-deleted_thread="$tmp/deleted-thread"
-mkdir -p "$deleted_thread/scripts"
-cp -R skills "$deleted_thread/skills"
-cp scripts/build-release-asset.sh "$deleted_thread/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i del mediator_thread' \
-  "$deleted_thread/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$deleted_thread" >/dev/null 2>&1; then
-  failures+=("deleted-thread-binding-counts-as-live-transport")
-fi
-
-empty_list="$tmp/empty-list"
-mkdir -p "$empty_list/scripts"
-cp -R skills "$empty_list/skills"
-cp scripts/build-release-asset.sh "$empty_list/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i [sys.exit(0) for _ in []]' \
-  "$empty_list/skills/implementaudit/scripts/check-authorization-binding.sh"
-if ! bash "$reachability" --repo-root "$empty_list" >/dev/null 2>&1; then
-  failures+=("empty-listcomp-body-rejects-live-route")
-fi
-
-overwritten_stub="$tmp/overwritten-stub"
-mkdir -p "$overwritten_stub/scripts"
-cp -R skills "$overwritten_stub/skills"
-cp scripts/build-release-asset.sh "$overwritten_stub/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread = threading\.Thread/i run_bounded_stub = lambda: None' \
-  "$overwritten_stub/skills/implementaudit/scripts/check-authorization-binding.sh"
-if bash "$reachability" --repo-root "$overwritten_stub" >/dev/null 2>&1; then
-  failures+=("overwritten-stub-definition-counts-as-live-producer")
-fi
-
-inert_deferred_bodies="$tmp/inert-deferred-bodies"
-mkdir -p "$inert_deferred_bodies/scripts"
-cp -R skills "$inert_deferred_bodies/skills"
-cp scripts/build-release-asset.sh "$inert_deferred_bodies/scripts/build-release-asset.sh"
-sed -i '/^mediator_thread\.start()$/i deferred_lambda = lambda: sys.exit(0)\ndeferred_generator = (sys.exit(0) for _ in ())' \
-  "$inert_deferred_bodies/skills/implementaudit/scripts/check-authorization-binding.sh"
-if ! bash "$reachability" --repo-root "$inert_deferred_bodies" >/dev/null 2>&1; then
-  failures+=("inert-lambda-or-generator-body-rejects-live-route")
-fi
-
-if ! grep -Fqx \
-  'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' \
-  skills/implementaudit/references/repo-state-comparison.md; then
-  failures+=("rehearsal-route-is-generic-prose-and-direct-test-only")
-fi
+if ! grep -Fqx 'helper-mode: check-authorization-binding.sh|--phase --rehearsal --launch|<phase> <receipt> <launch>|failed-rehearsal-blocks-launch|scripts/validate-phase.sh' skills/implementaudit/references/repo-state-comparison.md; then failures+=("rehearsal-route-is-generic-prose-and-direct-test-only"); fi
 
 asset_dir="$tmp/r33-asset"
 bash scripts/build-release-asset.sh "$asset_dir" >/dev/null
-if [ "$(wc -c < "$asset_dir/IMPLEMENTAUDIT.skill")" -gt 228000 ]; then
-  failures+=("r33-package-capacity-over-228000")
-fi
+if [ "$(wc -c < "$asset_dir/IMPLEMENTAUDIT.skill")" -gt 228000 ]; then failures+=("r33-package-capacity-over-228000"); fi
 
 if [ "${#failures[@]}" -gt 0 ]; then
   printf 'r11-r30-review-heldouts: GAP-REVISE reproduced: %s\n' "${failures[*]}" >&2

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 outer_timeout_only=0
 windows_custody_only=0
+candidate_probe_only=0
 case "${1:-}" in
   --outer-timeout-heldout) outer_timeout_only=1; shift;;
   --windows-custody-reproducer) windows_custody_only=1; shift;;
+  --candidate-probe-heldout) candidate_probe_only=1; shift;;
 esac
-[ "$#" -eq 0 ] || { printf 'usage: r11-r30-review-heldouts.test.sh [--outer-timeout-heldout]\n' >&2; exit 2; }
+[ "$#" -eq 0 ] || { printf 'usage: r11-r30-review-heldouts.test.sh [--outer-timeout-heldout|--candidate-probe-heldout]\n' >&2; exit 2; }
 cd "$repo_root"
 
 checker="skills/implementaudit/scripts/check-authorization-binding.sh"
@@ -179,6 +181,14 @@ seed_candidate() {
   cp fixtures/run-root-example/phases/phase-1.md "$candidate/fixtures/run-root-example/phases/"
   printf '%s\n' "$candidate"
 }
+seed_probe_authority() {
+  local authority="$tmp/$1"
+  mkdir -p "$authority/scripts" "$authority/tests"
+  cp "$reachability" "$authority/scripts/check-helper-reachability.sh"
+  cp tests/scarce-resource-rehearsal-contract.test.sh \
+    "$authority/tests/scarce-resource-rehearsal-contract.test.sh"
+  printf '%s\n' "$authority"
+}
 expect_rejected() {
   local label="$1" candidate="$2"
   if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then failures+=("$label"); fi
@@ -190,6 +200,28 @@ expect_rejected_with_diagnostic() {
   elif ! grep -Fq "$expected" <<<"$output"; then
     failures+=("$label-diagnostic-lost")
   fi
+}
+expect_authority_probe_timeout() {
+  local label="$1" expected="$2" candidate="$3" authority="$4" output
+  if output="$(bash "$authority/scripts/check-helper-reachability.sh" --repo-root "$candidate" 2>&1)"; then
+    failures+=("$label")
+  elif ! grep -Fq "$expected" <<<"$output"; then
+    failures+=("$label-diagnostic-lost")
+  fi
+}
+stall_probe_authority() {
+  local authority="$1"
+  python - "$authority/tests/scarce-resource-rehearsal-contract.test.sh" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+injection = 'printf "outer-timeout-diagnostic\\n" >&2\nsleep 60 &\nprintf "%s\\n" "$!" > "$PWD/.outer-timeout-child.pid"\nwait\n'
+if text.count("checker=") != 1:
+    raise SystemExit("expected one checker binding")
+path.write_text(text.replace("checker=", injection + "checker="), encoding="utf-8")
+PY
 }
 expect_no_pid() {
   local label="$1" pid_file="$2"
@@ -207,21 +239,25 @@ os.kill(pid, 9)
 raise SystemExit(1)
 PY
 }
+if [ "$candidate_probe_only" -eq 1 ]; then
+  self_authorized="$(seed_candidate candidate-owned-probe)"
+  sed -i 's/--rehearsal)/--receipt)/' \
+    "$self_authorized/skills/implementaudit/scripts/check-authorization-binding.sh"
+  printf 'exit 0\n' > "$self_authorized/tests/scarce-resource-rehearsal-contract.test.sh"
+  chmod +x "$self_authorized/tests/scarce-resource-rehearsal-contract.test.sh"
+  if bash "$reachability" --repo-root "$self_authorized" >/dev/null 2>&1; then
+    printf '%s\n' 'r11-r30-review-heldouts: GAP-REVISE reproduced: candidate-owned-probe-self-authorizes' >&2
+    exit 1
+  fi
+  printf '%s\n' 'r11-r30-review-heldouts: candidate-probe heldout ok'
+  exit 0
+fi
 if [ "$outer_timeout_only" -eq 1 ]; then
   stalled_consumer="$(seed_candidate stalled-consumer)"
-  python - "$stalled_consumer/tests/scarce-resource-rehearsal-contract.test.sh" <<'PY'
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8")
-injection = 'printf "outer-timeout-diagnostic\\n" >&2\nsleep 60 &\nprintf "%s\\n" "$!" > "$PWD/.outer-timeout-child.pid"\nwait\n'
-if text.count("checker=") != 1:
-    raise SystemExit("expected one checker binding")
-path.write_text(text.replace("checker=", injection + "checker="), encoding="utf-8")
-PY
-  expect_rejected_with_diagnostic stalled-candidate-process-tree \
-    'outer-timeout-diagnostic' "$stalled_consumer"
+  stalled_authority="$(seed_probe_authority stalled-authority)"
+  stall_probe_authority "$stalled_authority"
+  expect_authority_probe_timeout stalled-authority-process-tree \
+    'outer-timeout-diagnostic' "$stalled_consumer" "$stalled_authority"
   expect_no_pid stalled-candidate-process-tree "$stalled_consumer/.outer-timeout-child.pid"
   if [ "${#failures[@]}" -gt 0 ]; then
     printf 'r11-r30-review-heldouts: GAP-REVISE reproduced: %s\n' "${failures[*]}" >&2
@@ -236,6 +272,12 @@ fi
 missing="$(seed_candidate missing)"
 sed -i 's/--rehearsal)/--receipt)/' "$missing/skills/implementaudit/scripts/check-authorization-binding.sh"
 expect_rejected missing-parser-arm "$missing"
+
+self_authorized="$(seed_candidate candidate-owned-probe)"
+sed -i 's/--rehearsal)/--receipt)/' "$self_authorized/skills/implementaudit/scripts/check-authorization-binding.sh"
+printf 'exit 0\n' > "$self_authorized/tests/scarce-resource-rehearsal-contract.test.sh"
+chmod +x "$self_authorized/tests/scarce-resource-rehearsal-contract.test.sh"
+expect_rejected candidate-owned-probe-self-authorizes "$self_authorized"
 
 optional="$(seed_candidate optional)"
 sed -i 's/^mediator_thread\.start()$/if os.environ.get("R30_OPTIONAL"): mediator_thread.start()/' "$optional/skills/implementaudit/scripts/check-authorization-binding.sh"
@@ -287,10 +329,11 @@ expect_rejected_with_diagnostic dead-static-invocation-with-copied-terminal \
   'R30 native phase route did not invoke the declared helper' "$dead_consumer"
 
 stalled_consumer="$(seed_candidate stalled-consumer)"
-sed -i '/^checker=/i printf "outer-timeout-diagnostic\\n" >&2\nsleep 60' \
-  "$stalled_consumer/tests/scarce-resource-rehearsal-contract.test.sh"
-expect_rejected_with_diagnostic stalled-candidate-process-tree \
-  'outer-timeout-diagnostic' "$stalled_consumer"
+stalled_authority="$(seed_probe_authority stalled-authority)"
+stall_probe_authority "$stalled_authority"
+expect_authority_probe_timeout stalled-authority-process-tree \
+  'outer-timeout-diagnostic' "$stalled_consumer" "$stalled_authority"
+expect_no_pid stalled-authority-process-tree "$stalled_consumer/.outer-timeout-child.pid"
 
 inert="$(seed_candidate inert-deferred)"
 sed -i '/^mediator_thread\.start()$/i deferred_lambda = lambda: sys.exit(0)\ndeferred_generator = (sys.exit(0) for _ in ())\n[sys.exit(0) for _ in []]' "$inert/skills/implementaudit/scripts/check-authorization-binding.sh"

--- a/tests/r11-r30-review-heldouts.test.sh
+++ b/tests/r11-r30-review-heldouts.test.sh
@@ -21,80 +21,102 @@ stub = root / "producer-stub.py"
 stub.write_text("#!/usr/bin/env python3\nraise SystemExit(23)\n", encoding="utf-8")
 stub.chmod(0o755)
 
-wrapper = root / "forging-wrapper.py"
-wrapper.write_text('''#!/usr/bin/env python3
-import json, os, pathlib
-pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF"]).write_text(
-    os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"] + "\\n", encoding="utf-8")
-pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_TERMINAL"]).write_text(
-    os.environ["IMPLEMENTAUDIT_TEST_RECEIPT"] + "\\n", encoding="utf-8")
-if os.environ.get("HELDOUT_CREDENTIAL_SENTINEL"):
-    pathlib.Path(os.environ["IMPLEMENTAUDIT_TEST_INHERITED_MARKER"]).write_text("visible\\n", encoding="utf-8")
-''', encoding="utf-8")
-wrapper.chmod(0o755)
+def wrapper(name, body):
+    path = root / name
+    path.write_text("#!/usr/bin/env python3\n" + body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
 
-def payload(suffix, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"]):
-    terminal = root / f"terminal-{suffix}.json"
-    argv = [sys.executable, str(wrapper), "--input", argv_suffix]
-    command_hash = hashlib.sha256(json.dumps(
+# This candidate never invokes its declared producer.  On ada87d it can forge
+# the wrapper-visible event path/nonce and thereby falsely pass.
+forging = wrapper("forging-wrapper.py", '''import hashlib, json, os, pathlib
+stub = pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"])
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(json.dumps({
+  "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+  "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"], "exit_code": 0}), encoding="utf-8")
+''')
+ignoring = wrapper("ignoring-wrapper.py", '''import hashlib, json, os, pathlib, subprocess, sys
+stub = pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"])
+subprocess.run([sys.executable, stub], check=False)
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(json.dumps({
+  "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+  "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"], "exit_code": 0}), encoding="utf-8")
+''')
+leaking = wrapper("leaking-wrapper.py", '''import hashlib, json, os, pathlib
+stub = pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"])
+if os.environ.get("HELDOUT_CREDENTIAL_SENTINEL"):
+  pathlib.Path(os.environ["IMPLEMENTAUDIT_TEST_INHERITED_MARKER"]).write_text("visible\\n", encoding="utf-8")
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(json.dumps({
+  "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+  "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"], "exit_code": 0}), encoding="utf-8")
+''')
+
+def canonical_hash(argv, env_keys):
+    return hashlib.sha256(json.dumps(
         {"argv": argv, "env_keys_present": sorted(env_keys)},
         separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
-    receipt = {
-        "rehearsed_command_hash": command_hash,
-        "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
-        "stubbed_components": ["producer"],
-        "env_keys_present": env_keys,
-        "terminal_artifact_path": str(terminal),
-        "exit_code": 0,
-        "disposition": "PASS",
-        "timestamp": "2026-08-11T12:00:00Z",
-    }
-    launch = {
-        "argv": argv,
-        "env_keys_present": env_keys,
-        "terminal_artifact_path": str(terminal),
-        "launch_records": 1,
-        "metered_calls": 0,
-    }
-    (root / f"receipt-{suffix}.json").write_text(json.dumps(receipt), encoding="utf-8")
-    (root / f"launch-{suffix}.json").write_text(json.dumps(launch), encoding="utf-8")
-    return receipt
 
-(root / "phase.md").write_text("Scarce resource budget: 1 model-call\nResidual risk: none\n", encoding="utf-8")
-for suffix, argv_suffix, keys in (
-    ("forged", "fixture.txt", ["API_TOKEN", "MODEL"]),
-    ("changed", "changed-fixture.txt", ["ALT_TOKEN"]),
-    ("nonzero", "fixture.txt", ["API_TOKEN", "MODEL"]),
-    ("inherited", "fixture.txt", ["API_TOKEN", "MODEL"]),
-):
-    receipt = payload(suffix, argv_suffix, keys)
-    (root / f"receipt-env-{suffix}.txt").write_text(json.dumps(receipt), encoding="utf-8")
+def payload(suffix, wrapper_path, argv_suffix="fixture.txt", env_keys=["API_TOKEN", "MODEL"]):
+    terminal = root / f"terminal-{suffix}.json"
+    argv = [sys.executable, str(wrapper_path), "--input", argv_suffix]
+    receipt = {
+        "rehearsed_command_hash": canonical_hash(argv, env_keys),
+        "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
+        "stubbed_components": ["producer"], "env_keys_present": env_keys,
+        "terminal_artifact_path": str(terminal), "exit_code": 0,
+        "disposition": "PASS", "timestamp": "2026-08-11T12:00:00Z",
+    }
+    launch = {"argv": argv, "env_keys_present": env_keys,
+              "terminal_artifact_path": str(terminal), "launch_records": 1,
+              "metered_calls": 0}
+    receipt_path, launch_path = root / f"receipt-{suffix}.json", root / f"launch-{suffix}.json"
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    launch_path.write_text(json.dumps(launch), encoding="utf-8")
+    return receipt, receipt_path, launch_path
+
+def complete_phase(name, receipt, receipt_path, launch_path):
+    base = pathlib.Path("fixtures/run-root-example/phases/phase-1.md").read_text(encoding="utf-8")
+    fields = (
+        "Scarce resource budget: 1 model-call\n"
+        f"Rehearsal receipt: {receipt_path}\nRehearsal launch: {launch_path}\n"
+        f"Rehearsal producer stub: {stub}\n"
+        f"Rehearsal command hash: {receipt['rehearsed_command_hash']}\n"
+        f"Rehearsal terminal artifact: {receipt['terminal_artifact_path']}\n"
+        f"Rehearsal environment keys: {','.join(receipt['env_keys_present'])}\n"
+    )
+    path = root / name
+    path.write_text(base.replace("Depends on phases: none\n", "Depends on phases: none\n" + fields), encoding="utf-8")
+    return path
+
+forged, forged_receipt, forged_launch = payload("forged", forging)
+ignored, ignored_receipt, ignored_launch = payload("ignored", ignoring)
+inherited, inherited_receipt, inherited_launch = payload("inherited", leaking)
+changed, changed_receipt, changed_launch = payload("changed", forging, "changed-fixture.txt", ["ALT_TOKEN"])
+complete_phase("phase-forged.md", forged, forged_receipt, forged_launch)
+complete_phase("phase-ignored.md", ignored, ignored_receipt, ignored_launch)
+complete_phase("phase-inherited.md", inherited, inherited_receipt, inherited_launch)
 PY
 
 heldout_passes() {
-  local suffix="$1" marker="${2:-}"
-  local receipt
-  receipt="$(<"$tmp/receipt-env-$suffix.txt")"
+  local phase="$1" receipt="$2" launch="$3" marker="${4:-}"
   API_TOKEN=real-api-token MODEL=real-model-token ALT_TOKEN=real-alt-token \
   HELDOUT_CREDENTIAL_SENTINEL=must-not-reach-wrapper \
   IMPLEMENTAUDIT_TEST_INHERITED_MARKER="$marker" \
-  IMPLEMENTAUDIT_TEST_RECEIPT="$receipt" \
   IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
-  bash "$checker" --phase "$tmp/phase.md" \
-    --rehearsal "$tmp/receipt-$suffix.json" --launch "$tmp/launch-$suffix.json" \
+  bash "$checker" --phase "$phase" --rehearsal "$receipt" --launch "$launch" \
     >/dev/null 2>&1
 }
 
-if heldout_passes forged "$tmp/forged-inherited"; then
-  failures+=("wrapper-forges-proof-and-terminal-without-stub")
+if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-forged.json" "$tmp/launch-forged.json"; then
+  failures+=("wrapper-forges-wrapper-visible-event-without-stub")
 fi
-if heldout_passes changed "$tmp/changed-inherited"; then
+if heldout_passes "$tmp/phase-forged.md" "$tmp/receipt-changed.json" "$tmp/launch-changed.json"; then
   failures+=("self-consistent-changed-argv-env-terminal-pass")
 fi
-if heldout_passes nonzero "$tmp/nonzero-inherited"; then
+if heldout_passes "$tmp/phase-ignored.md" "$tmp/receipt-ignored.json" "$tmp/launch-ignored.json"; then
   failures+=("stub-exit-23-ignored-by-wrapper-passes")
 fi
-if heldout_passes inherited "$tmp/inherited-marker" \
+if heldout_passes "$tmp/phase-inherited.md" "$tmp/receipt-inherited.json" "$tmp/launch-inherited.json" "$tmp/inherited-marker" \
     && [ -f "$tmp/inherited-marker" ]; then
   failures+=("undeclared-credential-sentinel-reaches-wrapper")
 fi
@@ -105,10 +127,15 @@ cp -R skills "$candidate/skills"
 cp scripts/build-release-asset.sh "$candidate/scripts/build-release-asset.sh"
 sed -i 's/--rehearsal)/--receipt)/' \
   "$candidate/skills/implementaudit/scripts/check-authorization-binding.sh"
-printf '\n# inert --rehearsal literal retained by a comment\n' \
-  >>"$candidate/skills/implementaudit/scripts/check-authorization-binding.sh"
+cat >>"$candidate/skills/implementaudit/scripts/check-authorization-binding.sh" <<'EOF'
+cat <<'INERT_MODE'
+--phase)
+--rehearsal)
+--launch)
+INERT_MODE
+EOF
 if bash "$reachability" --repo-root "$candidate" >/dev/null 2>&1; then
-  failures+=("inert-rehearsal-literal-counts-as-implemented-mode")
+  failures+=("inert-heredoc-literal-counts-as-parser-arm")
 fi
 
 if ! grep -Fqx \

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -735,10 +735,14 @@ with zipfile.ZipFile(asset) as zf:
     OWNER_OUTER_BOUND_BYTES = 230_000
     MIN_HEADROOM_BYTES = 2_000
     CALIBRATION_QUANTUM_BYTES = 1_000
-    CURRENT_CALIBRATION_AUTHORITY = "owner"
+    CURRENT_CALIBRATION_AUTHORITY = "dedicated-calibration-lane"
     ALLOWED_CALIBRATION_AUTHORITIES = {
         "owner", "dedicated-calibration-lane",
     }
+    if CURRENT_CALIBRATION_AUTHORITY != "dedicated-calibration-lane":
+        raise SystemExit(
+            "current calibration authority must name the dedicated R33 lane"
+        )
 
     # The composed R11/R30 rehearsal repair raises the canonical Zopfli
     # method-8 package to 225,318 bytes. This dedicated R33 calibration uses the

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -744,13 +744,14 @@ with zipfile.ZipFile(asset) as zf:
             "current calibration authority must name the dedicated R33 lane"
         )
 
-    # The composed R11/R30 rehearsal repair raises the canonical Zopfli
-    # method-8 package to 225,318 bytes. This dedicated R33 calibration uses the
-    # smallest whole-1,000-byte value preserving at least 2,000 bytes of
-    # measured headroom. The 230,000-byte outer bound remains unchanged, and
-    # capacity is not a target.
+    # The composed R11/R30 rehearsal repair first measured 225,318 bytes.
+    # Its accepted packaged timeout/process-custody semantics then measure
+    # 225,945 bytes. This dedicated R33 calibration keeps the smallest
+    # whole-1,000-byte ceiling preserving at least 2,000 bytes of measured
+    # headroom. The 230,000-byte outer bound remains unchanged, and capacity
+    # is not a target.
     MAX_ASSET_BYTES = 228_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 225_318
+    CURRENT_CALIBRATION_ASSET_BYTES = 225_945
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -740,13 +740,13 @@ with zipfile.ZipFile(asset) as zf:
         "owner", "dedicated-calibration-lane",
     }
 
-    # The R02 verification-window repair raises the canonical Zopfli method-8
-    # package to 224,179 bytes. This dedicated R33 calibration uses the
+    # The composed R11/R30 rehearsal repair raises the canonical Zopfli
+    # method-8 package to 225,318 bytes. This dedicated R33 calibration uses the
     # smallest whole-1,000-byte value preserving at least 2,000 bytes of
     # measured headroom. The 230,000-byte outer bound remains unchanged, and
     # capacity is not a target.
-    MAX_ASSET_BYTES = 227_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 224_179
+    MAX_ASSET_BYTES = 228_000
+    CURRENT_CALIBRATION_ASSET_BYTES = 225_318
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -12,6 +12,46 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 fail() { printf 'scarce-resource-rehearsal-contract: %s\n' "$*" >&2; exit 1; }
 
+# The declared wrapper is the production-side launch boundary.  It deliberately
+# does nothing unless the checker supplies the bounded producer substitute and
+# terminal destination. The stub emits only its derived identity, and the
+# wrapper emits the terminal record after that bounded call.
+cat > "$tmp/production-wrapper.py" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+stub = os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]
+terminal = os.environ["IMPLEMENTAUDIT_REHEARSAL_TERMINAL"]
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_WRAPPER_PROOF"]).write_text("production-wrapper\n", encoding="utf-8")
+subprocess.run([sys.executable, stub], check=True)
+components = ["producer", "terminal-writer"] if os.environ.get("IMPLEMENTAUDIT_TEST_SCOPE_GAP") else ["producer"]
+receipt = {
+    "rehearsed_command_hash": os.environ["IMPLEMENTAUDIT_REHEARSAL_COMMAND_HASH"],
+    "stub_identity": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"],
+    "stubbed_components": components,
+    "env_keys_present": json.loads(os.environ["IMPLEMENTAUDIT_REHEARSAL_ENV_KEYS"]),
+    "terminal_artifact_path": terminal,
+    "exit_code": 0,
+    "disposition": "PASS_WITH_SCOPE_GAP" if len(components) > 1 else "PASS",
+    "timestamp": "2026-08-06T12:00:00Z",
+}
+pathlib.Path(terminal).write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+PY
+cat > "$tmp/producer-stub.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import pathlib
+
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF"]).write_text(
+    os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"] + "\n", encoding="utf-8"
+)
+PY
+chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py"
+
 cat > "$tmp/phase-budget.md" <<'EOF'
 Scarce resource budget: 2 model-calls
 Residual risk: none
@@ -29,7 +69,7 @@ Scarce resource budget: 2 model-calls
 Residual risk: none
 EOF
 
-python - "$fixture" "$tmp" <<'PY'
+python - "$fixture" "$tmp" "$tmp/production-wrapper.py" "$tmp/rehearsal-terminal.json" "$tmp/producer-stub.py" <<'PY'
 import copy
 import hashlib
 import json
@@ -38,6 +78,9 @@ import sys
 
 fixture = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 out = pathlib.Path(sys.argv[2])
+wrapper = sys.argv[3]
+terminal = sys.argv[4]
+stub = pathlib.Path(sys.argv[5])
 
 def canonical_hash(argv, env_keys):
     preimage = json.dumps(
@@ -48,18 +91,18 @@ def canonical_hash(argv, env_keys):
     return hashlib.sha256(preimage).hexdigest()
 
 launch = {
-    "argv": fixture["argv"],
+    "argv": [sys.executable, wrapper, "--input", "fixture.txt"],
     "env_keys_present": fixture["env_keys_present"],
-    "terminal_artifact_path": fixture["terminal_artifact_path"],
+    "terminal_artifact_path": terminal,
     "launch_records": 1,
     "metered_calls": 0,
 }
 receipt = {
     "rehearsed_command_hash": canonical_hash(launch["argv"], launch["env_keys_present"]),
-    "stub_identity": fixture["stub_identity"],
+    "stub_identity": "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest(),
     "stubbed_components": ["producer"],
     "env_keys_present": fixture["env_keys_present"],
-    "terminal_artifact_path": fixture["terminal_artifact_path"],
+    "terminal_artifact_path": terminal,
     "exit_code": 0,
     "disposition": "PASS",
     "timestamp": "2026-08-06T12:00:00Z",
@@ -70,6 +113,10 @@ def write(name, value):
 
 write("launch-good.json", launch)
 write("receipt-good.json", receipt)
+
+gap_launch = copy.deepcopy(launch)
+gap_launch["terminal_artifact_path"] = str(out / "rehearsal-gap-terminal.json")
+write("launch-gap.json", gap_launch)
 
 f1_launch = copy.deepcopy(launch)
 f1_launch.update(argv=[], launch_records=0, metered_calls=0)
@@ -89,6 +136,7 @@ write("launch-drift.json", drift_launch)
 gap = copy.deepcopy(receipt)
 gap["stubbed_components"] = ["producer", "terminal-writer"]
 gap["disposition"] = "PASS_WITH_SCOPE_GAP"
+gap["terminal_artifact_path"] = gap_launch["terminal_artifact_path"]
 write("receipt-gap.json", gap)
 
 extra = copy.deepcopy(receipt)
@@ -136,6 +184,12 @@ must_fail() {
 rehearse() {
   bash "$checker" --phase "$1" --rehearsal "$2" --launch "$3"
 }
+run_production_rehearsal() {
+  API_TOKEN=fixture-token MODEL=fixture-model \
+  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
+  IMPLEMENTAUDIT_REHEARSAL_WRAPPER_PROOF="$tmp/wrapper-proof" \
+  "$@"
+}
 
 # F1: a failed malformed-argv rehearsal cannot authorize launch; the fixture
 # independently proves that neither a launch record nor a metered call occurred.
@@ -156,12 +210,24 @@ must_pass F4 bash "$checker" --phase "$tmp/phase-none.md"
 
 # F5: interposed stubbing is a scope gap and every extra component must be
 # named by the phase's residual-risk statement.
-must_fail F5-missing-residual rehearse "$tmp/phase-gap-missing.md" "$tmp/receipt-gap.json" "$tmp/launch-good.json"
-must_pass F5-matched-residual rehearse "$tmp/phase-gap.md" "$tmp/receipt-gap.json" "$tmp/launch-good.json"
+must_fail F5-missing-residual rehearse "$tmp/phase-gap-missing.md" "$tmp/receipt-gap.json" "$tmp/launch-gap.json"
+
+# F9: a self-consistent receipt and launch declaration cannot establish a
+# rehearsal while the declared production wrapper and bounded producer stub
+# have not executed. This was intentionally RED against the former inert
+# checker and remains the detached-record false-positive control.
+must_fail F9-static-record-false-positive rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-good.json"
+[ ! -e "$tmp/wrapper-proof" ] || fail "F9 must not claim wrapper execution from a static record"
+[ ! -e "$tmp/stub-proof" ] || fail "F9 must not claim stub execution from a static record"
+
+IMPLEMENTAUDIT_TEST_SCOPE_GAP=1 \
+must_pass F5-matched-residual run_production_rehearsal rehearse "$tmp/phase-gap.md" "$tmp/receipt-gap.json" "$tmp/launch-gap.json"
 
 # F7: a repaired receipt may pass on a manual re-run. The policy itself must
 # keep that repair manual and forbid automatic retries.
-must_pass F7 rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-good.json"
+unset IMPLEMENTAUDIT_TEST_SCOPE_GAP
+must_pass F7 run_production_rehearsal rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-good.json"
+[ -f "$tmp/wrapper-proof" ] || fail "F7 production wrapper did not execute"
 
 # F8: strict schemas reject extras, value-bearing fields/key-value strings,
 # ordering/uniqueness violations, and booleans masquerading as integers.
@@ -180,9 +246,10 @@ p412="$(grep -n '^\*\*Rule P4-12 ' "$policy" | cut -d: -f1)"
 [ "$p410" -lt "$p411" ] && [ "$p411" -lt "$p412" ] || fail "P4-11 must sit between P4-10 and P4-12"
 p411_text="$(sed -n "${p411},$((p412 - 1))p" "$policy" | tr '\n' ' ')"
 printf '%s' "$p411_text" | grep -qi 'exact.*wrapper.*argv.*environment-key.*terminal' || fail "P4-11 missing exact apparatus identity"
+printf '%s' "$p411_text" | grep -Fq 'IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB' || fail "P4-11 missing bounded producer substitution control"
 printf '%s' "$p411_text" | grep -qi 'second apparatus.*cold review' || fail "F6 second-apparatus judgment must remain cold review"
 printf '%s' "$p411_text" | grep -qi 'manual repair.*re-run' || fail "F7 manual repair/re-run rule missing"
 printf '%s' "$p411_text" | grep -qi 'no automatic retr\|must not automatically retr' || fail "F7 automatic retry prohibition missing"
 grep -q '^Scarce resource budget: {{N <resource> | none}}$' "$template" || fail "phase budget field missing"
 
-printf 'scarce-resource-rehearsal-contract: ok (F1-F8; zero metered calls)\n'
+printf 'scarce-resource-rehearsal-contract: ok (F1-F9; zero metered calls)\n'

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -12,45 +12,56 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 fail() { printf 'scarce-resource-rehearsal-contract: %s\n' "$*" >&2; exit 1; }
 
-# The declared wrapper is the production-side launch boundary.  It deliberately
-# does nothing unless the checker supplies the bounded producer substitute and
-# terminal destination. The stub emits only its derived identity, and the
-# wrapper emits the terminal record after that bounded call.
+# The declared wrapper is the production-side launch boundary.  It receives no
+# terminal or receipt controls: it propagates the bounded producer result, and
+# the producer alone emits its execution event.  The checker is the terminal
+# author after observing that event.
 cat > "$tmp/production-wrapper.py" <<'PY'
 #!/usr/bin/env python3
-import json
 import os
-import pathlib
 import subprocess
 import sys
 
 stub = os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]
-terminal = os.environ["IMPLEMENTAUDIT_REHEARSAL_TERMINAL"]
-pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_WRAPPER_PROOF"]).write_text("production-wrapper\n", encoding="utf-8")
-subprocess.run([sys.executable, stub], check=True)
-components = ["producer", "terminal-writer"] if os.environ.get("IMPLEMENTAUDIT_TEST_SCOPE_GAP") else ["producer"]
-receipt = {
-    "rehearsed_command_hash": os.environ["IMPLEMENTAUDIT_REHEARSAL_COMMAND_HASH"],
-    "stub_identity": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"],
-    "stubbed_components": components,
-    "env_keys_present": json.loads(os.environ["IMPLEMENTAUDIT_REHEARSAL_ENV_KEYS"]),
-    "terminal_artifact_path": terminal,
-    "exit_code": 0,
-    "disposition": "PASS_WITH_SCOPE_GAP" if len(components) > 1 else "PASS",
-    "timestamp": "2026-08-06T12:00:00Z",
-}
-pathlib.Path(terminal).write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+if os.environ.get("HELDOUT_CREDENTIAL_SENTINEL"):
+    raise SystemExit("caller credential sentinel leaked into wrapper")
+if os.environ.get("API_TOKEN") != "" or os.environ.get("MODEL") != "":
+    raise SystemExit("declared environment keys must be empty rehearsal placeholders")
+raise SystemExit(subprocess.run([sys.executable, stub], check=False).returncode)
 PY
 cat > "$tmp/producer-stub.py" <<'PY'
 #!/usr/bin/env python3
+import hashlib
+import json
 import os
 import pathlib
+import sys
 
-pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF"]).write_text(
-    os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_IDENTITY"] + "\n", encoding="utf-8"
+identity = "sha256:" + hashlib.sha256(pathlib.Path(__file__).read_bytes()).hexdigest()
+exit_code = int(os.environ.get("IMPLEMENTAUDIT_TEST_STUB_EXIT", "0"))
+pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(
+    json.dumps({
+        "stub_identity": identity,
+        "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"],
+        "exit_code": exit_code,
+    }) + "\n",
+    encoding="utf-8",
 )
+raise SystemExit(exit_code)
 PY
-chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py"
+cat > "$tmp/ignoring-wrapper.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+# Deliberately wrong: a wrapper that ignores the producer exit must not pass
+# merely because it returns zero itself.
+subprocess.run([sys.executable, os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]], check=False)
+PY
+sed 's/exit_code = int(os.environ.get("IMPLEMENTAUDIT_TEST_STUB_EXIT", "0"))/exit_code = 23/' \
+  "$tmp/producer-stub.py" > "$tmp/producer-stub-23.py"
+chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py" "$tmp/producer-stub-23.py" "$tmp/ignoring-wrapper.py"
 
 cat > "$tmp/phase-budget.md" <<'EOF'
 Scarce resource budget: 2 model-calls
@@ -171,6 +182,58 @@ launch_text = json.dumps(launch, indent=2) + "\n"
     launch_text.replace('"argv": [', '"argv": [],\n  "argv": [', 1),
     encoding="utf-8",
 )
+
+def phase(name, receipt_path, launch_path, receipt, stub_path=stub):
+    (out / name).write_text(
+        "Scarce resource budget: 2 model-calls\n"
+        "Residual risk: terminal-writer is interposed during rehearsal\n"
+        f"Rehearsal receipt: {receipt_path}\n"
+        f"Rehearsal launch: {launch_path}\n"
+        f"Rehearsal producer stub: {stub_path}\n"
+        f"Rehearsal command hash: {receipt['rehearsed_command_hash']}\n"
+        f"Rehearsal terminal artifact: {receipt['terminal_artifact_path']}\n"
+        f"Rehearsal environment keys: {','.join(receipt['env_keys_present'])}\n",
+        encoding="utf-8",
+    )
+
+phase("phase-budget.md", out / "receipt-good.json", out / "launch-good.json", receipt)
+phase("phase-gap.md", out / "receipt-gap.json", out / "launch-gap.json", gap)
+phase("phase-gap-missing.md", out / "receipt-gap.json", out / "launch-gap.json", gap)
+
+consumer_launch = copy.deepcopy(launch)
+consumer_launch["terminal_artifact_path"] = str(out / "consumer-terminal.json")
+consumer_receipt = copy.deepcopy(receipt)
+consumer_receipt["terminal_artifact_path"] = consumer_launch["terminal_artifact_path"]
+write("launch-consumer.json", consumer_launch)
+write("receipt-consumer.json", consumer_receipt)
+consumer_phase = pathlib.Path("fixtures/run-root-example/phases/phase-1.md").read_text(encoding="utf-8")
+consumer_fields = (
+    "Scarce resource budget: 2 model-calls\n"
+    f"Rehearsal receipt: {out / 'receipt-consumer.json'}\n"
+    f"Rehearsal launch: {out / 'launch-consumer.json'}\n"
+    f"Rehearsal producer stub: {stub}\n"
+    f"Rehearsal command hash: {consumer_receipt['rehearsed_command_hash']}\n"
+    f"Rehearsal terminal artifact: {consumer_receipt['terminal_artifact_path']}\n"
+    f"Rehearsal environment keys: {','.join(consumer_receipt['env_keys_present'])}\n"
+)
+(out / "phase-consumer.md").write_text(
+    consumer_phase.replace("Depends on phases: none\n", "Depends on phases: none\n" + consumer_fields),
+    encoding="utf-8",
+)
+
+ignored_launch = copy.deepcopy(launch)
+ignored_launch["argv"] = [sys.executable, str(out / "ignoring-wrapper.py"), "--input", "fixture.txt"]
+ignored_launch["terminal_artifact_path"] = str(out / "ignored-terminal.json")
+ignored_receipt = copy.deepcopy(receipt)
+ignored_receipt["rehearsed_command_hash"] = canonical_hash(
+    ignored_launch["argv"], ignored_launch["env_keys_present"]
+)
+ignored_receipt["terminal_artifact_path"] = ignored_launch["terminal_artifact_path"]
+ignored_stub = out / "producer-stub-23.py"
+ignored_receipt["stub_identity"] = "sha256:" + hashlib.sha256(ignored_stub.read_bytes()).hexdigest()
+write("launch-ignored.json", ignored_launch)
+write("receipt-ignored.json", ignored_receipt)
+phase("phase-ignored.md", out / "receipt-ignored.json", out / "launch-ignored.json", ignored_receipt, ignored_stub)
 PY
 
 must_pass() {
@@ -185,9 +248,8 @@ rehearse() {
   bash "$checker" --phase "$1" --rehearsal "$2" --launch "$3"
 }
 run_production_rehearsal() {
-  API_TOKEN=fixture-token MODEL=fixture-model \
-  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
-  IMPLEMENTAUDIT_REHEARSAL_WRAPPER_PROOF="$tmp/wrapper-proof" \
+  API_TOKEN=fixture-token MODEL=fixture-model HELDOUT_CREDENTIAL_SENTINEL=withhold-me \
+  IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="${IMPLEMENTAUDIT_TEST_PRODUCER_STUB:-$tmp/producer-stub.py}" \
   "$@"
 }
 
@@ -223,11 +285,26 @@ must_fail F9-static-record-false-positive rehearse "$tmp/phase-budget.md" "$tmp/
 IMPLEMENTAUDIT_TEST_SCOPE_GAP=1 \
 must_pass F5-matched-residual run_production_rehearsal rehearse "$tmp/phase-gap.md" "$tmp/receipt-gap.json" "$tmp/launch-gap.json"
 
+# A malicious wrapper can mask the transport exit, but it cannot mask the
+# separate stub event: a zero wrapper exit plus producer exit 23 still blocks.
+IMPLEMENTAUDIT_TEST_PRODUCER_STUB="$tmp/producer-stub-23.py" \
+must_fail F6-stub-exit-propagation run_production_rehearsal rehearse \
+  "$tmp/phase-ignored.md" "$tmp/receipt-ignored.json" "$tmp/launch-ignored.json"
+[ ! -e "$tmp/ignored-terminal.json" ] || fail "F6 nonzero stub must not receive a terminal"
+
 # F7: a repaired receipt may pass on a manual re-run. The policy itself must
 # keep that repair manual and forbid automatic retries.
 unset IMPLEMENTAUDIT_TEST_SCOPE_GAP
 must_pass F7 run_production_rehearsal rehearse "$tmp/phase-budget.md" "$tmp/receipt-good.json" "$tmp/launch-good.json"
-[ -f "$tmp/wrapper-proof" ] || fail "F7 production wrapper did not execute"
+[ -f "$tmp/rehearsal-terminal.json" ] || fail "F7 checker did not bind the observed terminal"
+! grep -q 'IMPLEMENTAUDIT_REHEARSAL_TERMINAL\|IMPLEMENTAUDIT_REHEARSAL_STUB_PROOF' \
+  "$tmp/production-wrapper.py" || fail "F7 wrapper must not author proof or terminal"
+
+# F10/R30: the native phase validator consumes the same audit object and
+# executes the declared checker route; this is not a direct-test/prose proxy.
+must_pass F10-native-phase-consumer run_production_rehearsal \
+  bash skills/implementaudit/scripts/validate-phase.sh "$tmp/phase-consumer.md"
+[ -f "$tmp/consumer-terminal.json" ] || fail "F10 native phase route did not bind terminal"
 
 # F8: strict schemas reject extras, value-bearing fields/key-value strings,
 # ordering/uniqueness violations, and booleans masquerading as integers.
@@ -251,5 +328,6 @@ printf '%s' "$p411_text" | grep -qi 'second apparatus.*cold review' || fail "F6 
 printf '%s' "$p411_text" | grep -qi 'manual repair.*re-run' || fail "F7 manual repair/re-run rule missing"
 printf '%s' "$p411_text" | grep -qi 'no automatic retr\|must not automatically retr' || fail "F7 automatic retry prohibition missing"
 grep -q '^Scarce resource budget: {{N <resource> | none}}$' "$template" || fail "phase budget field missing"
+grep -q '^Rehearsal terminal artifact: {{PATH | none}}$' "$template" || fail "phase terminal binding field missing"
 
-printf 'scarce-resource-rehearsal-contract: ok (F1-F9; zero metered calls)\n'
+printf 'scarce-resource-rehearsal-contract: ok (F1-F10; zero metered calls)\n'

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -2,6 +2,20 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+probe_only=0
+if [ "${1:-}" = "--r30-probe" ]; then
+  probe_only=1
+  shift
+  [ "${1:-}" = "--repo-root" ] && [ "$#" -eq 2 ] || {
+    printf 'usage: scarce-resource-rehearsal-contract.test.sh --r30-probe --repo-root <dir>\n' >&2
+    exit 2
+  }
+  repo_root="$(cd "$2" && pwd)"
+  shift 2
+elif [ "$#" -ne 0 ]; then
+  printf 'usage: scarce-resource-rehearsal-contract.test.sh [--r30-probe --repo-root <dir>]\n' >&2
+  exit 2
+fi
 cd "$repo_root"
 
 checker="skills/implementaudit/scripts/check-authorization-binding.sh"
@@ -236,6 +250,25 @@ run_production_rehearsal() {
   "$@"
 }
 
+r30_probe() {
+  must_pass R30-native-phase-consumer run_production_rehearsal \
+    bash skills/implementaudit/scripts/validate-phase.sh "$tmp/phase-consumer.md"
+  [ -f "$tmp/consumer-terminal.json" ] || fail "R30 native phase route did not bind terminal"
+  python - "$tmp/launch-consumer.json" "$tmp/consumer-terminal.json" <<'PY' \
+    || fail "R30 probe did not retain the zero-meter terminal receipt"
+import json, pathlib, sys
+launch = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+terminal = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+raise SystemExit(0 if launch["metered_calls"] == 0 and terminal["exit_code"] == 0 else 1)
+PY
+}
+
+if [ "$probe_only" -eq 1 ]; then
+  r30_probe
+  printf 'scarce-resource-rehearsal-contract: r30-probe ok (F10; zero metered calls)\n'
+  exit 0
+fi
+
 # F1: a failed malformed-argv rehearsal cannot authorize launch; the fixture
 # independently proves that neither a launch record nor a metered call occurred.
 must_fail F1 rehearse "$tmp/phase-budget.md" "$tmp/receipt-f1-fail.json" "$tmp/launch-f1-zero.json"
@@ -285,9 +318,7 @@ must_pass F7 run_production_rehearsal rehearse "$tmp/phase-budget.md" "$tmp/rece
 
 # F10/R30: the native phase validator consumes the same audit object and
 # executes the declared checker route; this is not a direct-test/prose proxy.
-must_pass F10-native-phase-consumer run_production_rehearsal \
-  bash skills/implementaudit/scripts/validate-phase.sh "$tmp/phase-consumer.md"
-[ -f "$tmp/consumer-terminal.json" ] || fail "F10 native phase route did not bind terminal"
+r30_probe
 
 # F8: strict schemas reject extras, value-bearing fields/key-value strings,
 # ordering/uniqueness violations, and booleans masquerading as integers.

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -58,7 +58,21 @@ import sys
 subprocess.run([sys.executable, os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]], check=False)
 PY
 printf '%s\n' '#!/usr/bin/env python3' 'raise SystemExit(23)' > "$tmp/producer-stub-23.py"
-chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py" "$tmp/producer-stub-23.py" "$tmp/ignoring-wrapper.py"
+printf '%s\n' '#!/usr/bin/env python3' 'import time' 'time.sleep(60)' > "$tmp/producer-stub-hang.py"
+cat > "$tmp/producer-stub-child-hang.py" <<'PY'
+#!/usr/bin/env python3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+Path(__file__).with_suffix(".pid").write_text(str(child.pid), encoding="utf-8")
+time.sleep(60)
+PY
+printf '%s\n' '#!/usr/bin/env python3' 'import time' 'time.sleep(60)' > "$tmp/wrapper-hang.py"
+chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py" "$tmp/producer-stub-23.py" \
+  "$tmp/producer-stub-hang.py" "$tmp/producer-stub-child-hang.py" "$tmp/wrapper-hang.py" "$tmp/ignoring-wrapper.py"
 
 cat > "$tmp/phase-budget.md" <<'EOF'
 Scarce resource budget: 2 model-calls
@@ -233,6 +247,43 @@ write("receipt-ignored.json", ignored_receipt)
 phase("phase-ignored.md", out / "receipt-ignored.json", out / "launch-ignored.json", ignored_receipt, ignored_stub)
 PY
 
+python - "$tmp" <<'PY'
+import hashlib, json, re, sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+base_launch = json.loads((out / "launch-good.json").read_text(encoding="utf-8"))
+base_receipt = json.loads((out / "receipt-good.json").read_text(encoding="utf-8"))
+base_phase = (out / "phase-budget.md").read_text(encoding="utf-8")
+
+def command_hash(launch):
+    return hashlib.sha256(json.dumps({"argv": launch["argv"], "env_keys_present": sorted(launch["env_keys_present"])}, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+
+def write_case(name, wrapper, stub):
+    launch = dict(base_launch)
+    launch["argv"] = [sys.executable, str(wrapper), "--input", "fixture.txt"]
+    launch["terminal_artifact_path"] = str(out / f"terminal-{name}.json")
+    receipt = dict(base_receipt)
+    receipt["rehearsed_command_hash"] = command_hash(launch)
+    receipt["stub_identity"] = "sha256:" + hashlib.sha256(stub.read_bytes()).hexdigest()
+    receipt["terminal_artifact_path"] = launch["terminal_artifact_path"]
+    (out / f"launch-{name}.json").write_text(json.dumps(launch), encoding="utf-8")
+    (out / f"receipt-{name}.json").write_text(json.dumps(receipt), encoding="utf-8")
+    replacements = {
+        "Rehearsal receipt": out / f"receipt-{name}.json", "Rehearsal launch": out / f"launch-{name}.json",
+        "Rehearsal producer stub": stub, "Rehearsal command hash": receipt["rehearsed_command_hash"],
+        "Rehearsal terminal artifact": receipt["terminal_artifact_path"],
+    }
+    phase = base_phase
+    for field, value in replacements.items():
+        phase = re.sub(rf"(?m)^{re.escape(field)}:.*$", lambda _: f"{field}: {value}", phase)
+    (out / f"phase-{name}.md").write_text(phase, encoding="utf-8")
+
+write_case("producer-hang", out / "production-wrapper.py", out / "producer-stub-hang.py")
+write_case("producer-child-hang", out / "production-wrapper.py", out / "producer-stub-child-hang.py")
+write_case("wrapper-hang", out / "wrapper-hang.py", out / "producer-stub.py")
+PY
+
 must_pass() {
   local label="$1"; shift
   "$@" >/dev/null 2>&1 || fail "$label must pass"
@@ -240,6 +291,32 @@ must_pass() {
 must_fail() {
   local label="$1"; shift
   if "$@" >/dev/null 2>&1; then fail "$label must fail"; fi
+}
+must_timeout_diagnostic() {
+  local label="$1" expected="$2"; shift 2
+  local log="$tmp/$label.log"
+  command -v timeout >/dev/null 2>&1 || fail "$label needs timeout"
+  if timeout 12 "$@" >"$log" 2>&1; then fail "$label must fail"; fi
+  grep -Fq "$expected" "$log" || { cat "$log" >&2; fail "$label must report $expected"; }
+}
+must_not_leave_pid() {
+  local label="$1" pid_file="$2"
+  python - "$pid_file" <<'PY' || fail "$label left a child process"
+import os, subprocess, sys
+from pathlib import Path
+
+pid = int(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if os.name == "nt":
+    result = subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    raise SystemExit(1 if result.returncode == 0 else 0)
+try:
+    os.kill(pid, 0)
+except OSError:
+    raise SystemExit(0)
+os.kill(pid, 9)
+raise SystemExit(1)
+PY
 }
 rehearse() {
   bash "$checker" --phase "$1" --rehearsal "$2" --launch "$3"
@@ -250,9 +327,94 @@ run_production_rehearsal() {
   "$@"
 }
 
+run_phase_with_timeout() {
+  local log_path="$1" seconds="$2"; shift 2
+  python - "$log_path" "$seconds" "$@" <<'PY'
+import os, signal, subprocess, sys
+from pathlib import Path
+
+log_path, seconds, *command = sys.argv[1:]
+creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    start_new_session=os.name != "nt", creationflags=creationflags)
+timed_out = False
+try:
+    stdout, stderr = process.communicate(timeout=float(seconds))
+except subprocess.TimeoutExpired:
+    timed_out = True
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    else:
+        os.killpg(process.pid, signal.SIGKILL)
+    stdout, stderr = process.communicate()
+Path(log_path).write_bytes(stdout + stderr)
+if timed_out:
+    sys.stderr.write(f"r30 probe: candidate validate-phase timed out after {seconds}s\n")
+    raise SystemExit(124)
+raise SystemExit(process.returncode)
+PY
+}
+
 r30_probe() {
-  must_pass R30-native-phase-consumer run_production_rehearsal \
-    bash skills/implementaudit/scripts/validate-phase.sh "$tmp/phase-consumer.md"
+  local probe_skills="$tmp/r30-probe-skills" real_helper="$tmp/r30-real-check-authorization-binding.sh"
+  local sentinel marker nonce log_path
+  marker="${IMPLEMENTAUDIT_TEST_R30_SENTINEL_MARKER:-$tmp/r30-sentinel-marker.json}"
+  log_path="$tmp/r30-probe-validator.log"
+  cp -R "$repo_root/skills" "$probe_skills"
+  sentinel="$probe_skills/implementaudit/scripts/check-authorization-binding.sh"
+  mv "$sentinel" "$real_helper"
+  cmp -s "$real_helper" "$repo_root/skills/implementaudit/scripts/check-authorization-binding.sh" \
+    || fail "R30 probe relocated helper differs from candidate source"
+  nonce="$(python - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  cat > "$sentinel" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+python - "$marker" "$nonce" "\$@" <<'PY'
+import json, os, stat, sys
+from pathlib import Path
+
+marker, nonce, *argv = sys.argv[1:]
+fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as stream:
+    json.dump({"nonce": nonce, "argv": argv}, stream, separators=(",", ":"))
+    stream.write("\\n")
+entry = Path(marker).lstat()
+if not stat.S_ISREG(entry.st_mode) or entry.st_nlink != 1:
+    raise SystemExit("invalid verifier sentinel marker")
+PY
+exec "$real_helper" "\$@"
+EOF
+  chmod 700 "$sentinel" "$real_helper"
+  if ! run_production_rehearsal run_phase_with_timeout "$log_path" 10 \
+    "$BASH" -c 'cd "$1" && exec bash validate-phase.sh "$2"' r30-probe \
+    "$probe_skills/implementaudit/scripts" "$tmp/phase-consumer.md"; then
+    cat "$log_path" >&2 || true
+    fail "R30 native phase consumer failed"
+  fi
+  python - "$marker" "$nonce" "$tmp/phase-consumer.md" "$tmp/receipt-consumer.json" "$tmp/launch-consumer.json" <<'PY' \
+    || fail "R30 native phase route did not invoke the declared helper"
+import json, os, stat, sys
+from pathlib import Path
+
+marker, nonce, phase, receipt, launch = map(Path, sys.argv[1:])
+entry = marker.lstat()
+if not stat.S_ISREG(entry.st_mode) or entry.st_nlink != 1:
+    raise SystemExit(1)
+observed = json.loads(marker.read_text(encoding="utf-8"))
+argv = observed.get("argv") if type(observed) is dict else None
+expected_paths = (phase, receipt, launch)
+identity = type(argv) is list and len(argv) == 6 and argv[::2] == ["--phase", "--rehearsal", "--launch"]
+if identity:
+    identity = all(Path(actual).resolve() == expected for actual, expected in zip(argv[1::2], expected_paths))
+if observed.get("nonce") != str(nonce) or not identity:
+    sys.stderr.write("r30 probe: verifier sentinel marker identity mismatch\n")
+    raise SystemExit(1)
+PY
   [ -f "$tmp/consumer-terminal.json" ] || fail "R30 native phase route did not bind terminal"
   python - "$tmp/launch-consumer.json" "$tmp/consumer-terminal.json" <<'PY' \
     || fail "R30 probe did not retain the zero-meter terminal receipt"
@@ -308,6 +470,24 @@ must_fail F6-stub-exit-propagation run_production_rehearsal rehearse \
   "$tmp/phase-ignored.md" "$tmp/receipt-ignored.json" "$tmp/launch-ignored.json"
 [ ! -e "$tmp/ignored-terminal.json" ] || fail "F6 nonzero stub must not receive a terminal"
 
+# The bounded transport cannot leave a hung producer or wrapper behind, and
+# must preserve its own timeout diagnostic rather than letting the outer test
+# watchdog become the only verdict.
+API_TOKEN=fixture-token MODEL=fixture-model HELDOUT_CREDENTIAL_SENTINEL=withhold-me \
+IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub-hang.py" \
+must_timeout_diagnostic F6-producer-timeout 'producer timed out' \
+  bash "$checker" --phase "$tmp/phase-producer-hang.md" --rehearsal "$tmp/receipt-producer-hang.json" --launch "$tmp/launch-producer-hang.json"
+[ ! -e "$tmp/terminal-producer-hang.json" ] || fail "F6 producer timeout must not receive a terminal"
+IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub-child-hang.py" \
+must_timeout_diagnostic F6-producer-child-timeout 'producer timed out' \
+  bash "$checker" --phase "$tmp/phase-producer-child-hang.md" --rehearsal "$tmp/receipt-producer-child-hang.json" --launch "$tmp/launch-producer-child-hang.json"
+must_not_leave_pid F6-producer-child-timeout "$tmp/producer-stub-child-hang.pid"
+API_TOKEN=fixture-token MODEL=fixture-model HELDOUT_CREDENTIAL_SENTINEL=withhold-me \
+IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB="$tmp/producer-stub.py" \
+must_timeout_diagnostic F6-wrapper-timeout 'wrapper timed out' \
+  bash "$checker" --phase "$tmp/phase-wrapper-hang.md" --rehearsal "$tmp/receipt-wrapper-hang.json" --launch "$tmp/launch-wrapper-hang.json"
+[ ! -e "$tmp/terminal-wrapper-hang.json" ] || fail "F6 wrapper timeout must not receive a terminal"
+
 # F7: a repaired receipt may pass on a manual re-run. The policy itself must
 # keep that repair manual and forbid automatic retries.
 unset IMPLEMENTAUDIT_TEST_SCOPE_GAP
@@ -319,6 +499,23 @@ must_pass F7 run_production_rehearsal rehearse "$tmp/phase-budget.md" "$tmp/rece
 # F10/R30: the native phase validator consumes the same audit object and
 # executes the declared checker route; this is not a direct-test/prose proxy.
 r30_probe
+
+# The verifier-owned sentinel accepts only an absent path it can create.  A
+# pre-existing hardlink or symlink must not become an alias for its marker.
+sentinel_victim="$tmp/r30-sentinel-victim"
+printf 'sentinel-victim\n' > "$sentinel_victim"
+for sentinel_alias in "$tmp/r30-sentinel-hardlink" "$tmp/r30-sentinel-symlink"; do
+  rm -f "$sentinel_alias"
+  if [ "$sentinel_alias" = "$tmp/r30-sentinel-hardlink" ]; then
+    ln "$sentinel_victim" "$sentinel_alias"
+  elif ! ln -s "$sentinel_victim" "$sentinel_alias" 2>/dev/null; then
+    continue
+  fi
+  if IMPLEMENTAUDIT_TEST_R30_SENTINEL_MARKER="$sentinel_alias" \
+    bash "$0" --r30-probe --repo-root "$repo_root" >/dev/null 2>&1; then
+    fail "F10 pre-existing sentinel alias must fail"
+  fi
+done
 
 # F8: strict schemas reject extras, value-bearing fields/key-value strings,
 # ordering/uniqueness violations, and booleans masquerading as integers.

--- a/tests/scarce-resource-rehearsal-contract.test.sh
+++ b/tests/scarce-resource-rehearsal-contract.test.sh
@@ -31,23 +31,7 @@ raise SystemExit(subprocess.run([sys.executable, stub], check=False).returncode)
 PY
 cat > "$tmp/producer-stub.py" <<'PY'
 #!/usr/bin/env python3
-import hashlib
-import json
-import os
-import pathlib
-import sys
-
-identity = "sha256:" + hashlib.sha256(pathlib.Path(__file__).read_bytes()).hexdigest()
-exit_code = int(os.environ.get("IMPLEMENTAUDIT_TEST_STUB_EXIT", "0"))
-pathlib.Path(os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_EVENT"]).write_text(
-    json.dumps({
-        "stub_identity": identity,
-        "nonce": os.environ["IMPLEMENTAUDIT_REHEARSAL_STUB_NONCE"],
-        "exit_code": exit_code,
-    }) + "\n",
-    encoding="utf-8",
-)
-raise SystemExit(exit_code)
+raise SystemExit(0)
 PY
 cat > "$tmp/ignoring-wrapper.py" <<'PY'
 #!/usr/bin/env python3
@@ -59,8 +43,7 @@ import sys
 # merely because it returns zero itself.
 subprocess.run([sys.executable, os.environ["IMPLEMENTAUDIT_REHEARSAL_PRODUCER_STUB"]], check=False)
 PY
-sed 's/exit_code = int(os.environ.get("IMPLEMENTAUDIT_TEST_STUB_EXIT", "0"))/exit_code = 23/' \
-  "$tmp/producer-stub.py" > "$tmp/producer-stub-23.py"
+printf '%s\n' '#!/usr/bin/env python3' 'raise SystemExit(23)' > "$tmp/producer-stub-23.py"
 chmod +x "$tmp/production-wrapper.py" "$tmp/producer-stub.py" "$tmp/producer-stub-23.py" "$tmp/ignoring-wrapper.py"
 
 cat > "$tmp/phase-budget.md" <<'EOF'


### PR DESCRIPTION
## Outcome

Repair the reopened R11 rehearsal false green and the R30 rehearsal-mode
reachability gap as one coupled change. A rehearsal receipt is now produced only
after the real production validator traverses the authorization helper,
checker-controlled mediator and bounded zero-meter producer stub. Static source
shape is retained only for the helper/mode/caller census; it is no longer the
acceptance authority for runtime reachability.

Refs #84
Refs #157

## Why this shape

Repeated AST-only repairs admitted equivalent dead, optional, rebound or
non-traversed Python routes while focused tests remained green. The R32
recurrence disposition therefore required mechanism replacement rather than
another syntax case.

The terminal probe is candidate-bound but not candidate-self-authenticated:
the executing checker supplies the independent F10 probe program and points it
at the candidate runtime and fixtures. A candidate that breaks its rehearsal
parser and replaces its own test with `exit 0` is rejected. The outer probe and
the helper-owned producer/wrapper calls are bounded, emit causal diagnostics and
clean their process trees.

## Scope

- execute the real wrapper-to-stub rehearsal route with zero metered calls;
- bind terminal publication to the checker-owned mediator and live helper
  identity;
- reject fabricated records, dead/static-only routes, path aliases, hardlinks,
  stale/rebound producers and candidate-owned evaluator substitution;
- add the R30 rehearsal invocation mode to the existing 18-helper reachability
  population;
- retain ordinary non-rehearsal and cheap paths;
- calibrate the exact packaged candidate under the existing R33
  dedicated-calibration authority.

No ActiveGraph, R36 mutation primitive, public projection, release, or issue
closure is included.

## Evidence

- independent coupled mutant: rejected;
- R11/R30 held-outs: PASS;
- scarce-resource rehearsal F1-F10: PASS, zero metered calls;
- helper reachability: PASS, 18/18 helpers and 4/4 modes;
- authorization, e2e and phase validation: PASS;
- R35 acceptance-instrument discipline: 39/39;
- R33 semantic preservation: 21/21;
- release asset/package shape/reproducibility: PASS;
- package: 225,945 bytes, 50 members, SHA-256
  `f2b8eb5e5ac49aac71c9bcc4f0f8b9730c48d1ddee650607ad0b4f2f3ca4f094`;
- ceiling: 228,000 bytes; headroom: 2,055 bytes; outer bound unchanged at
  230,000 bytes;
- shell syntax and `git diff --check`: PASS.

The first hosted run exposed one source-evidence registration gap: the new
held-out was not yet invoked by `verify-package.sh` or the workflow's explicit
focused registry. Commit `6a3413633bf5277fe6cad10355af6a68372bc02e`
registered it exactly once in each existing registry. Focused registry evidence
passed 70/70, and an independent exact-tree review found the three-line delta
safe to push.

Hosted run `31533566003` then completed SUCCESS on exact head `6a341363`: the
complete package contract and the focused behaviour step both passed. The
complete verifier was not duplicated locally.

## Rollback

Revert this PR as one composed R11/R30 repair. Do not retain the rehearsal-mode
route declaration without its executed probe, and do not retain the probe while
removing the production validator/helper path it qualifies.
