### PR TITLE
fix: bind R35 repository evidence identities

### DIFF
--- a/fixtures/acceptance-instrument-discipline/cases.json
+++ b/fixtures/acceptance-instrument-discipline/cases.json
@@ -1,5 +1,6 @@
 {
   "schema": "implementaudit-acceptance-instrument-discipline-fixtures-v2",
+  "policy_evidence_context": {"default_classification": "contract-fixture", "repository_evidence": {}},
   "mutation_records": {
     "R35-legitimate-evaluator-repair": {"property_owner": "authoritative contract owner", "consumer": "closure decision", "changes": ["evaluator-change"], "residual_risk": "adjacent false decisions", "rollback": "restore old evaluator", "stop_condition": "held-out controls discriminate"},
     "R35-legitimate-prompt-repair": {"property_owner": "prompt contract owner", "consumer": "model evaluation", "changes": ["evaluator-change"], "residual_risk": "prompt leakage", "rollback": "restore old prompt", "stop_condition": "prompt-blind controls discriminate"},

--- a/scripts/check-acceptance-instrument-discipline.sh
+++ b/scripts/check-acceptance-instrument-discipline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deterministically exercise the issue #85 acceptance/instrument control bank.
+# Deterministically exercise the issues #85 and #164 acceptance/instrument controls.
 set -euo pipefail
 
 fixture="${1:-fixtures/acceptance-instrument-discipline/cases.json}"
@@ -8,6 +8,13 @@ fixture="${1:-fixtures/acceptance-instrument-discipline/cases.json}"
     "$fixture" >&2
   exit 2
 }
+repository=""
+if [ "${2:-}" = "--repository" ] && [ -n "${3:-}" ] && [ "$#" -eq 3 ]; then
+  repository="$3"
+elif [ "$#" -gt 1 ]; then
+  printf 'usage: %s [fixture] [--repository PATH]\n' "$0" >&2
+  exit 2
+fi
 
 if command -v python >/dev/null 2>&1; then
   py_cmd=(python)
@@ -20,9 +27,10 @@ else
   exit 2
 fi
 
-"${py_cmd[@]}" - "$fixture" <<'PY'
+"${py_cmd[@]}" - "$fixture" "$repository" <<'PY'
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -83,6 +91,10 @@ AUTHORITY_KEYS = {
     "source_identity", "owner_locator", "contract_locator",
     "effective_boundary",
 }
+IDENTITY_RELATIONSHIP_KEYS = {"candidate_parent", "authority_parent"}
+POPULATION_KEYS = {
+    "source_identity", "total_count", "examined_count",
+}
 BEHAVIOUR_KEYS = {"positive", "negative", "boundary", "adjacent"}
 EXPECTED_BEHAVIOUR = {
     "positive": "PASS", "negative": "FAIL", "boundary": "FAIL",
@@ -100,6 +112,94 @@ SURFACES = {
 }
 EVENTS = {"candidate-fail", "product-change", "contract-change", "evaluator-change"}
 VERDICTS = {"NOT_RUN", "PASS", "FAIL"}
+
+
+def git_result(repository, *arguments):
+    return subprocess.run(
+        ["git", "-C", repository, *arguments], check=False,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def require_git_object(repository, identity, owner, object_type=None):
+    suffix = "^{commit}" if object_type == "commit" else ""
+    resolved = git_result(repository, "cat-file", "-e", identity + suffix)
+    if resolved.returncode != 0:
+        raise ValueError(f"{owner}: identity does not resolve in evaluation repository")
+    if object_type == "blob":
+        actual = git_result(repository, "cat-file", "-t", identity)
+        if actual.returncode != 0 or actual.stdout.strip() != "blob":
+            raise ValueError(f"{owner}: population source is not a blob")
+
+
+def validate_repository_evidence(evidence, metadata, case_id, repository):
+    if not repository:
+        raise ValueError(f"{case_id}: evaluation repository required")
+    repository_probe = git_result(repository, "rev-parse", "--absolute-git-dir")
+    if repository_probe.returncode != 0:
+        raise ValueError(f"{case_id}: evaluation repository invalid")
+
+    candidate = evidence["candidate_identity"]
+    parent = evidence["parent_identity"]
+    authority = evidence["authority"]
+    witness = evidence["witness"]
+    relationship = require_exact(
+        metadata["identity_relationship"], IDENTITY_RELATIONSHIP_KEYS,
+        f"{case_id} identity relationship")
+    if relationship != {
+            "candidate_parent": "direct-parent",
+            "authority_parent": "tree-object-at-owner-locator"}:
+        raise ValueError(f"{case_id}: identity relationship unsupported")
+    if candidate == parent:
+        raise ValueError(f"{case_id}: candidate equals parent")
+    if authority is None:
+        raise ValueError(f"{case_id}: repository evidence authority missing")
+    authority_identity = authority["source_identity"]
+    if authority_identity in {candidate, parent}:
+        raise ValueError(f"{case_id}: authority is candidate or parent substitution")
+    if witness is None:
+        raise ValueError(f"{case_id}: retained witness missing")
+
+    for label, identity in (("candidate", candidate), ("parent", parent)):
+        require_git_object(repository, identity, f"{case_id} {label}", "commit")
+    require_git_object(repository, authority_identity, f"{case_id} authority")
+
+    parents = git_result(repository, "rev-list", "--parents", "-n", "1", candidate)
+    if parents.returncode != 0 or parent not in parents.stdout.split()[1:]:
+        raise ValueError(f"{case_id}: declared candidate parent relationship invalid")
+    independent = git_result(
+        repository, "rev-parse",
+        f"{parent}:{authority['owner_locator']}")
+    if (independent.returncode != 0 or
+            independent.stdout.strip() != authority_identity):
+        raise ValueError(f"{case_id}: declared authority relationship invalid")
+
+    population = require_exact(
+        metadata["population"], POPULATION_KEYS,
+        f"{case_id} evidence population")
+    source_identity = population["source_identity"]
+    if not re.fullmatch(r"[0-9a-f]{40}", source_identity):
+        raise ValueError(f"{case_id}: population source identity invalid")
+    require_git_object(
+        repository, source_identity, f"{case_id} population source", "blob")
+    source = git_result(repository, "cat-file", "-p", source_identity)
+    if source.returncode != 0:
+        raise ValueError(f"{case_id}: population source unreadable")
+    enumerated = [line.strip() for line in source.stdout.splitlines() if line.strip()]
+    if (not enumerated or len(enumerated) != len(set(enumerated)) or
+            any(not re.fullmatch(r"[0-9a-f]{40}", value)
+                for value in enumerated)):
+        raise ValueError(f"{case_id}: population source enumeration invalid")
+    identities = evidence["evidence_population"]
+    if (type(population["total_count"]) is not int or
+            type(population["examined_count"]) is not int or
+            type(identities) is not list or identities != enumerated or
+            population["total_count"] != len(enumerated) or
+            population["examined_count"] != len(enumerated)):
+        raise ValueError(f"{case_id}: population coverage incomplete")
+    for identity in identities:
+        require_git_object(repository, identity, f"{case_id} population member")
+    if witness["identity"] not in identities:
+        raise ValueError(f"{case_id}: retained witness absent from population")
 
 
 def result(activation, classification, route, disposition):
@@ -490,12 +590,14 @@ def classify(case):
 
 
 path = Path(sys.argv[1])
+repository = sys.argv[2]
 fixture = json.loads(
     path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_keys)
 require_exact(
     fixture,
     {"schema", "controls", "instrument_parity", "mutation_cases",
-     "mutation_records", "phase_cases", "policy_cases", "policy_evidence"},
+     "mutation_records", "phase_cases", "policy_cases", "policy_evidence",
+     "policy_evidence_context"},
     "fixture bank")
 if fixture["schema"] != "implementaudit-acceptance-instrument-discipline-fixtures-v2":
     raise ValueError("fixture bank schema invalid")
@@ -510,6 +612,15 @@ if type(fixture["policy_cases"]) is not list or not fixture["policy_cases"]:
 policy_evidence = fixture["policy_evidence"]
 if type(policy_evidence) is not dict:
     raise ValueError("fixture policy_evidence must be an object")
+policy_evidence_context = require_exact(
+    fixture["policy_evidence_context"],
+    {"default_classification", "repository_evidence"},
+    "policy evidence context")
+if policy_evidence_context["default_classification"] != "contract-fixture":
+    raise ValueError("policy evidence default must be explicit contract-fixture")
+repository_evidence = policy_evidence_context["repository_evidence"]
+if type(repository_evidence) is not dict:
+    raise ValueError("repository evidence context must be an object")
 mutation_records = fixture["mutation_records"]
 if type(mutation_records) is not dict:
     raise ValueError("fixture mutation_records must be an object")
@@ -646,8 +757,18 @@ for index, case in enumerate(fixture["policy_cases"]):
             raise ValueError(f"{case['id']}: witness identity invalid")
     population = evidence["evidence_population"]
     if (type(population) is not list or
-            any(not re.fullmatch(r"[0-9a-f]{40}", value) for value in population)):
+            any(not re.fullmatch(r"[0-9a-f]{40}", value)
+                for value in population)):
         raise ValueError(f"{case['id']}: evidence population invalid")
+    if case["id"] in repository_evidence:
+        metadata = require_exact(
+            repository_evidence[case["id"]],
+            {"classification", "identity_relationship", "population"},
+            f"{case['id']} repository evidence context")
+        if metadata["classification"] != "repository-evidence":
+            raise ValueError(f"{case['id']}: repository classification invalid")
+        validate_repository_evidence(
+            evidence, metadata, case["id"], repository)
     behaviour = require_exact(
         evidence["behaviour"], {"baseline", "candidate"},
         f"{case['id']} policy behaviour")
@@ -688,6 +809,8 @@ if len(policy_ids) != len(set(policy_ids)) or set(policy_ids) != required_policy
     raise ValueError("policy control identity set invalid")
 if set(policy_evidence) != required_policy_ids:
     raise ValueError("policy evidence identity set invalid")
+if set(repository_evidence) - required_policy_ids:
+    raise ValueError("repository evidence context identity has no policy case")
 
 required_mutation_ids = {
     "R35-unrelated-test-no-trigger",

--- a/tests/acceptance-instrument-discipline.test.sh
+++ b/tests/acceptance-instrument-discipline.test.sh
@@ -39,6 +39,187 @@ else
   record_fail "deterministic control checker rejected the fixture bank"
 fi
 
+identity_proxy_fixture="$tmp/r35-nonresolving-identity-proxy.json"
+"${py_cmd[@]}" - "$fixture" "$identity_proxy_fixture" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source, target = map(Path, sys.argv[1:])
+fixture = json.loads(source.read_text(encoding="utf-8"))
+case_id = "R35-CP5-legitimate-policy-repair"
+evidence = fixture["policy_evidence"][case_id]
+fixture["policy_evidence_context"]["repository_evidence"][case_id] = {
+    "classification": "repository-evidence",
+    "identity_relationship": {
+        "candidate_parent": "direct-parent",
+        "authority_parent": "tree-object-at-owner-locator",
+    },
+    "population": {
+        "source_identity": "5555555555555555555555555555555555555555",
+        "total_count": 1,
+        "examined_count": 1,
+    },
+}
+identities = [
+    evidence["candidate_identity"],
+    evidence["parent_identity"],
+    evidence["authority"]["source_identity"],
+    *evidence["evidence_population"],
+]
+if len(identities) != len(set(identities)):
+    raise SystemExit("identity-proxy witness must use distinct identities")
+target.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+PY
+identity_proxy_out="$tmp/r35-nonresolving-identity-proxy.out"
+if bash scripts/check-acceptance-instrument-discipline.sh \
+    "$identity_proxy_fixture" --repository "$repo_root" \
+    >"$identity_proxy_out" 2>&1; then
+  record_fail "distinct non-resolving candidate, parent, authority and population identities were accepted"
+elif grep -Fq "R35-CP5-legitimate-policy-repair" "$identity_proxy_out"; then
+  record_pass
+else
+  record_fail "R35 identity-proxy negative failed without identifying the rejected cell"
+  cat "$identity_proxy_out" >&2
+fi
+
+identity_repo="$tmp/r35-identity-repository"
+wrong_identity_repo="$tmp/r35-wrong-identity-repository"
+git init -q "$identity_repo"
+git -C "$identity_repo" config user.name "R35 Test"
+git -C "$identity_repo" config user.email "r35@example.invalid"
+mkdir -p "$identity_repo/contracts"
+printf 'independent evaluator authority\n' >"$identity_repo/contracts/evaluator"
+git -C "$identity_repo" add contracts/evaluator
+git -C "$identity_repo" commit -q -m authority
+authority_identity="$(git -C "$identity_repo" rev-parse HEAD:contracts/evaluator)"
+git -C "$identity_repo" commit -q --allow-empty -m parent
+parent_identity="$(git -C "$identity_repo" rev-parse HEAD)"
+witness_identity="$(printf 'retained witness\n' | git -C "$identity_repo" hash-object -w --stdin)"
+adjacent_identity="$(printf 'adjacent witness\n' | git -C "$identity_repo" hash-object -w --stdin)"
+population_source_identity="$({
+  printf '%s\n' "$witness_identity"
+  printf '%s\n' "$adjacent_identity"
+} | git -C "$identity_repo" hash-object -w --stdin)"
+git -C "$identity_repo" commit -q --allow-empty -m candidate
+candidate_identity="$(git -C "$identity_repo" rev-parse HEAD)"
+git init -q "$wrong_identity_repo"
+
+if [ "$(git -C "$identity_repo" rev-parse "$candidate_identity^")" = "$parent_identity" ] &&
+   [ "$(git -C "$identity_repo" rev-parse \
+     "$parent_identity:contracts/evaluator")" = "$authority_identity" ] &&
+   [ "$(git -C "$identity_repo" cat-file -p "$population_source_identity")" = \
+     "$witness_identity
+$adjacent_identity" ]; then
+  record_pass
+else
+  record_fail "independent Git controls did not establish R35 identity and population relationships"
+fi
+
+repository_fixture="$tmp/r35-repository-evidence.json"
+"${py_cmd[@]}" - "$fixture" "$repository_fixture" \
+    "$candidate_identity" "$parent_identity" "$authority_identity" \
+    "$witness_identity" "$adjacent_identity" "$population_source_identity" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(source, target, candidate, parent, authority, witness, adjacent,
+ population_source) = sys.argv[1:]
+fixture = json.loads(Path(source).read_text(encoding="utf-8"))
+case_id = "R35-CP5-legitimate-policy-repair"
+evidence = fixture["policy_evidence"][case_id]
+evidence["candidate_identity"] = candidate
+evidence["parent_identity"] = parent
+evidence["authority"]["source_identity"] = authority
+evidence["witness"]["identity"] = witness
+evidence["evidence_population"] = [witness, adjacent]
+fixture["policy_evidence_context"]["repository_evidence"][case_id] = {
+    "classification": "repository-evidence",
+    "identity_relationship": {
+        "candidate_parent": "direct-parent",
+        "authority_parent": "tree-object-at-owner-locator",
+    },
+    "population": {
+        "source_identity": population_source,
+        "total_count": 2,
+        "examined_count": 2,
+    },
+}
+Path(target).write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+PY
+
+repository_fixture_out="$tmp/r35-repository-evidence.out"
+if bash scripts/check-acceptance-instrument-discipline.sh \
+    "$repository_fixture" --repository "$identity_repo" \
+    >"$repository_fixture_out" 2>&1; then
+  record_pass
+else
+  record_fail "valid repository-bound R35 evidence was rejected"
+  cat "$repository_fixture_out" >&2
+fi
+
+repository_mutants="$tmp/r35-repository-mutants"
+mkdir -p "$repository_mutants"
+"${py_cmd[@]}" - "$repository_fixture" "$repository_mutants" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+source, target_dir = Path(sys.argv[1]), Path(sys.argv[2])
+fixture = json.loads(source.read_text(encoding="utf-8"))
+case_id = "R35-CP5-legitimate-policy-repair"
+for name in ("authority-candidate-equal", "authority-parent-substitution",
+             "candidate-parent-equal", "missing-population",
+             "partial-population"):
+    payload = copy.deepcopy(fixture)
+    evidence = payload["policy_evidence"][case_id]
+    population = payload["policy_evidence_context"]["repository_evidence"][case_id]["population"]
+    if name == "authority-candidate-equal":
+        evidence["authority"]["source_identity"] = evidence["candidate_identity"]
+    elif name == "authority-parent-substitution":
+        evidence["authority"]["source_identity"] = evidence["parent_identity"]
+    elif name == "candidate-parent-equal":
+        evidence["candidate_identity"] = evidence["parent_identity"]
+    elif name == "missing-population":
+        evidence["evidence_population"] = []
+        population["total_count"] = 0
+        population["examined_count"] = 0
+    elif name == "partial-population":
+        evidence["evidence_population"] = evidence["evidence_population"][:1]
+        population["examined_count"] = 1
+    (target_dir / f"{name}.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+for mutant_name in authority-candidate-equal authority-parent-substitution \
+    candidate-parent-equal missing-population partial-population; do
+  mutant_out="$tmp/r35-repository-$mutant_name.out"
+  if bash scripts/check-acceptance-instrument-discipline.sh \
+      "$repository_mutants/$mutant_name.json" --repository "$identity_repo" \
+      >"$mutant_out" 2>&1; then
+    record_fail "R35 repository mutant $mutant_name was accepted"
+  elif grep -Fq "R35-CP5-legitimate-policy-repair" "$mutant_out"; then
+    record_pass
+  else
+    record_fail "R35 repository mutant $mutant_name failed without identifying the rejected cell"
+    cat "$mutant_out" >&2
+  fi
+done
+
+wrong_repository_out="$tmp/r35-wrong-repository.out"
+if bash scripts/check-acceptance-instrument-discipline.sh \
+    "$repository_fixture" --repository "$wrong_identity_repo" \
+    >"$wrong_repository_out" 2>&1; then
+  record_fail "R35 repository evidence was accepted from the wrong object store"
+elif grep -Fq "R35-CP5-legitimate-policy-repair" "$wrong_repository_out"; then
+  record_pass
+else
+  record_fail "R35 wrong-repository negative failed without identifying the rejected cell"
+  cat "$wrong_repository_out" >&2
+fi
+
 state_matrix_out="$tmp/r35-state-matrix.out"
 if "${py_cmd[@]}" - "$fixture" >"$state_matrix_out" <<'PY'
 import itertools


### PR DESCRIPTION
## Summary

- require repository evidence to resolve inside an operator-supplied Git object store;
- prove the candidate/parent edge and bind independent authority to the accepted parent's declared owner;
- bind the retained evidence population to one immutable source blob and exact denominator/member census;
- preserve synthetic contract fixtures as explicitly classified fixture evidence.

Refs #164. This PR addresses the final-coherence repository-identity/population tail; it does not close the issue or make release claims.

## Evidence

- retained false-pass: distinct non-resolving 40-hex identities passed the prior checker;
- focused acceptance-instrument suite: 48/48 PASS;
- direct bank: 12 instrument + 28 mutation + 10 policy controls PASS;
- independent exact-tree review: PASS at `3b6a2e419a6ee982f9e4b221165812647f08777d` / tree `077346007cf39741057191c8dfd4ae18a46094ab`;
- novel review controls: grandparent, wrong authority binding, commit-as-population, non-resolving member, population reorder, missing operator repository all reject; valid repository-bound evidence accepts;
- shell syntax and diff checks: PASS.

## Boundaries

- Three repository-side R35 files only; no package bytes, registry, public docs, sidecar, R36 or release surface changes.
- No expected-answer, scoring or product-policy weakening.
- Final composed R29/R33/release qualification remains separate.
