### PR TITLE
fix: bind repeated v0.3.3.3 correction identity

### DIFF
--- a/fixtures/release-identity/current-public-v0.3.3.3.json
+++ b/fixtures/release-identity/current-public-v0.3.3.3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "kind": "implementaudit-public-release-asset-readback",
+  "release_tag": "v0.3.3.3",
+  "release_id": 368332810,
+  "asset_name": "IMPLEMENTAUDIT.skill",
+  "asset_id": 510191694,
+  "api_bytes": 227999,
+  "api_digest": "sha256:151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e",
+  "download_bytes": 227999,
+  "download_sha256": "151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e"
+}

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "42f73752e84d63333a47b2e36b9289e961632191d28e33ea16fe5391b613179a",
+    "builder_sha256": "7caed3d302db2989b9970c84f7819b55d4d9ec6d612badb8d884eac07215e4e7",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "03d0e0fa65449513efe073c02a1bf91e5838134c2938d75cda061d9884fd63ad",
+    "builder_sha256": "42f73752e84d63333a47b2e36b9289e961632191d28e33ea16fe5391b613179a",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "package_evidence": {
     "builder_path": "scripts/build-release-asset.sh",
-    "builder_sha256": "7caed3d302db2989b9970c84f7819b55d4d9ec6d612badb8d884eac07215e4e7",
+    "builder_sha256": "f626c9fdbccf6faf75b8d3433bd0d3a15d82309ab59d3f7e7a4d53d8093a2f91",
     "repo_only_instrumentation": [
       "fixtures/semantic-preservation/cases.json",
       "fixtures/semantic-preservation/evaluate.py",

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -23,7 +23,7 @@ asset_name="IMPLEMENTAUDIT.skill"
 cleanup_dir=""
 
 check_release_identity() {
-  local mode="${1:-}" previous_identity="${2:-}" candidate_identity="" release_commit="" check_root="" candidate_asset=""
+  local mode="${1:-}" previous_identity="${2:-}" candidate_identity="" current_public_receipt="" release_commit="" check_root="" candidate_asset=""
   if [ "$mode" = "family-forward" ]; then
     candidate_identity="${3:-}"
     release_commit="${4:-}"
@@ -33,11 +33,12 @@ check_release_identity() {
       || fail "--check-release-identity family-forward requires <previous-tag> <candidate-tag> <release-commit> [repo-root] [candidate-asset]"
   elif [ "$mode" = "same-tag-correction" ]; then
     candidate_identity="$previous_identity"
-    release_commit="${3:-}"
-    check_root="${4:-$repo_root}"
-    candidate_asset="${5:-$check_root/$asset_name}"
-    [ -n "$candidate_identity" ] && [ -n "$release_commit" ] \
-      || fail "--check-release-identity same-tag-correction requires <public-tag> <release-commit> [repo-root] [candidate-asset]"
+    current_public_receipt="${3:-}"
+    release_commit="${4:-}"
+    check_root="${5:-$repo_root}"
+    candidate_asset="${6:-$check_root/$asset_name}"
+    [ -n "$candidate_identity" ] && [ -n "$current_public_receipt" ] && [ -n "$release_commit" ] \
+      || fail "--check-release-identity same-tag-correction requires <public-tag> <current-public-receipt> <release-commit> [repo-root] [candidate-asset]"
   else
     release_commit="${3:-}"
     check_root="${4:-$repo_root}"
@@ -45,7 +46,7 @@ check_release_identity() {
     [ -n "$mode" ] && [ -n "$previous_identity" ] && [ -n "$release_commit" ] \
       || fail "--check-release-identity requires <forward|republish> <previous-version> <release-commit> [repo-root] [candidate-asset]"
   fi
-  "${py_cmd[@]}" - "$mode" "$previous_identity" "$candidate_identity" "$release_commit" "$check_root" "$candidate_asset" <<'PY'
+  "${py_cmd[@]}" - "$mode" "$previous_identity" "$candidate_identity" "$current_public_receipt" "$release_commit" "$check_root" "$candidate_asset" <<'PY'
 import hashlib
 import json
 import re
@@ -53,7 +54,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-mode, previous_identity, candidate_identity, release_commit, root_arg, candidate_arg = sys.argv[1:]
+mode, previous_identity, candidate_identity, receipt_arg, release_commit, root_arg, candidate_arg = sys.argv[1:]
 root = Path(root_arg).resolve()
 if mode not in {"forward", "republish", "family-forward", "same-tag-correction"}:
     raise SystemExit(
@@ -167,6 +168,72 @@ if mode != "same-tag-correction" and previous_identity != authoritative_previous
     raise SystemExit(
         f"declared previous identity {previous_identity!r} != CHANGELOG authority {authoritative_previous!r}"
     )
+
+current_public_digest = ""
+current_public_bytes = 0
+if mode == "same-tag-correction":
+    receipt_path = Path(receipt_arg)
+    if not receipt_path.is_absolute():
+        receipt_path = root / receipt_path
+    if receipt_path.is_symlink() or not receipt_path.is_file():
+        raise SystemExit("same-tag correction current-public receipt must be a regular non-symlink JSON file")
+
+    def reject_duplicate_key(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        receipt = json.loads(
+            receipt_path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_key,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ValueError(f"non-standard constant {value!r}")
+            ),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"same-tag correction current-public receipt is invalid: {exc}") from exc
+
+    expected_receipt_keys = {
+        "schema_version",
+        "kind",
+        "release_tag",
+        "release_id",
+        "asset_name",
+        "asset_id",
+        "api_bytes",
+        "api_digest",
+        "download_bytes",
+        "download_sha256",
+    }
+    if not isinstance(receipt, dict) or set(receipt) != expected_receipt_keys:
+        raise SystemExit("same-tag correction current-public receipt has the wrong schema")
+    if (
+        isinstance(receipt["schema_version"], bool)
+        or receipt["schema_version"] != 1
+        or receipt["kind"] != "implementaudit-public-release-asset-readback"
+    ):
+        raise SystemExit("same-tag correction current-public receipt has the wrong schema identity")
+    if receipt["release_tag"] != candidate_identity:
+        raise SystemExit("same-tag correction current-public receipt names the wrong release tag")
+    if receipt["asset_name"] != "IMPLEMENTAUDIT.skill":
+        raise SystemExit("same-tag correction current-public receipt names the wrong asset")
+    for field in ("release_id", "asset_id", "api_bytes", "download_bytes"):
+        value = receipt[field]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise SystemExit(f"same-tag correction current-public receipt field {field} must be a positive integer")
+    api_digest = receipt["api_digest"]
+    download_digest = receipt["download_sha256"]
+    api_match = re.fullmatch(r"sha256:([0-9a-f]{64})", api_digest) if isinstance(api_digest, str) else None
+    if not api_match or not isinstance(download_digest, str) or not re.fullmatch(r"[0-9a-f]{64}", download_digest):
+        raise SystemExit("same-tag correction current-public receipt has an invalid digest")
+    current_public_digest = api_match.group(1)
+    current_public_bytes = receipt["api_bytes"]
+    if current_public_digest != download_digest or current_public_bytes != receipt["download_bytes"]:
+        raise SystemExit("same-tag correction current-public API and download readbacks disagree")
 
 resolved = subprocess.run(
     ["git", "-C", str(root), "rev-parse", "--verify", f"{release_commit}^{{commit}}"],
@@ -291,13 +358,21 @@ added = "\n".join(
     if line.startswith("+") and not line.startswith("+++")
 )
 if mode == "same-tag-correction":
-    pairs = re.findall(
-        r"(?ims)^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
-        r"`IMPLEMENTAUDIT\.skill`:\s+prematurely\s+published\s+"
-        r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
-        r"final\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$",
-        added,
+    pair_patterns = (
+        (
+            r"(?ims)^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
+            r"`IMPLEMENTAUDIT\.skill`:\s+prematurely\s+published\s+"
+            r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
+            r"final\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$"
+        ),
+        (
+            r"(?ims)^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
+            r"`IMPLEMENTAUDIT\.skill`:\s+current\s+public\s+"
+            r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
+            r"candidate\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$"
+        ),
     )
+    pairs = [pair for pattern in pair_patterns for pair in re.findall(pattern, added)]
 else:
     pairs = re.findall(
         r"(?ims)^[ \t]*-\s+`IMPLEMENTAUDIT\.skill`:\s+superseded\s+"
@@ -311,12 +386,10 @@ superseded_digest, superseded_bytes_text, superseding_digest, superseding_bytes_
 if superseded_digest == superseding_digest:
     raise SystemExit(f"{mode} digest pair must name distinct payloads")
 if mode == "same-tag-correction":
-    expected_digest = "bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536"
     superseded_bytes = int(superseded_bytes_text.replace(",", ""))
-    if superseded_digest != expected_digest or superseded_bytes != 227995:
+    if superseded_digest != current_public_digest or superseded_bytes != current_public_bytes:
         raise SystemExit(
-            "same-tag correction must supersede the premature v0.3.3.3 "
-            "IMPLEMENTAUDIT.skill digest and 227,995-byte payload"
+            "same-tag correction pair does not match the retained current-public receipt"
         )
 superseding_bytes = int(superseding_bytes_text.replace(",", ""))
 if superseding_digest != candidate_digest or superseding_bytes != candidate_bytes:

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -176,7 +176,7 @@ if mode == "same-tag-correction":
     if not receipt_path.is_absolute():
         receipt_path = root / receipt_path
     canonical_receipt_relpath = (
-        "docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+        "fixtures/release-identity/current-public-v0.3.3.3.json"
     )
     canonical_receipt_path = root / canonical_receipt_relpath
     if receipt_path.resolve() != canonical_receipt_path.resolve():

--- a/scripts/build-release-asset.sh
+++ b/scripts/build-release-asset.sh
@@ -175,6 +175,15 @@ if mode == "same-tag-correction":
     receipt_path = Path(receipt_arg)
     if not receipt_path.is_absolute():
         receipt_path = root / receipt_path
+    canonical_receipt_relpath = (
+        "docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+    )
+    canonical_receipt_path = root / canonical_receipt_relpath
+    if receipt_path.resolve() != canonical_receipt_path.resolve():
+        raise SystemExit(
+            "same-tag correction current-public receipt must use canonical "
+            f"repository custody at {canonical_receipt_relpath}"
+        )
     if receipt_path.is_symlink() or not receipt_path.is_file():
         raise SystemExit("same-tag correction current-public receipt must be a regular non-symlink JSON file")
 
@@ -244,6 +253,17 @@ resolved = subprocess.run(
 if resolved.returncode != 0:
     raise SystemExit("release identity commit does not resolve")
 commit_sha = resolved.stdout.strip()
+parent_sha = ""
+if mode == "same-tag-correction":
+    resolved_parent = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--verify", f"{commit_sha}^1^{{commit}}"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if resolved_parent.returncode != 0:
+        raise SystemExit("same-tag correction release commit must have a first parent")
+    parent_sha = resolved_parent.stdout.strip()
 owner_relpaths = [
     ".claude-plugin/plugin.json",
     "skills/implementaudit/SKILL.md",
@@ -251,6 +271,8 @@ owner_relpaths = [
 ]
 if mode in {"family-forward", "same-tag-correction"}:
     owner_relpaths.append("docs/portal/site.json")
+if mode == "same-tag-correction":
+    owner_relpaths.append(canonical_receipt_relpath)
 for owner_relpath in owner_relpaths:
     committed_owner = subprocess.run(
         ["git", "-C", str(root), "show", f"{commit_sha}:{owner_relpath}"],
@@ -264,6 +286,22 @@ for owner_relpath in owner_relpaths:
     if (root / owner_relpath).read_bytes() != committed_owner.stdout:
         raise SystemExit(
             f"release identity owner {owner_relpath} does not match release commit {commit_sha}"
+        )
+if mode == "same-tag-correction":
+    parent_receipt = subprocess.run(
+        ["git", "-C", str(root), "show", f"{parent_sha}:{canonical_receipt_relpath}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if parent_receipt.returncode != 0:
+        raise SystemExit(
+            "same-tag correction current-public receipt must be retained in the "
+            "release commit first parent"
+        )
+    if parent_receipt.stdout != receipt_path.read_bytes():
+        raise SystemExit(
+            "same-tag correction current-public receipt must remain byte-identical "
+            "from the release commit first parent"
         )
 commit_tree = subprocess.run(
     ["git", "-C", str(root), "rev-parse", f"{commit_sha}^{{tree}}"],
@@ -358,21 +396,70 @@ added = "\n".join(
     if line.startswith("+") and not line.startswith("+++")
 )
 if mode == "same-tag-correction":
-    pair_patterns = (
-        (
-            r"(?ims)^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
+    pair_patterns = {
+        "historical": re.compile(
+            r"^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
             r"`IMPLEMENTAUDIT\.skill`:\s+prematurely\s+published\s+"
             r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
-            r"final\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$"
+            r"final\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$",
+            re.IGNORECASE,
         ),
-        (
-            r"(?ims)^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
+        "current": re.compile(
+            r"^[ \t]*-\s+same-tag\s+correction\s+for\s+`v0\.3\.3\.3`\s+"
             r"`IMPLEMENTAUDIT\.skill`:\s+current\s+public\s+"
             r"`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*(?:→|->)\s*"
-            r"candidate\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$"
+            r"candidate\s+`?([0-9a-f]{64})`?\s*\(([0-9][0-9,]*)\s+bytes?\)\s*\.?\s*$",
+            re.IGNORECASE,
         ),
-    )
-    pairs = [pair for pattern in pair_patterns for pair in re.findall(pattern, added)]
+    }
+
+    def committed_changelog(commit):
+        shown_changelog = subprocess.run(
+            ["git", "-C", str(root), "show", f"{commit}:CHANGELOG.md"],
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if shown_changelog.returncode != 0:
+            raise SystemExit(
+                f"same-tag correction CHANGELOG.md is missing from commit {commit}"
+            )
+        return shown_changelog.stdout
+
+    def correction_rows(text):
+        rows = []
+        for line in text.splitlines():
+            for grammar, pattern in pair_patterns.items():
+                match = pattern.fullmatch(line)
+                if match:
+                    rows.append((grammar, line, match.groups()))
+                    break
+        return rows
+
+    parent_rows = correction_rows(committed_changelog(parent_sha))
+    current_rows = correction_rows(committed_changelog(commit_sha))
+    if (
+        len(current_rows) != len(parent_rows) + 1
+        or current_rows[: len(parent_rows)] != parent_rows
+    ):
+        raise SystemExit(
+            "same-tag correction must preserve every historical correction pair "
+            "and append exactly one new pair"
+        )
+    new_grammar, new_pair_line, new_pair = current_rows[-1]
+    required_grammar = "historical" if not parent_rows else "current"
+    if new_grammar != required_grammar:
+        raise SystemExit(
+            "same-tag correction must use prematurely-published-to-final grammar "
+            "only for the first correction and current-public-to-candidate grammar "
+            "for every repeated correction"
+        )
+    if added.splitlines().count(new_pair_line) != 1:
+        raise SystemExit(
+            "same-tag correction release commit must add its new canonical "
+            "IMPLEMENTAUDIT.skill pair"
+        )
+    pairs = [new_pair]
 else:
     pairs = re.findall(
         r"(?ims)^[ \t]*-\s+`IMPLEMENTAUDIT\.skill`:\s+superseded\s+"

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -21,10 +21,10 @@ if [ "${1:-}" = "--release-identity" ]; then
       shift 5
       ;;
     same-tag-correction)
-      [ "$#" -eq 4 ] \
-        || fail "--release-identity same-tag-correction requires <public-tag> <release-commit>"
-      release_identity_args=("$2" "$3" "$4")
-      shift 4
+      [ "$#" -eq 5 ] \
+        || fail "--release-identity same-tag-correction requires <public-tag> <current-public-receipt> <release-commit>"
+      release_identity_args=("$2" "$3" "$4" "$5")
+      shift 5
       ;;
     forward|republish)
       [ "$#" -eq 4 ] \

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -17,6 +17,23 @@ if [ "${1:-}" = "--identity-only" ]; then
   a_digest='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
   b_digest='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 
+  write_public_receipt() {
+    local path="$1" tag="$2" digest="$3" bytes="$4" release_id="$5" asset_id="$6"
+    printf '%s\n' \
+      '{' \
+      '  "schema_version": 1,' \
+      '  "kind": "implementaudit-public-release-asset-readback",' \
+      "  \"release_tag\": \"$tag\"," \
+      "  \"release_id\": $release_id," \
+      '  "asset_name": "IMPLEMENTAUDIT.skill",' \
+      "  \"asset_id\": $asset_id," \
+      "  \"api_bytes\": $bytes," \
+      "  \"api_digest\": \"sha256:$digest\"," \
+      "  \"download_bytes\": $bytes," \
+      "  \"download_sha256\": \"$digest\"" \
+      '}' > "$path"
+  }
+
   make_fixture() {
     local root="$1" version="$2" previous_tag="${3:-v0.3.2.0}"
     mkdir -p "$root/.claude-plugin" "$root/skills/implementaudit"
@@ -60,6 +77,8 @@ if [ "${1:-}" = "--identity-only" ]; then
     local pair_count="${6:-1}"
     local old_digest='bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536'
     make_fixture "$root" "$runtime_version" v0.3.3.0
+    write_public_receipt "$root/current-public-receipt.json" "$public_tag" \
+      "$old_digest" 227995 368332810 509660798
     mkdir -p "$root/docs/portal"
     printf '{"release":{"milestone":"%s","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/%s"}}\n' \
       "$site_milestone" "$ledger_name" > "$root/docs/portal/site.json"
@@ -94,20 +113,189 @@ if [ "${1:-}" = "--identity-only" ]; then
     git -C "$root" merge -q --no-ff -m merge-correction "$correction_commit"
   }
 
+  make_repeated_same_tag_correction_fixture() {
+    local root="$1" pair_count="${2:-1}"
+    local current_digest='151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e'
+    make_fixture "$root" 0.3.3 v0.3.3.0
+    mkdir -p "$root/docs/portal"
+    cp fixtures/release-identity/current-public-v0.3.3.3.json \
+      "$root/current-public-receipt.json"
+    printf '%s\n' \
+      '{"release":{"milestone":"v0.3.3.3","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.3-release-report.md"}}' \
+      > "$root/docs/portal/site.json"
+    {
+      printf '# Changelog\n\n## [v0.3.3.3] - 2026-08-11\n\n'
+      printf -- '- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `%s` (227,995 bytes) -> final `%s` (227,999 bytes).\n\n' \
+        'bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536' \
+        "$current_digest"
+      tail -n +3 "$root/CHANGELOG.md"
+    } > "$root/CHANGELOG.md.next"
+    mv "$root/CHANGELOG.md.next" "$root/CHANGELOG.md"
+    git -C "$root" add .
+    git -C "$root" commit -qm first-public-correction
+
+    printf 'repeated corrected package bytes\n' > "$root/IMPLEMENTAUDIT.skill"
+    local candidate_digest candidate_bytes
+    candidate_digest="$(sha256sum "$root/IMPLEMENTAUDIT.skill" | awk '{print $1}')"
+    candidate_bytes="$(wc -c < "$root/IMPLEMENTAUDIT.skill" | tr -d '[:space:]')"
+    for _ in $(seq 1 "$pair_count"); do
+      printf '\n- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: current public `%s` (227,999 bytes) -> candidate `%s` (%s bytes).\n' \
+        "$current_digest" "$candidate_digest" "$candidate_bytes" >> "$root/CHANGELOG.md"
+    done
+    git -C "$root" add IMPLEMENTAUDIT.skill CHANGELOG.md
+    git -C "$root" commit -qm repeated-same-tag-correction
+  }
+
   same_tag_correction="$tmp_parent/same-tag-correction"
   make_same_tag_correction_fixture "$same_tag_correction"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 HEAD "$same_tag_correction" >/dev/null \
+    same-tag-correction v0.3.3.3 "$same_tag_correction/current-public-receipt.json" \
+    HEAD "$same_tag_correction" >/dev/null \
     || fail 'valid v0.3.3.3 same-tag correction was rejected'
 
   same_tag_merge="$tmp_parent/same-tag-merge"
   make_same_tag_merge_fixture "$same_tag_merge"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 HEAD "$same_tag_merge" >/dev/null \
+    same-tag-correction v0.3.3.3 "$same_tag_merge/current-public-receipt.json" \
+    HEAD "$same_tag_merge" >/dev/null \
     || fail 'valid same-tag correction merged through a pull request was rejected'
 
+  repeated_same_tag="$tmp_parent/repeated-same-tag"
+  make_repeated_same_tag_correction_fixture "$repeated_same_tag"
+  bash scripts/build-release-asset.sh --check-release-identity \
+    same-tag-correction v0.3.3.3 "$repeated_same_tag/current-public-receipt.json" \
+    HEAD "$repeated_same_tag" >/dev/null \
+    || fail 'valid repeated v0.3.3.3 correction bound to current public receipt was rejected'
+  [ "$(grep -c 'same-tag correction for `v0.3.3.3`' "$repeated_same_tag/CHANGELOG.md")" -eq 2 ] \
+    || fail 'repeated correction did not preserve the earlier same-tag pair as chronology'
+
+  repeated_stale_receipt="$tmp_parent/repeated-stale-receipt"
+  make_repeated_same_tag_correction_fixture "$repeated_stale_receipt"
+  sed -i \
+    -e 's/151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e/bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536/g' \
+    -e 's/227999/227995/g' \
+    "$repeated_stale_receipt/current-public-receipt.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.2 HEAD "$same_tag_correction" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$repeated_stale_receipt/current-public-receipt.json" \
+      HEAD "$repeated_stale_receipt" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a stale first-publication receipt as the current preimage'
+  fi
+
+  repeated_disagreeing_receipt="$tmp_parent/repeated-disagreeing-receipt"
+  make_repeated_same_tag_correction_fixture "$repeated_disagreeing_receipt"
+  sed -i \
+    's/"download_sha256": "[0-9a-f]*"/"download_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/' \
+    "$repeated_disagreeing_receipt/current-public-receipt.json"
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_disagreeing_receipt/current-public-receipt.json" \
+      HEAD "$repeated_disagreeing_receipt" >/dev/null 2>&1; then
+    fail 'repeated correction accepted disagreeing API and download readbacks'
+  fi
+
+  repeated_wrong_tag_receipt="$tmp_parent/repeated-wrong-tag-receipt"
+  make_repeated_same_tag_correction_fixture "$repeated_wrong_tag_receipt"
+  sed -i 's/"release_tag": "v0.3.3.3"/"release_tag": "v0.3.3.2"/' \
+    "$repeated_wrong_tag_receipt/current-public-receipt.json"
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_tag_receipt/current-public-receipt.json" \
+      HEAD "$repeated_wrong_tag_receipt" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a current-public receipt for another tag'
+  fi
+
+  repeated_missing_pair="$tmp_parent/repeated-missing-pair"
+  make_repeated_same_tag_correction_fixture "$repeated_missing_pair"
+  sed -i '/current public/d' "$repeated_missing_pair/CHANGELOG.md"
+  git -C "$repeated_missing_pair" add CHANGELOG.md
+  git -C "$repeated_missing_pair" commit -qm repeated-missing-pair
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_missing_pair/current-public-receipt.json" \
+      HEAD "$repeated_missing_pair" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a release commit without a new current-to-candidate pair'
+  fi
+
+  repeated_duplicate_pair="$tmp_parent/repeated-duplicate-pair"
+  make_repeated_same_tag_correction_fixture "$repeated_duplicate_pair" 2
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_duplicate_pair/current-public-receipt.json" \
+      HEAD "$repeated_duplicate_pair" >/dev/null 2>&1; then
+    fail 'repeated correction accepted duplicate current-to-candidate pairs'
+  fi
+
+  repeated_unchanged_digest="$tmp_parent/repeated-unchanged-digest"
+  make_repeated_same_tag_correction_fixture "$repeated_unchanged_digest"
+  sed -i -E \
+    '/current public/s/(candidate `)[0-9a-f]{64}/\1151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e/' \
+    "$repeated_unchanged_digest/CHANGELOG.md"
+  git -C "$repeated_unchanged_digest" add CHANGELOG.md
+  git -C "$repeated_unchanged_digest" commit -qm repeated-unchanged-digest
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_unchanged_digest/current-public-receipt.json" \
+      HEAD "$repeated_unchanged_digest" >/dev/null 2>&1; then
+    fail 'repeated correction accepted an unchanged current-public digest'
+  fi
+
+  repeated_wrong_candidate="$tmp_parent/repeated-wrong-candidate"
+  make_repeated_same_tag_correction_fixture "$repeated_wrong_candidate"
+  sed -i -E \
+    '/current public/s/(candidate `)[0-9a-f]{64}/\1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/' \
+    "$repeated_wrong_candidate/CHANGELOG.md"
+  git -C "$repeated_wrong_candidate" add CHANGELOG.md
+  git -C "$repeated_wrong_candidate" commit -qm repeated-wrong-candidate
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate/current-public-receipt.json" \
+      HEAD "$repeated_wrong_candidate" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a candidate digest that does not match the asset'
+  fi
+
+  repeated_wrong_candidate_bytes="$tmp_parent/repeated-wrong-candidate-bytes"
+  make_repeated_same_tag_correction_fixture "$repeated_wrong_candidate_bytes"
+  sed -i -E '/current public/s/(candidate `[^`]+` \()[0-9,]+/\1999/' \
+    "$repeated_wrong_candidate_bytes/CHANGELOG.md"
+  git -C "$repeated_wrong_candidate_bytes" add CHANGELOG.md
+  git -C "$repeated_wrong_candidate_bytes" commit -qm repeated-wrong-candidate-bytes
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate_bytes/current-public-receipt.json" \
+      HEAD "$repeated_wrong_candidate_bytes" >/dev/null 2>&1; then
+    fail 'repeated correction accepted candidate bytes that do not match the asset'
+  fi
+
+  repeated_dirty_owner="$tmp_parent/repeated-dirty-owner"
+  make_repeated_same_tag_correction_fixture "$repeated_dirty_owner"
+  printf '\n' >> "$repeated_dirty_owner/docs/portal/site.json"
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_dirty_owner/current-public-receipt.json" \
+      HEAD "$repeated_dirty_owner" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a dirty release identity owner'
+  fi
+
+  repeated_non_head="$tmp_parent/repeated-non-head"
+  make_repeated_same_tag_correction_fixture "$repeated_non_head"
+  repeated_release_commit="$(git -C "$repeated_non_head" rev-parse HEAD)"
+  printf 'later repeated tree\n' >> "$repeated_non_head/payload.txt"
+  git -C "$repeated_non_head" add payload.txt
+  git -C "$repeated_non_head" commit -qm repeated-later-tree
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_non_head/current-public-receipt.json" \
+      "$repeated_release_commit" "$repeated_non_head" >/dev/null 2>&1; then
+    fail 'repeated correction accepted a non-HEAD release commit/tree'
+  fi
+
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      forward 0.3.3.3 HEAD "$repeated_same_tag" >/dev/null 2>&1; then
+    fail 'forward substituted for a repeated same-tag correction'
+  fi
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      republish 0.3.3 HEAD "$repeated_same_tag" >/dev/null 2>&1; then
+    fail 'republish substituted for a repeated same-tag correction'
+  fi
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      family-forward v0.3.3.0 v0.3.3.3 HEAD "$repeated_same_tag" >/dev/null 2>&1; then
+    fail 'family-forward substituted for a repeated same-tag correction'
+  fi
+
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.2 "$same_tag_correction/current-public-receipt.json" \
+      HEAD "$same_tag_correction" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a different public tag'
   fi
 
@@ -117,7 +305,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_missing_pair" add CHANGELOG.md
   git -C "$same_tag_missing_pair" commit -qm remove-pair
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_missing_pair" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_missing_pair/current-public-receipt.json" \
+      HEAD "$same_tag_missing_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a commit without the replacement pair'
   fi
 
@@ -125,7 +314,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_same_tag_correction_fixture "$same_tag_duplicate_pair" \
     0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.3-release-report.md 2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_duplicate_pair" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_duplicate_pair/current-public-receipt.json" \
+      HEAD "$same_tag_duplicate_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted duplicate replacement pairs'
   fi
 
@@ -137,7 +327,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_unchanged_digest" add CHANGELOG.md
   git -C "$same_tag_unchanged_digest" commit -qm unchanged-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_unchanged_digest" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_unchanged_digest/current-public-receipt.json" \
+      HEAD "$same_tag_unchanged_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted an unchanged package digest'
   fi
 
@@ -149,7 +340,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_old_digest" commit -qm wrong-old-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_old_digest" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_digest/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_old_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package digest'
   fi
 
@@ -159,7 +351,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_old_bytes" commit -qm wrong-old-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_old_bytes" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_bytes/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_old_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package byte count'
   fi
 
@@ -171,7 +364,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_new_digest" commit -qm wrong-new-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_new_digest" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_digest/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_new_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement digest that does not match the candidate'
   fi
 
@@ -182,7 +376,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_new_bytes" commit -qm wrong-new-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_new_bytes" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_bytes/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_new_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement byte count that does not match the candidate'
   fi
 
@@ -196,7 +391,8 @@ if [ "${1:-}" = "--identity-only" ]; then
     make_same_tag_correction_fixture "$dirty_owner_root"
     printf '\n' >> "$dirty_owner_root/$dirty_owner"
     if bash scripts/build-release-asset.sh --check-release-identity \
-        same-tag-correction v0.3.3.3 HEAD "$dirty_owner_root" >/dev/null 2>&1; then
+        same-tag-correction v0.3.3.3 "$dirty_owner_root/current-public-receipt.json" \
+        HEAD "$dirty_owner_root" >/dev/null 2>&1; then
       fail "same-tag correction accepted dirty release identity owner $dirty_owner"
     fi
   done
@@ -204,21 +400,24 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_portal="$tmp_parent/same-tag-wrong-portal"
   make_same_tag_correction_fixture "$same_tag_wrong_portal" 0.3.3 v0.3.3.3 v0.3.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_portal" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_portal/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_portal" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong portal milestone'
   fi
 
   same_tag_wrong_ledger="$tmp_parent/same-tag-wrong-ledger"
   make_same_tag_correction_fixture "$same_tag_wrong_ledger" 0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.2-release-report.md
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_ledger" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_ledger/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_ledger" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong release ledger'
   fi
 
   same_tag_wrong_runtime="$tmp_parent/same-tag-wrong-runtime"
   make_same_tag_correction_fixture "$same_tag_wrong_runtime" 0.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 HEAD "$same_tag_wrong_runtime" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_runtime/current-public-receipt.json" \
+      HEAD "$same_tag_wrong_runtime" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a runtime outside 0.3.3'
   fi
 
@@ -229,7 +428,8 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_non_head" add payload.txt
   git -C "$same_tag_non_head" commit -qm later-tree
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_release_commit" "$same_tag_non_head" >/dev/null 2>&1; then
+      same-tag-correction v0.3.3.3 "$same_tag_non_head/current-public-receipt.json" \
+      "$same_tag_release_commit" "$same_tag_non_head" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a non-HEAD release commit/tree'
   fi
 
@@ -250,7 +450,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   verify_same_tag_output="$(bash scripts/verify-package.sh \
     --release-identity same-tag-correction 2>&1 || true)"
   case "$verify_same_tag_output" in
-    *"--release-identity same-tag-correction requires <public-tag> <release-commit>"*) : ;;
+    *"--release-identity same-tag-correction requires <public-tag> <current-public-receipt> <release-commit>"*) : ;;
     *) fail 'verify-package.sh did not expose same-tag-correction identity mode' ;;
   esac
 

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -77,8 +77,12 @@ if [ "${1:-}" = "--identity-only" ]; then
     local pair_count="${6:-1}"
     local old_digest='bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536'
     make_fixture "$root" "$runtime_version" v0.3.3.0
-    write_public_receipt "$root/current-public-receipt.json" "$public_tag" \
+    mkdir -p "$root/docs/audits/archive"
+    write_public_receipt "$root/docs/audits/archive/v0.3.3.3-current-public-receipt.json" "$public_tag" \
       "$old_digest" 227995 368332810 509660798
+    git -C "$root" add docs/audits/archive/v0.3.3.3-current-public-receipt.json
+    git -C "$root" -c user.email=t@example.invalid -c user.name=t \
+      commit -qm retain-current-public-receipt
     mkdir -p "$root/docs/portal"
     printf '{"release":{"milestone":"%s","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/%s"}}\n' \
       "$site_milestone" "$ledger_name" > "$root/docs/portal/site.json"
@@ -115,19 +119,21 @@ if [ "${1:-}" = "--identity-only" ]; then
 
   make_repeated_same_tag_correction_fixture() {
     local root="$1" pair_count="${2:-1}"
-    local current_digest='151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e'
+    local current_digest="${3:-151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e}"
+    local current_bytes="${4:-227999}"
+    local history_action="${5:-preserve}" grammar="${6:-current}"
     make_fixture "$root" 0.3.3 v0.3.3.0
-    mkdir -p "$root/docs/portal"
+    mkdir -p "$root/docs/audits/archive" "$root/docs/portal"
     cp fixtures/release-identity/current-public-v0.3.3.3.json \
-      "$root/current-public-receipt.json"
+      "$root/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
     printf '%s\n' \
       '{"release":{"milestone":"v0.3.3.3","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.3-release-report.md"}}' \
       > "$root/docs/portal/site.json"
     {
       printf '# Changelog\n\n## [v0.3.3.3] - 2026-08-11\n\n'
-      printf -- '- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `%s` (227,995 bytes) -> final `%s` (227,999 bytes).\n\n' \
+      printf -- '- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `%s` (227,995 bytes) -> final `%s` (%s bytes).\n\n' \
         'bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536' \
-        "$current_digest"
+        "$current_digest" "$current_bytes"
       tail -n +3 "$root/CHANGELOG.md"
     } > "$root/CHANGELOG.md.next"
     mv "$root/CHANGELOG.md.next" "$root/CHANGELOG.md"
@@ -138,9 +144,15 @@ if [ "${1:-}" = "--identity-only" ]; then
     local candidate_digest candidate_bytes
     candidate_digest="$(sha256sum "$root/IMPLEMENTAUDIT.skill" | awk '{print $1}')"
     candidate_bytes="$(wc -c < "$root/IMPLEMENTAUDIT.skill" | tr -d '[:space:]')"
+    [ "$history_action" = preserve ] || sed -i '/prematurely published/d' "$root/CHANGELOG.md"
     for _ in $(seq 1 "$pair_count"); do
-      printf '\n- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: current public `%s` (227,999 bytes) -> candidate `%s` (%s bytes).\n' \
-        "$current_digest" "$candidate_digest" "$candidate_bytes" >> "$root/CHANGELOG.md"
+      if [ "$grammar" = historical ]; then
+        printf '\n- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: prematurely published `%s` (%s bytes) -> final `%s` (%s bytes).\n' \
+          "$current_digest" "$current_bytes" "$candidate_digest" "$candidate_bytes" >> "$root/CHANGELOG.md"
+      else
+        printf '\n- same-tag correction for `v0.3.3.3` `IMPLEMENTAUDIT.skill`: current public `%s` (%s bytes) -> candidate `%s` (%s bytes).\n' \
+          "$current_digest" "$current_bytes" "$candidate_digest" "$candidate_bytes" >> "$root/CHANGELOG.md"
+      fi
     done
     git -C "$root" add IMPLEMENTAUDIT.skill CHANGELOG.md
     git -C "$root" commit -qm repeated-same-tag-correction
@@ -149,34 +161,66 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_correction="$tmp_parent/same-tag-correction"
   make_same_tag_correction_fixture "$same_tag_correction"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$same_tag_correction/current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$same_tag_correction/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
     HEAD "$same_tag_correction" >/dev/null \
     || fail 'valid v0.3.3.3 same-tag correction was rejected'
 
   same_tag_merge="$tmp_parent/same-tag-merge"
   make_same_tag_merge_fixture "$same_tag_merge"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$same_tag_merge/current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$same_tag_merge/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
     HEAD "$same_tag_merge" >/dev/null \
     || fail 'valid same-tag correction merged through a pull request was rejected'
 
   repeated_same_tag="$tmp_parent/repeated-same-tag"
   make_repeated_same_tag_correction_fixture "$repeated_same_tag"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$repeated_same_tag/current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$repeated_same_tag/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
     HEAD "$repeated_same_tag" >/dev/null \
     || fail 'valid repeated v0.3.3.3 correction bound to current public receipt was rejected'
   [ "$(grep -c 'same-tag correction for `v0.3.3.3`' "$repeated_same_tag/CHANGELOG.md")" -eq 2 ] \
     || fail 'repeated correction did not preserve the earlier same-tag pair as chronology'
+
+  repeated_deleted_history="$tmp_parent/repeated-deleted-history"
+  make_repeated_same_tag_correction_fixture "$repeated_deleted_history" 1 \
+    151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e 227999 delete
+
+  repeated_fake_receipt="$tmp_parent/repeated-fake-receipt"
+  make_repeated_same_tag_correction_fixture "$repeated_fake_receipt" 1 "$a_digest" 123
+  write_public_receipt "$repeated_fake_receipt/untracked-self-authored-receipt.json" \
+    v0.3.3.3 "$a_digest" 123 1 1
+
+  repeated_historical_grammar="$tmp_parent/repeated-historical-grammar"
+  make_repeated_same_tag_correction_fixture "$repeated_historical_grammar" 1 \
+    151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e 227999 preserve historical
+
+  accepted_heldouts=()
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_deleted_history/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      HEAD "$repeated_deleted_history" >/dev/null 2>&1; then
+    accepted_heldouts+=(deleted-history)
+  fi
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_fake_receipt/untracked-self-authored-receipt.json" \
+      HEAD "$repeated_fake_receipt" >/dev/null 2>&1; then
+    accepted_heldouts+=(untracked-self-authored-receipt)
+  fi
+  if bash scripts/build-release-asset.sh --check-release-identity \
+      same-tag-correction v0.3.3.3 "$repeated_historical_grammar/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      HEAD "$repeated_historical_grammar" >/dev/null 2>&1; then
+    accepted_heldouts+=(repeated-historical-grammar)
+  fi
+  [ "${#accepted_heldouts[@]}" -eq 0 ] \
+    || fail "same-tag correction accepted held-outs: ${accepted_heldouts[*]}"
 
   repeated_stale_receipt="$tmp_parent/repeated-stale-receipt"
   make_repeated_same_tag_correction_fixture "$repeated_stale_receipt"
   sed -i \
     -e 's/151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e/bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536/g' \
     -e 's/227999/227995/g' \
-    "$repeated_stale_receipt/current-public-receipt.json"
+    "$repeated_stale_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_stale_receipt/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_stale_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_stale_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted a stale first-publication receipt as the current preimage'
   fi
@@ -185,9 +229,9 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_repeated_same_tag_correction_fixture "$repeated_disagreeing_receipt"
   sed -i \
     's/"download_sha256": "[0-9a-f]*"/"download_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/' \
-    "$repeated_disagreeing_receipt/current-public-receipt.json"
+    "$repeated_disagreeing_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_disagreeing_receipt/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_disagreeing_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_disagreeing_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted disagreeing API and download readbacks'
   fi
@@ -195,9 +239,9 @@ if [ "${1:-}" = "--identity-only" ]; then
   repeated_wrong_tag_receipt="$tmp_parent/repeated-wrong-tag-receipt"
   make_repeated_same_tag_correction_fixture "$repeated_wrong_tag_receipt"
   sed -i 's/"release_tag": "v0.3.3.3"/"release_tag": "v0.3.3.2"/' \
-    "$repeated_wrong_tag_receipt/current-public-receipt.json"
+    "$repeated_wrong_tag_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_tag_receipt/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_tag_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_wrong_tag_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted a current-public receipt for another tag'
   fi
@@ -208,7 +252,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_missing_pair" add CHANGELOG.md
   git -C "$repeated_missing_pair" commit -qm repeated-missing-pair
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_missing_pair/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_missing_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_missing_pair" >/dev/null 2>&1; then
     fail 'repeated correction accepted a release commit without a new current-to-candidate pair'
   fi
@@ -216,7 +260,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   repeated_duplicate_pair="$tmp_parent/repeated-duplicate-pair"
   make_repeated_same_tag_correction_fixture "$repeated_duplicate_pair" 2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_duplicate_pair/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_duplicate_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_duplicate_pair" >/dev/null 2>&1; then
     fail 'repeated correction accepted duplicate current-to-candidate pairs'
   fi
@@ -229,7 +273,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_unchanged_digest" add CHANGELOG.md
   git -C "$repeated_unchanged_digest" commit -qm repeated-unchanged-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_unchanged_digest/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_unchanged_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_unchanged_digest" >/dev/null 2>&1; then
     fail 'repeated correction accepted an unchanged current-public digest'
   fi
@@ -242,7 +286,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_wrong_candidate" add CHANGELOG.md
   git -C "$repeated_wrong_candidate" commit -qm repeated-wrong-candidate
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_wrong_candidate" >/dev/null 2>&1; then
     fail 'repeated correction accepted a candidate digest that does not match the asset'
   fi
@@ -254,7 +298,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_wrong_candidate_bytes" add CHANGELOG.md
   git -C "$repeated_wrong_candidate_bytes" commit -qm repeated-wrong-candidate-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate_bytes/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_wrong_candidate_bytes" >/dev/null 2>&1; then
     fail 'repeated correction accepted candidate bytes that do not match the asset'
   fi
@@ -263,7 +307,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_repeated_same_tag_correction_fixture "$repeated_dirty_owner"
   printf '\n' >> "$repeated_dirty_owner/docs/portal/site.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_dirty_owner/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_dirty_owner/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$repeated_dirty_owner" >/dev/null 2>&1; then
     fail 'repeated correction accepted a dirty release identity owner'
   fi
@@ -275,7 +319,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_non_head" add payload.txt
   git -C "$repeated_non_head" commit -qm repeated-later-tree
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_non_head/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_non_head/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       "$repeated_release_commit" "$repeated_non_head" >/dev/null 2>&1; then
     fail 'repeated correction accepted a non-HEAD release commit/tree'
   fi
@@ -294,7 +338,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   fi
 
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.2 "$same_tag_correction/current-public-receipt.json" \
+      same-tag-correction v0.3.3.2 "$same_tag_correction/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_correction" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a different public tag'
   fi
@@ -305,7 +349,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_missing_pair" add CHANGELOG.md
   git -C "$same_tag_missing_pair" commit -qm remove-pair
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_missing_pair/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_missing_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_missing_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a commit without the replacement pair'
   fi
@@ -314,7 +358,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_same_tag_correction_fixture "$same_tag_duplicate_pair" \
     0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.3-release-report.md 2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_duplicate_pair/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_duplicate_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_duplicate_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted duplicate replacement pairs'
   fi
@@ -327,7 +371,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_unchanged_digest" add CHANGELOG.md
   git -C "$same_tag_unchanged_digest" commit -qm unchanged-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_unchanged_digest/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_unchanged_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_unchanged_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted an unchanged package digest'
   fi
@@ -340,7 +384,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_old_digest" commit -qm wrong-old-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_digest/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_old_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package digest'
   fi
@@ -351,7 +395,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_old_bytes" commit -qm wrong-old-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_bytes/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_old_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package byte count'
   fi
@@ -364,7 +408,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_new_digest" commit -qm wrong-new-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_digest/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_new_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement digest that does not match the candidate'
   fi
@@ -376,7 +420,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_new_bytes" commit -qm wrong-new-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_bytes/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_new_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement byte count that does not match the candidate'
   fi
@@ -391,7 +435,7 @@ if [ "${1:-}" = "--identity-only" ]; then
     make_same_tag_correction_fixture "$dirty_owner_root"
     printf '\n' >> "$dirty_owner_root/$dirty_owner"
     if bash scripts/build-release-asset.sh --check-release-identity \
-        same-tag-correction v0.3.3.3 "$dirty_owner_root/current-public-receipt.json" \
+        same-tag-correction v0.3.3.3 "$dirty_owner_root/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
         HEAD "$dirty_owner_root" >/dev/null 2>&1; then
       fail "same-tag correction accepted dirty release identity owner $dirty_owner"
     fi
@@ -400,7 +444,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_portal="$tmp_parent/same-tag-wrong-portal"
   make_same_tag_correction_fixture "$same_tag_wrong_portal" 0.3.3 v0.3.3.3 v0.3.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_portal/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_portal/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_portal" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong portal milestone'
   fi
@@ -408,7 +452,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_ledger="$tmp_parent/same-tag-wrong-ledger"
   make_same_tag_correction_fixture "$same_tag_wrong_ledger" 0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.2-release-report.md
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_ledger/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_ledger/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_ledger" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong release ledger'
   fi
@@ -416,7 +460,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_runtime="$tmp_parent/same-tag-wrong-runtime"
   make_same_tag_correction_fixture "$same_tag_wrong_runtime" 0.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_runtime/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_runtime/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       HEAD "$same_tag_wrong_runtime" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a runtime outside 0.3.3'
   fi
@@ -428,7 +472,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_non_head" add payload.txt
   git -C "$same_tag_non_head" commit -qm later-tree
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_non_head/current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_non_head/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
       "$same_tag_release_commit" "$same_tag_non_head" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a non-HEAD release commit/tree'
   fi

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -10,6 +10,17 @@ trap 'rm -rf "$tmp_parent"; rm -f "$stray_file"' EXIT
 
 if [ "${1:-}" = "--identity-only" ]; then
   fail() { printf 'release-asset.test: %s\n' "$*" >&2; exit 1; }
+  canonical_receipt='fixtures/release-identity/current-public-v0.3.3.3.json'
+  [ -f "$canonical_receipt" ] \
+    || fail 'canonical current-public receipt is absent from the real worktree'
+  git show "HEAD^:$canonical_receipt" > "$tmp_parent/parent-current-public-receipt.json" \
+    || fail 'canonical current-public receipt is absent from the real first parent'
+  git show "HEAD:$canonical_receipt" > "$tmp_parent/head-current-public-receipt.json" \
+    || fail 'canonical current-public receipt is absent from the real HEAD'
+  cmp -s "$tmp_parent/parent-current-public-receipt.json" "$canonical_receipt" \
+    || fail 'canonical current-public receipt differs between first parent and worktree'
+  cmp -s "$tmp_parent/head-current-public-receipt.json" "$canonical_receipt" \
+    || fail 'canonical current-public receipt differs between HEAD and worktree'
   grep -Fq -- '--check-release-identity' scripts/build-release-asset.sh \
     || fail 'release-identity checker mode is missing'
   grep -Fq -- '--check-stale-artifact' scripts/build-release-asset.sh \
@@ -77,10 +88,10 @@ if [ "${1:-}" = "--identity-only" ]; then
     local pair_count="${6:-1}"
     local old_digest='bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536'
     make_fixture "$root" "$runtime_version" v0.3.3.0
-    mkdir -p "$root/docs/audits/archive"
-    write_public_receipt "$root/docs/audits/archive/v0.3.3.3-current-public-receipt.json" "$public_tag" \
+    mkdir -p "$root/fixtures/release-identity"
+    write_public_receipt "$root/fixtures/release-identity/current-public-v0.3.3.3.json" "$public_tag" \
       "$old_digest" 227995 368332810 509660798
-    git -C "$root" add docs/audits/archive/v0.3.3.3-current-public-receipt.json
+    git -C "$root" add fixtures/release-identity/current-public-v0.3.3.3.json
     git -C "$root" -c user.email=t@example.invalid -c user.name=t \
       commit -qm retain-current-public-receipt
     mkdir -p "$root/docs/portal"
@@ -123,9 +134,9 @@ if [ "${1:-}" = "--identity-only" ]; then
     local current_bytes="${4:-227999}"
     local history_action="${5:-preserve}" grammar="${6:-current}"
     make_fixture "$root" 0.3.3 v0.3.3.0
-    mkdir -p "$root/docs/audits/archive" "$root/docs/portal"
+    mkdir -p "$root/fixtures/release-identity" "$root/docs/portal"
     cp fixtures/release-identity/current-public-v0.3.3.3.json \
-      "$root/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+      "$root/fixtures/release-identity/current-public-v0.3.3.3.json"
     printf '%s\n' \
       '{"release":{"milestone":"v0.3.3.3","audit_ledger_url":"https://github.com/theislampill/IMPLEMENTAUDIT.md/blob/main/docs/audits/archive/v0.3.3.3-release-report.md"}}' \
       > "$root/docs/portal/site.json"
@@ -161,21 +172,21 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_correction="$tmp_parent/same-tag-correction"
   make_same_tag_correction_fixture "$same_tag_correction"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$same_tag_correction/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$same_tag_correction/fixtures/release-identity/current-public-v0.3.3.3.json" \
     HEAD "$same_tag_correction" >/dev/null \
     || fail 'valid v0.3.3.3 same-tag correction was rejected'
 
   same_tag_merge="$tmp_parent/same-tag-merge"
   make_same_tag_merge_fixture "$same_tag_merge"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$same_tag_merge/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$same_tag_merge/fixtures/release-identity/current-public-v0.3.3.3.json" \
     HEAD "$same_tag_merge" >/dev/null \
     || fail 'valid same-tag correction merged through a pull request was rejected'
 
   repeated_same_tag="$tmp_parent/repeated-same-tag"
   make_repeated_same_tag_correction_fixture "$repeated_same_tag"
   bash scripts/build-release-asset.sh --check-release-identity \
-    same-tag-correction v0.3.3.3 "$repeated_same_tag/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+    same-tag-correction v0.3.3.3 "$repeated_same_tag/fixtures/release-identity/current-public-v0.3.3.3.json" \
     HEAD "$repeated_same_tag" >/dev/null \
     || fail 'valid repeated v0.3.3.3 correction bound to current public receipt was rejected'
   [ "$(grep -c 'same-tag correction for `v0.3.3.3`' "$repeated_same_tag/CHANGELOG.md")" -eq 2 ] \
@@ -196,7 +207,7 @@ if [ "${1:-}" = "--identity-only" ]; then
 
   accepted_heldouts=()
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_deleted_history/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_deleted_history/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_deleted_history" >/dev/null 2>&1; then
     accepted_heldouts+=(deleted-history)
   fi
@@ -206,7 +217,7 @@ if [ "${1:-}" = "--identity-only" ]; then
     accepted_heldouts+=(untracked-self-authored-receipt)
   fi
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_historical_grammar/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_historical_grammar/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_historical_grammar" >/dev/null 2>&1; then
     accepted_heldouts+=(repeated-historical-grammar)
   fi
@@ -218,9 +229,9 @@ if [ "${1:-}" = "--identity-only" ]; then
   sed -i \
     -e 's/151cb5400d248e3e41a30750ba690d8c46bbe907294ba82a0a5a627536ad563e/bfe323853fcb814530c9f58e078ef09d4e930419d99005af26c9135f936e3536/g' \
     -e 's/227999/227995/g' \
-    "$repeated_stale_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+    "$repeated_stale_receipt/fixtures/release-identity/current-public-v0.3.3.3.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_stale_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_stale_receipt/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_stale_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted a stale first-publication receipt as the current preimage'
   fi
@@ -229,9 +240,9 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_repeated_same_tag_correction_fixture "$repeated_disagreeing_receipt"
   sed -i \
     's/"download_sha256": "[0-9a-f]*"/"download_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/' \
-    "$repeated_disagreeing_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+    "$repeated_disagreeing_receipt/fixtures/release-identity/current-public-v0.3.3.3.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_disagreeing_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_disagreeing_receipt/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_disagreeing_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted disagreeing API and download readbacks'
   fi
@@ -239,9 +250,9 @@ if [ "${1:-}" = "--identity-only" ]; then
   repeated_wrong_tag_receipt="$tmp_parent/repeated-wrong-tag-receipt"
   make_repeated_same_tag_correction_fixture "$repeated_wrong_tag_receipt"
   sed -i 's/"release_tag": "v0.3.3.3"/"release_tag": "v0.3.3.2"/' \
-    "$repeated_wrong_tag_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json"
+    "$repeated_wrong_tag_receipt/fixtures/release-identity/current-public-v0.3.3.3.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_tag_receipt/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_tag_receipt/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_wrong_tag_receipt" >/dev/null 2>&1; then
     fail 'repeated correction accepted a current-public receipt for another tag'
   fi
@@ -252,7 +263,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_missing_pair" add CHANGELOG.md
   git -C "$repeated_missing_pair" commit -qm repeated-missing-pair
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_missing_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_missing_pair/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_missing_pair" >/dev/null 2>&1; then
     fail 'repeated correction accepted a release commit without a new current-to-candidate pair'
   fi
@@ -260,7 +271,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   repeated_duplicate_pair="$tmp_parent/repeated-duplicate-pair"
   make_repeated_same_tag_correction_fixture "$repeated_duplicate_pair" 2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_duplicate_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_duplicate_pair/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_duplicate_pair" >/dev/null 2>&1; then
     fail 'repeated correction accepted duplicate current-to-candidate pairs'
   fi
@@ -273,7 +284,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_unchanged_digest" add CHANGELOG.md
   git -C "$repeated_unchanged_digest" commit -qm repeated-unchanged-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_unchanged_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_unchanged_digest/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_unchanged_digest" >/dev/null 2>&1; then
     fail 'repeated correction accepted an unchanged current-public digest'
   fi
@@ -286,7 +297,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_wrong_candidate" add CHANGELOG.md
   git -C "$repeated_wrong_candidate" commit -qm repeated-wrong-candidate
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_wrong_candidate" >/dev/null 2>&1; then
     fail 'repeated correction accepted a candidate digest that does not match the asset'
   fi
@@ -298,7 +309,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_wrong_candidate_bytes" add CHANGELOG.md
   git -C "$repeated_wrong_candidate_bytes" commit -qm repeated-wrong-candidate-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_wrong_candidate_bytes/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_wrong_candidate_bytes" >/dev/null 2>&1; then
     fail 'repeated correction accepted candidate bytes that do not match the asset'
   fi
@@ -307,7 +318,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_repeated_same_tag_correction_fixture "$repeated_dirty_owner"
   printf '\n' >> "$repeated_dirty_owner/docs/portal/site.json"
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_dirty_owner/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_dirty_owner/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$repeated_dirty_owner" >/dev/null 2>&1; then
     fail 'repeated correction accepted a dirty release identity owner'
   fi
@@ -319,7 +330,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$repeated_non_head" add payload.txt
   git -C "$repeated_non_head" commit -qm repeated-later-tree
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$repeated_non_head/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$repeated_non_head/fixtures/release-identity/current-public-v0.3.3.3.json" \
       "$repeated_release_commit" "$repeated_non_head" >/dev/null 2>&1; then
     fail 'repeated correction accepted a non-HEAD release commit/tree'
   fi
@@ -338,7 +349,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   fi
 
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.2 "$same_tag_correction/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.2 "$same_tag_correction/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_correction" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a different public tag'
   fi
@@ -349,7 +360,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_missing_pair" add CHANGELOG.md
   git -C "$same_tag_missing_pair" commit -qm remove-pair
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_missing_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_missing_pair/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_missing_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a commit without the replacement pair'
   fi
@@ -358,7 +369,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   make_same_tag_correction_fixture "$same_tag_duplicate_pair" \
     0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.3-release-report.md 2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_duplicate_pair/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_duplicate_pair/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_duplicate_pair" >/dev/null 2>&1; then
     fail 'same-tag correction accepted duplicate replacement pairs'
   fi
@@ -371,7 +382,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_unchanged_digest" add CHANGELOG.md
   git -C "$same_tag_unchanged_digest" commit -qm unchanged-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_unchanged_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_unchanged_digest/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_unchanged_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted an unchanged package digest'
   fi
@@ -384,7 +395,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_old_digest" commit -qm wrong-old-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_digest/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_old_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package digest'
   fi
@@ -395,7 +406,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_old_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_old_bytes" commit -qm wrong-old-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_old_bytes/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_old_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong premature package byte count'
   fi
@@ -408,7 +419,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_digest" add CHANGELOG.md
   git -C "$same_tag_wrong_new_digest" commit -qm wrong-new-digest
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_digest/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_digest/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_new_digest" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement digest that does not match the candidate'
   fi
@@ -420,7 +431,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_wrong_new_bytes" add CHANGELOG.md
   git -C "$same_tag_wrong_new_bytes" commit -qm wrong-new-bytes
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_bytes/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_new_bytes/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_new_bytes" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a replacement byte count that does not match the candidate'
   fi
@@ -435,7 +446,7 @@ if [ "${1:-}" = "--identity-only" ]; then
     make_same_tag_correction_fixture "$dirty_owner_root"
     printf '\n' >> "$dirty_owner_root/$dirty_owner"
     if bash scripts/build-release-asset.sh --check-release-identity \
-        same-tag-correction v0.3.3.3 "$dirty_owner_root/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+        same-tag-correction v0.3.3.3 "$dirty_owner_root/fixtures/release-identity/current-public-v0.3.3.3.json" \
         HEAD "$dirty_owner_root" >/dev/null 2>&1; then
       fail "same-tag correction accepted dirty release identity owner $dirty_owner"
     fi
@@ -444,7 +455,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_portal="$tmp_parent/same-tag-wrong-portal"
   make_same_tag_correction_fixture "$same_tag_wrong_portal" 0.3.3 v0.3.3.3 v0.3.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_portal/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_portal/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_portal" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong portal milestone'
   fi
@@ -452,7 +463,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_ledger="$tmp_parent/same-tag-wrong-ledger"
   make_same_tag_correction_fixture "$same_tag_wrong_ledger" 0.3.3 v0.3.3.3 v0.3.3.3 v0.3.3.2-release-report.md
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_ledger/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_ledger/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_ledger" >/dev/null 2>&1; then
     fail 'same-tag correction accepted the wrong release ledger'
   fi
@@ -460,7 +471,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   same_tag_wrong_runtime="$tmp_parent/same-tag-wrong-runtime"
   make_same_tag_correction_fixture "$same_tag_wrong_runtime" 0.3.2
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_wrong_runtime/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_wrong_runtime/fixtures/release-identity/current-public-v0.3.3.3.json" \
       HEAD "$same_tag_wrong_runtime" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a runtime outside 0.3.3'
   fi
@@ -472,7 +483,7 @@ if [ "${1:-}" = "--identity-only" ]; then
   git -C "$same_tag_non_head" add payload.txt
   git -C "$same_tag_non_head" commit -qm later-tree
   if bash scripts/build-release-asset.sh --check-release-identity \
-      same-tag-correction v0.3.3.3 "$same_tag_non_head/docs/audits/archive/v0.3.3.3-current-public-receipt.json" \
+      same-tag-correction v0.3.3.3 "$same_tag_non_head/fixtures/release-identity/current-public-v0.3.3.3.json" \
       "$same_tag_release_commit" "$same_tag_non_head" >/dev/null 2>&1; then
     fail 'same-tag correction accepted a non-HEAD release commit/tree'
   fi


### PR DESCRIPTION
## Summary

- generalise `same-tag-correction` for a later correction of the same public `v0.3.3.3` identity;
- bind the exact currently public asset through a canonical retained readback receipt;
- require append-only correction chronology and exactly one current-public→candidate pair;
- preserve the original first-correction grammar and every normal forward/republish/family-forward path.

Refs #89. This PR addresses the repeated-correction identity gate only. It does not publish, retag, replace assets, close #89, or claim a final release candidate.

## Evidence

- retained REDs: later correction rejected by old interface; deleted chronology, self-authored untracked receipt, historical-grammar substitution, and synthetic-only custody all reproduced;
- identity-only suite: PASS;
- independent exact-tree review: PASS at `63d73f7043ccf5ffa32a286f3a18861195a8b57d` / tree `c312f5e47e6457e4c5a212b51d16b2aaad2d589d`;
- canonical receipt blob `ec1de1f90100aeae573f651770cf9ebc5b76c829` is byte-identical in retained parent lineage, first parent, HEAD, and worktree;
- R33 21/21, Lean 17/17, R35 39/39, syntax/JSON/diff checks: PASS;
- parent/current package invariance: 225,945 bytes, SHA-256 `f2b8eb5e5ac49aac71c9bcc4f0f8b9730c48d1ddee650607ad0b4f2f3ca4f094`.

## Boundary

The checker does not query GitHub. Final composed release control must retain an independently read-back current-public receipt before the correction commit, then perform fresh API/download/install readback after replacement.
