### PR TITLE
Fix post-compaction controller currentness

### DIFF
--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -15,7 +15,7 @@
       "owner": {
         "path": "skills/implementaudit/SKILL.md",
         "revision": "WORKTREE",
-        "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859",
+        "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019",
         "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"
       },
       "consumer": {
@@ -31,19 +31,19 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "lean-same-owner-equivalent": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Engineering-value admission, retention, and retirement"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "lean-lost": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
-      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "anchor": "Package semantic preservation"},
+      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "anchor": "Package semantic preservation"},
       "consumers": [
         {"kind": "checker", "required": true, "path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "869bb31cb92fb237570c059a9e2f46133cb8cedd1a35f7ecd22ced0f48e490ae", "route_anchor": "Package semantic preservation", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "869bb31cb92fb237570c059a9e2f46133cb8cedd1a35f7ecd22ced0f48e490ae", "anchor": "Package semantic preservation"}}
       ]
@@ -52,21 +52,21 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "d7a3c1852202aa6a564641af6835f554662b34dd4ab654ce75f8edda4bf9b30d", "anchor": "# Contributing"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "nonexistent-owner": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "references/definitely-not-shipped.md", "revision": "WORKTREE", "sha256": null, "anchor": null},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "broken-consumer": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/definitely-not-shipped.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/definitely-not-shipped.md"}
       ]
     },
     "invented-consumer": {
@@ -77,22 +77,22 @@
       ]
     },
     "safe-progressive": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "anchor": "references/lean-operating-discipline.md"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "anchor": "references/lean-operating-discipline.md"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/install-codex-from-release.sh", "revision": "WORKTREE", "sha256": "37b0e31d45c5dd0e88dd64d967f0f502739b6c3d74b9eb4ae28f240cbe011f9c", "anchor": "references/lean-operating-discipline.md"}}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/install-codex-from-release.sh", "revision": "WORKTREE", "sha256": "37b0e31d45c5dd0e88dd64d967f0f502739b6c3d74b9eb4ae28f240cbe011f9c", "anchor": "references/lean-operating-discipline.md"}}
       ]
     },
     "exact-marker-changed": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
         {"kind": "parser", "required": true, "path": "scripts/check-marker-order.sh", "revision": "WORKTREE", "sha256": "9764979aa3e1324e217828684e45ef67f40f14427537502a62ce3d66b6872b31", "route_anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"}
       ]
     },
     "exact-marker-broken-consumer": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
-      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
       "consumers": [
         {"kind": "parser", "required": true, "path": "scripts/check-marker-order.sh", "revision": "WORKTREE", "sha256": "9764979aa3e1324e217828684e45ef67f40f14427537502a62ce3d66b6872b31", "route_anchor": "DEFINITELY_NOT_A_MARKER"}
       ]
@@ -101,14 +101,14 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "held-out-runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "869bb31cb92fb237570c059a9e2f46133cb8cedd1a35f7ecd22ced0f48e490ae", "anchor": "DEFINITELY_NOT_A_HELD_OUT_ASSERTION"}}
+        {"kind": "held-out-runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "869bb31cb92fb237570c059a9e2f46133cb8cedd1a35f7ecd22ced0f48e490ae", "anchor": "DEFINITELY_NOT_A_HELD_OUT_ASSERTION"}}
       ]
     },
     "optional-only": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "8a11a5510ec20414ee79dc51cc1fba1a493545f2736a80b6c9d5759ea66a9b1a", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "advisory-note", "required": false, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "a0174687efe61cda559233d85d6d3e76be38eaa1bb7c43da667e0ef83a5a8859", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "advisory-note", "required": false, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "d77c2207153c0ae93baad23f123583f37175b6696a32f54f0b674d7601700019", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     }
   },

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -23,32 +23,18 @@ without evidence. Continue until every item is terminally `done`, `changed`,
 `blocked`, `deferred`, or `unverified`.
 
 First executable dogfood rule: Do not read this entire skill or installed
-payload. Begin with target-repo baseline, then read only the owner/source
-sections required by the current gate.
+payload. Baseline the target repo first, then use progressive disclosure for
+only the owner/source sections required by the current gate.
 
 ---
 
 ## Dogfood Bootstrap / Read Map
 
 Do not read this entire installed `SKILL.md` before acting, and do not chunk
-through the installed payload because a tool display was truncated. Baseline
-the target repo first, discover the host/CLI syntax, record the evidence
-boundary, then inspect only owner/source sections needed for the current gate.
-
-Use this read order for package or CLI dogfood:
-
-1. Baseline the target repo first: `git status --short --branch --untracked-files=all`
-   and `git rev-parse HEAD` when permitted.
-2. Discover the actual host command syntax before invoking it. Do not guess.
-3. Inspect headings, table-of-contents shape, and targeted sections rather than
-   full-file readback.
-4. Use targeted `rg`/grep for required markers, claims, and owner/source files.
-5. Inspect live files named by the gate: `AGENTS.md`, `README.md`, audit docs,
-   validation scripts, fixtures, manifests, or exact package owner/source files.
-6. Package proof uses deterministic checks, not model-visible full-file
-   readback: package manifests, archive listing, checksums, targeted grep,
-   `build-release-asset.sh --check`, installed file existence, and
-   `verify-package.sh`.
+through a truncated payload. Baseline first, discover actual host syntax, then
+use headings and targeted `rg`/grep for the live owner/source files. Package proof uses deterministic checks, not model-visible full-file readback:
+manifests, archive listing, checksums, `build-release-asset.sh --check`, installed
+file existence, and `verify-package.sh`.
 
 Full installed-payload readback is non-evidence for dogfood proof unless a
 specific owner/source section is the audit target. Do not reproduce secrets,
@@ -56,32 +42,22 @@ tokens, credentials, auth files, or private diagnostic contents in transcripts.
 
 ### Dogfood Runner Contract
 
-Live Codex self-dogfood proves only the safe runner contract that actually ran.
-Use a temporary Codex home, a locally built and installed skill payload, and the
-target repo named by the audit. Do not install into a real user home.
+Live Codex self-dogfood proves only the runner that actually ran. Use a locally
+built payload in a temp `CODEX_HOME`; never install proof into a real home.
 Real-home installed skill readback is non-evidence for release-candidate
-dogfood. Before invoking Codex, record the temp `CODEX_HOME`, the installed skill path under that temp home,
-the installed `SKILL.md` line/byte count, and the exact command proving Codex used that temp home. If a proof lane reads from
-the real user home's installed skill directory (for example
-`$CODEX_HOME/skills/implementaudit` or `~/.codex/skills/implementaudit`)
-before the temp install path is established, register `ANDON_PROBE` (class:
-evidence-mismatch; abnormality: stale-installed-skill /
-real-home-contamination) and do not claim dogfood proof from that run.
+dogfood. Before Codex runs, record the temp `CODEX_HOME`, installed skill path under that temp home, installed `SKILL.md` line/byte count, and exact command proving Codex used that temp home. Earlier real-home access registers `ANDON_PROBE` (evidence-mismatch:
+stale-installed-skill / real-home-contamination) and supplies no dogfood proof.
 
 Runner order:
 
 1. Baseline/read-only checks first: `git status --short --branch --untracked-files=all`
    and `git rev-parse HEAD` when permitted.
-2. Targeted owner/source reads next: headings, file-specific `rg`/grep, and
-   narrow reads of named docs, scripts, tests, fixtures, manifests, or ledgers.
-3. Repo-local validation after the read map is satisfied: in the IMPLEMENTAUDIT
-   source checkout only, run requested safe checks such as `git diff --check`,
-   source repo only `bash scripts/check-*.sh`, `bash tests/*.test.sh`, and
-   source repo only `bash scripts/verify-package.sh`; these repo-root checkers
-   are not shipped in the installed runtime payload.
-4. Record blocked commands exactly. If policy rejects a required local command,
-   classify dogfood as blocked unless an owner-authorized runner mode or narrow
-   exec-policy allowlist permits that exact repo-local command.
+2. Targeted owner/source reads next: headings, file-specific `rg`/grep, and named
+   docs, scripts, tests, fixtures, manifests, or ledgers.
+3. Repo-local validation after the read map is satisfied: run the requested safe
+   source-checkout checks; repo-root checkers are not installed runtime payload.
+4. Record blocked commands exactly; without an authorised runner or narrow
+   allowlist for a required command, dogfood is blocked.
 
 `--ask-for-approval never` is valid only when every required command is already
 trusted by the host policy. If it rejects needed baseline or validation
@@ -115,14 +91,12 @@ Run invariants:
   system/developer/user instructions or `AGENTS.md`.
 - No secret reproduction. Redact or omit secrets, bearer tokens, auth files,
   credentials, private diagnostics, and unrelated local paths.
-- No commit. No push. No tag. No release. No publication. No provenance.
-  Each action needs separate explicit authorization.
-- No issue creation, license choice, marketplace claim, real-home install, or
-  provenance claim without explicit authorization and evidence.
+- No commit. No push. No tag. No release. No publication. No provenance. Each
+  action—and issue creation, licence choice, marketplace claim, or real-home
+  install—needs separate explicit authorization and evidence.
 - Smoke A happens before mutation; Smoke B happens after implementation.
 - Verify mutations in post-state; tool success is not proof. Generated artifacts stay generator-first.
-- Local commit, push, tag, release, publication, and provenance are separate
-  gates. If local commit is not authorized, provide a proposed commit message.
+- If local commit is not authorized, provide a proposed commit message.
 - Graphify output is orientation evidence, not proof. ActiveGraph custody is not correctness proof. Sidecars are optional unless a repo says otherwise; their presence authorizes no install, indexing, setup, config, export, or sidecar mutation.
 - Capability Ledger entries, when configured, are derived from recorded gate
   passages only. Do not claim general competence from one run.
@@ -172,40 +146,22 @@ Final `ydqyq-audit-action` -> terminal verified closure is required before
 
 Load references only when the current gate needs them:
 
-- `references/routing.md`: greenfield/brownfield/mixed routing, DMAIC,
-  DMADV, governed casual-build intake, and repo content as data.
-- `references/planning-depth.md`: when to synthesize a goal vs govern an
-  existing one, and the action-selection contract for warranted depth.
-- `references/phase-design.md`: phase slicing, Stage 6 self-critique, and phase
-  quality.
-- `references/goal-format.md`: one ready-to-paste `/goal`, final
-  response shape, and marker usage.
-- `references/transcript-contract.md`: marker ordering, `AUDIT_COMPLETE`
-  before `IMPLEMENTAUDIT_RUN_COMPLETE`, pause/continuity markers, and handoff
-  exclusivity.
-- `references/continuity.md`: context-epoch continuity — post-boundary
-  reconciliation before mutation, instruction lifecycle/applicability,
-  satisfied one-shot replay refusal, capsule binding, single-writer epochs.
-- `references/repo-state-comparison.md`: state/baseline/final checks and
-  shipped-helper dispatch.
-- `references/sidecars.md`: optional Graphify/ActiveGraph Gemba, first-run
-  tooling onboarding, and no silent install/index/export boundaries.
-- `references/lean-operating-discipline.md`: PDCA, Gemba, Kaizen,
-  Jidoka/Andon, Hansei, 5 Whys, 5S, Poka-yoke, no arbitrary try caps, and no
-  arbitrary revision caps.
-- `references/audit-category-matrix.md`: default correctness, tests,
-  security, performance, architecture, dependencies, DX, docs, and direction
-  pressure.
+- `references/routing.md`: repo/content routing and governed casual-build intake.
+- `references/planning-depth.md`: goal choice and warranted action depth.
+- `references/phase-design.md`: phase slicing, critique, and quality.
+- `references/goal-format.md`: `/goal`, response, and marker shape.
+- `references/transcript-contract.md`: marker order and handoff exclusivity.
+- `references/continuity.md`: controller currentness, epochs, replay refusal,
+  receiver receipts, and post-boundary reconciliation before mutation.
+- `references/repo-state-comparison.md`: baseline/final and helper dispatch.
+- `references/sidecars.md`: optional Graphify/ActiveGraph and tooling bounds.
+- `references/lean-operating-discipline.md`: PDCA, Andon, Hansei, 5 Whys,
+  Poka-yoke, and no arbitrary try/revision caps.
+- `references/audit-category-matrix.md`: native audit-category routing.
 - `references/audit-playbook.md`: detailed audit heuristics.
-- `references/plan-lifecycle.md`: Self-Contained Plan Standard, Branch
-  And Diff Scoping, Review-Plan Semantics, Execute / Dispatch / Review,
-  Reconciliation Semantics, read-only `plans/` output lane, and Issue
-  Publication Deferred.
-- `references/issue-ready-work-orders.md`: material issue synthesis and
-  multi-draft reconciliation before authorised publication.
-- `references/child-agents.md`: bounded read-only review loops,
-  non-authority boundaries, and the binding specialist-fanout coverage
-  contract with serialized fallback.
+- `references/plan-lifecycle.md`: self-contained plans, execution, and review.
+- `references/issue-ready-work-orders.md`: issue synthesis and reconciliation.
+- `references/child-agents.md`: bounded fanout, ready cells, and serial fallback.
 - `references/terminology-integration.md`: thin terminology precedence.
   Use FMEA-lite fields when risk is material, STRIDE/trust-boundary notes when
   a material security surface exists, SOLID/GRASP generic-advice guard, and a
@@ -321,21 +277,20 @@ second `/goal` inside an existing `/goal` run.
 
 ## Runtime Loop
 
-0. Continuity boundary (when resuming): after any `host-reported-compaction`
-   / `new-session` / `handoff-resume` / `manual-resume` /
-   `inferred-context-gap` — never a fabricated compaction — FIRST reread
-   the live run-root STATE.md and ROADMAP.md from disk: a compacted or
-   reconstructed summary is an observation of history, and live state wins.
-   Each bound live durable-state file must be read in its own completed host
-   action before the first mutation. Evidence-bearing read actions must not use
-   ';', '&&', pipelines, multi-stage shell composition, or batching.
-   Record the boundary provenance as a STATE epoch row, classify each
-   remembered steer by lifecycle, and refuse to re-execute a satisfied
-   one-shot (e.g. an already-resolved ANDON), citing its terminal evidence:
-   "Target already satisfied at <evidence>; no duplicate action taken."
-   Standing constraints/authorizations survive the boundary. Then continue
-   from the current next authorized action — never restart. Details:
-   `references/continuity.md`. An uninterrupted turn skips this step.
+0. Continuity boundary (when resuming): after `host-reported-compaction`,
+   `new-session`, `handoff-resume`, `manual-resume`, or
+   `inferred-context-gap` — never a fabricated compaction — FIRST use
+   `scripts/claim-run.sh --current-controller` to discover the unique live
+   controller; missing, ambiguous, or stale custody refuses mutation. Reread
+   its STATE.md and ROADMAP.md from disk, each in its own completed host action;
+   evidence-bearing reads must not use ';', '&&', pipelines, multi-stage shell
+   composition, or batching. A reconstructed summary is an observation of
+   history and live state wins. Record the STATE epoch row, classify remembered
+   steers, and refuse a satisfied one-shot: "Target already satisfied at
+   <evidence>; no duplicate action taken." Then create and verify the
+   `--resume-controller` receipt before mutation and continue from the live Next
+   action. Standing constraints/authorizations survive; an uninterrupted turn
+   skips this step. Details: `references/continuity.md`.
 1. Safety read: `AGENTS.md`, README/CONTRIBUTING/docs/workflows, existing audit
    docs, generator/source ownership, and authorization chain.
 2. Input gate: stop on empty, malformed, unsafe, unsupported, or non-audit

--- a/skills/implementaudit/references/continuity.md
+++ b/skills/implementaudit/references/continuity.md
@@ -31,11 +31,10 @@ NOT add epoch ceremony.
 
 After any continuity boundary, and before the next repository mutation:
 
-1. Establish the unique active run root and the current repository identity
-   (repo root + HEAD; for non-Git subjects, the declared inventory).
-   Ambiguous or multiple candidate run roots route to an audited handoff —
-   never guess. No run root at all means truthful intake, not fabricated
-   recovery.
+1. Establish the unique active run root and current repository identity. In Git,
+   `scripts/claim-run.sh --current-controller [controller-id]` discovers the
+   Git-common current-controller record without prior worktree knowledge.
+   Missing, ambiguous, invalid, or stale custody refuses; never guess.
 2. Reread current `ROADMAP.md`, `STATE.md`, the repository-family
    `.IMPLEMENTAUDIT/host-notes.md` when present, process/command state
    (including `background/<chain-id>` chains), and the relevant terminal
@@ -55,6 +54,14 @@ After any continuity boundary, and before the next repository mutation:
 7. When continuity cannot be established (identity mismatch, corrupted
    state, irreconcilable instruction set), hand off with the evidence rather
    than speculate.
+
+Transfer long-run controller ownership with the atomic expected-claim CAS
+`claim-run.sh --controller <id> --supersede-claim <claim> <task>`. After the
+separate live reads and reconciled epoch row, run `--resume-controller <id>
+--boundary <provenance> --epoch <epoch>` and verify its token with
+`--verify-resume-receipt`. The receipt binds controller/run claim, repo
+HEAD/tree, STATE/ROADMAP hashes, boundary, epoch, and Next action; without that
+verified current receipt, refuse post-boundary mutation.
 
 At every phase start, read `.IMPLEMENTAUDIT/host-notes.md` from the
 repository-family root (the parent of Git's common directory) when present

--- a/skills/implementaudit/scripts/claim-run.sh
+++ b/skills/implementaudit/scripts/claim-run.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# claim-run.sh - atomically claim a native IMPLEMENTAUDIT run root.
-#
-# The helper is intentionally small and side-effect bounded: it creates the
-# run-root directory and its claim metadata under IMPLEMENTAUDIT_BASE, then
-# prints that path. It does not write roadmap/state/protocol files, inspect
-# source files, install tools, index sidecars, or start execution.
+# Atomically claim native run roots and controller continuity.
 
 set -u
 
@@ -22,6 +17,81 @@ reject_coordination_reparse() {
   fi
   return 0
 }
+
+controller_io() {
+  local a="$1" c="$2" repo common ref oid s rc rg root rr target_common; shift 2
+  repo="$(git rev-parse --path-format=absolute --show-toplevel)" || return
+  common="$(cd "$(git rev-parse --path-format=absolute --git-common-dir)" && pwd -P)" || return
+  if [ "$a" = current ] && [ -z "$c" ]; then
+    local x=(); mapfile -t x < <(git for-each-ref --format='%(refname)' refs/implementaudit/controllers/)
+    [ "${#x[@]}" = 1 ] || { printf 'claim-run.sh: ambiguous controller population: %s\n' "${#x[@]}" >&2; return 1; }
+    c="${x[0]##*/}"
+  fi
+  case "$c" in ''|*[!a-z0-9-]*|-*) return 1;; esac
+  [ "${#c}" -le 48 ] || return 1; ref="refs/implementaudit/controllers/$c"
+  load() {
+    oid="$(git rev-parse --verify "$ref" 2>/dev/null)" || return
+    IFS=$'\t' read -r s rc rg root <<< "$(git cat-file blob "$oid")"
+    rr="${root%/.IMPLEMENTAUDIT/runs/*}"
+    target_common="$(cd "$(git -C "$rr" rev-parse --path-format=absolute --git-common-dir)" && pwd -P)" || return
+    [ "$s:$rc" = "implementaudit.controller-current.v1:$c" ] &&
+      [ "$target_common" = "$common" ] &&
+      bash "$(dirname "$0")/validate-run-root.sh" --claim-only "$root" --repo-root "$rr" >/dev/null 2>&1 &&
+      grep -Fxq "claim_id=$rg" "$root/.claimed"
+  }
+  case "$a" in
+    bind)
+      [ "$#" = 2 ] && [ "$base" = .IMPLEMENTAUDIT/runs ] || return 1
+      local expect="$1" run="$2" old new newclaim zero=0000000000000000000000000000000000000000
+      newclaim="$(sed -n 's/^claim_id=//p' "$repo/$run/.claimed")"; [ -n "$newclaim" ] || return
+      old="$(git rev-parse --verify "$ref" 2>/dev/null || printf %s "$zero")"
+      if [ "$old" != "$zero" ]; then
+        IFS=$'\t' read -r s rc rg _ <<< "$(git cat-file blob "$old")"
+        [ -n "$expect" ] && [ "$s:$rc:$rg" = "implementaudit.controller-current.v1:$c:$expect" ] || return 1
+      else [ -z "$expect" ] || return 1; fi
+      new="$(printf 'implementaudit.controller-current.v1\t%s\t%s\t%s/%s\n' "$c" "$newclaim" "$repo" "$run" | git hash-object -w --stdin)" &&
+        git update-ref "$ref" "$new" "$old" ;;
+    current)
+      load || return; printf '%s\t%s\t%s\t%s\n' "$c" "$rr" "$root" "$rg" ;;
+    resume|verify)
+      load || return; [ "$repo" = "$rr" ] || return 1
+      local state="$root/STATE.md" road="$root/ROADMAP.md" token rref roid h t sh rh
+      h="$(git rev-parse HEAD)"; t="$(git rev-parse 'HEAD^{tree}')"
+      sh="$(sha256sum "$state" | cut -d' ' -f1)"; rh="$(sha256sum "$road" | cut -d' ' -f1)"
+      if [ "$a" = resume ]; then
+        local b="$1" e="$2" next newr zero=0000000000000000000000000000000000000000
+        case "$b" in host-reported-compaction|new-session|handoff-resume|manual-resume|inferred-context-gap):;; *) return 1;; esac
+        next="$(awk -F'|' -v e="$e" -v b="$b" -v h="$h" -v t="$t" 'function q(x){gsub(/^[ \t`]+|[ \t`]+$/, "", x);return x} /^Current epoch:/{ce=$0} q($2)=="Next action"{n=q($3)} q($2)==e&&q($3)==b&&q($6)=="yes"&&index($5,h)&&index($5,t){ok=1} END{if(ce=="Current epoch: "e&&ok&&n!=""&&n!="-"&&tolower(n)!="none"&&tolower(n)!="pending")print n;else exit 1}' "$state")" || return
+        rref="refs/implementaudit/continuity-receipts/$c/$e"
+        newr="$(printf 'implementaudit.continuity-receipt.v1\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$c" "$oid" "$rg" "$h" "$t" "$sh" "$rh" "$b" "$e" "$next" | git hash-object -w --stdin)" &&
+          git update-ref "$rref" "$newr" "$zero" || return
+        token="$rref@$newr"
+      else
+        token="$1"; rref="${token%@*}"; roid="${token##*@}"
+        [ "$(git rev-parse --verify "$rref" 2>/dev/null)" = "$roid" ] || return
+        IFS=$'\t' read -r s rc owner rg2 h2 t2 sh2 rh2 b2 e2 _ <<< "$(git cat-file blob "$roid")"
+        [ "$rref" = "refs/implementaudit/continuity-receipts/$c/$e2" ] &&
+          [ "$s:$rc:$owner:$rg2:$h2:$t2:$sh2:$rh2" = "implementaudit.continuity-receipt.v1:$c:$oid:$rg:$h:$t:$sh:$rh" ] || return
+      fi
+      printf '%s\n' "$token" ;;
+    *) return 1 ;;
+  esac
+}
+
+controller='' supersede=''
+case "${1:-}" in
+  --current-controller) controller_io current "${2:-}"; exit $? ;;
+  --resume-controller)
+    controller="${2:-}"; shift 2; boundary='' epoch=''
+    while [ "$#" -gt 0 ]; do case "$1" in --boundary) boundary="${2:-}"; shift 2;; --epoch) epoch="${2:-}"; shift 2;; *) printf 'claim-run.sh: unknown resume argument: %s\n' "$1" >&2; exit 1;; esac; done
+    controller_io resume "$controller" "$boundary" "$epoch"; exit $? ;;
+  --verify-resume-receipt)
+    receipt_arg="${2:-}"; controller="${receipt_arg%@*}"; controller="${controller#refs/implementaudit/continuity-receipts/}"; controller="${controller%/*}"
+    controller_io verify "$controller" "$receipt_arg"; exit $? ;;
+  --controller)
+    controller="${2:-}"; shift 2
+    if [ "${1:-}" = --supersede-claim ]; then supersede="${2:-}"; shift 2; fi ;;
+esac
 
 mode=full
 if [ "${1:-}" = "--micro" ]; then
@@ -77,10 +147,6 @@ run_root="$(mktemp -d "$base/${slug}-XXXXXX" 2>/dev/null)" || {
 
 claimed_at_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  # Keep producer and strict consumer in Git's native absolute path domain.
-  # In Git Bash, `pwd -P` may spell the worktree as /c/... while Git and the
-  # host Python runtime use C:/...; mixing those domains makes an own-generated
-  # claim fail strict custody despite naming the same worktree.
   claim_repo="$(git rev-parse --path-format=absolute --show-toplevel)" || exit 1
   claim_common="$(git rev-parse --path-format=absolute --git-common-dir)" || exit 1
   claim_id="$(LC_ALL=C od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
@@ -95,8 +161,12 @@ if [ ! -f "$run_root/.claimed" ]; then
   exit 1
 fi
 
-# Claiming remains non-blocking so explicitly parallel work can declare itself.
-# List siblings that need COMPLETE, HANDOFF, SUPERSEDED_BY, or PARALLEL state.
+if [ -n "$controller" ]; then
+  controller_io bind "$controller" "$supersede" "$run_root" || {
+    rm -f "$run_root/.claimed"; rmdir "$run_root" 2>/dev/null; exit 1
+  }
+fi
+
 for sibling in "$base"/*; do
   [ -d "$sibling" ] || continue
   [ "$sibling" = "$run_root" ] && continue
@@ -108,9 +178,6 @@ for sibling in "$base"/*; do
   fi
 done
 
-# Advisory only (this helper never mutates repo config): in target repos that
-# do not ignore the run-root base, run artifacts would appear as untracked
-# changes in commits and evidence scans.
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if ! git check-ignore -q "$base" 2>/dev/null; then
     printf 'claim-run: note: %s is not gitignored here; consider adding ".IMPLEMENTAUDIT/" to .git/info/exclude (local-only) so run artifacts stay out of commits and evidence\n' "$base" >&2

--- a/tests/continuity-contract.test.sh
+++ b/tests/continuity-contract.test.sh
@@ -76,6 +76,17 @@ done
 grep -qi "live state wins" "$skill" || fail "SKILL.md runtime loop missing live-state-wins rule"
 grep -qi "Target already satisfied at" "$skill" || fail "SKILL.md runtime loop missing refusal sentence"
 grep -qi "epoch row" "$skill" || fail "SKILL.md runtime loop missing epoch-row recording"
+route_ok() {
+  grep -q -- '--current-controller' "$1" && grep -q -- '--resume-controller' "$1" &&
+    grep -q -- '--current-controller' "$2" && grep -q -- '--resume-controller' "$2" &&
+    grep -q -- '--supersede-claim' "$2" && grep -q -- '--verify-resume-receipt' "$2"
+}
+route_ok "$skill" "$ref" || fail "runtime route omits controller discovery, transfer, or receipt verification"
+cp "$skill" "$tmp/mutant-skill.md"; cp "$ref" "$tmp/mutant-continuity.md"
+sed -i 's/--current-controller/--lost-controller/' "$tmp/mutant-skill.md"
+route_ok "$tmp/mutant-skill.md" "$tmp/mutant-continuity.md" && fail "source-removal mutant retained a green continuity route"
+cp "$skill" "$tmp/mutant-skill.md"; sed -i 's/--supersede-claim/--lost-predecessor/' "$tmp/mutant-continuity.md"
+route_ok "$tmp/mutant-skill.md" "$tmp/mutant-continuity.md" && fail "transfer-removal mutant retained a green continuity route"
 for surface in "$skill" "$ref" "$proto"; do
   contains_normalized "$surface" "own completed host action" ||
     fail "$surface missing separately attributable durable-state read rule"
@@ -160,5 +171,239 @@ epoch_case bare_satisfied \
 epoch_case bare_revoked \
 "| e2 | inferred-context-gap | 2026-07-18T02:00Z | repo@abc def | yes | - |" \
 "| i1 | evt-h | standing-authorization | owner | commit-auth | e1 | revoked | - | - | - |" fail
+
+# 7. Long evolving-run continuity is keyed to a stable controller, not the
+# last plausible worktree-local root.  The active controller migrates by an
+# atomic expected-claim transition.  After compaction, a stale summary/root
+# must resolve to the successor and cannot emit the successor's receipt.
+claim_helper="${IMPLEMENTAUDIT_CLAIM_HELPER:-$repo_root/skills/implementaudit/scripts/claim-run.sh}"
+resume_repo="$tmp/resume-repo"; successor_repo="$tmp/resume-successor"
+mkdir -p "$resume_repo"
+git -C "$resume_repo" init -q
+git -C "$resume_repo" config user.name 'continuity fixture'
+git -C "$resume_repo" config user.email 'continuity@example.invalid'
+printf 'pre-merge\n' > "$resume_repo/product.txt"
+git -C "$resume_repo" add product.txt
+git -C "$resume_repo" commit -qm 'pre-merge state'
+git -C "$resume_repo" worktree add -q -b successor "$successor_repo"
+
+initial_rel="$(cd "$resume_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller release-v0333 'long evolving run' 2>/dev/null)" \
+  || fail "initial controller claim failed"
+initial_root="$resume_repo/$initial_rel"
+initial_claim="$(sed -n 's/^claim_id=//p' "$initial_root/.claimed")"
+
+printf 'post-merge\n' >> "$successor_repo/product.txt"
+git -C "$successor_repo" add product.txt
+git -C "$successor_repo" commit -qm 'authoritative successor state'
+successor_head="$(git -C "$successor_repo" rev-parse HEAD)"
+successor_tree="$(git -C "$successor_repo" rev-parse 'HEAD^{tree}')"
+successor_rel="$(cd "$successor_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller release-v0333 --supersede-claim "$initial_claim" \
+  'continued controller' 2>/dev/null)" || fail "controller migration failed"
+successor_root="$successor_repo/$successor_rel"
+successor_claim="$(sed -n 's/^claim_id=//p' "$successor_root/.claimed")"
+
+for root in "$initial_root" "$successor_root"; do
+  for f in STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
+    cp "$repo_root/skills/implementaudit/templates/$f" "$root/$f"
+  done
+done
+
+"${py_cmd[@]}" - "$initial_root/STATE.md" "$initial_rel" \
+  "$(git -C "$resume_repo" rev-parse HEAD)" "$(git -C "$resume_repo" rev-parse 'HEAD^{tree}')" \
+  "$successor_root/STATE.md" "$successor_rel" "$successor_head" "$successor_tree" <<'PY'
+import sys
+from pathlib import Path
+for state, run, head, tree, epoch, boundary, action in (
+    (*sys.argv[1:5], "e1", "new-session", "continue implementation in the controller worktree"),
+    (*sys.argv[5:9], "e2", "host-reported-compaction", "qualify the authoritative successor before release"),
+):
+    p=Path(state); s=p.read_text(encoding="utf-8")
+    s=s.replace("| Run root |  |", f"| Run root | `{run}` |")
+    s=s.replace("| Next action |  |", f"| Next action | {action} |")
+    s=s.replace("Current epoch: e1", f"Current epoch: {epoch}")
+    anchor="| Epoch | Boundary provenance | Established at | Repo identity | Reconciled | Notes |\n|---|---|---|---|---|---|"
+    row=f"| {epoch} | {boundary} | 2026-08-12T13:00:00Z | repo at `{head}` / `{tree}` | yes | live readback complete |"
+    p.write_text(s.replace(anchor, anchor+"\n"+row), encoding="utf-8")
+PY
+
+current="$(cd "$resume_repo" && bash "$claim_helper" --current-controller)" \
+  || fail "current controller discovery failed"
+"${py_cmd[@]}" - "$current" "$successor_repo" "$successor_root" "$successor_claim" <<'PY' \
+  || fail "stale worktree did not discover the exact successor controller: $current"
+import os,sys
+from pathlib import Path
+controller,repo,root,claim=sys.argv[1].split("\t")
+expected_repo,expected_root,expected_claim=sys.argv[2:]
+same=lambda a,b: os.path.normcase(str(Path(a).resolve()))==os.path.normcase(str(Path(b).resolve()))
+assert controller=="release-v0333" and same(repo,expected_repo) and same(root,expected_root) and claim==expected_claim
+PY
+
+if (cd "$resume_repo" && bash "$claim_helper" --resume-controller release-v0333 \
+    --boundary host-reported-compaction --epoch e2) >/dev/null 2>&1; then
+  fail "stale controller worktree emitted a successor continuity receipt"
+fi
+
+receipt="$(cd "$successor_repo" && bash "$claim_helper" --resume-controller release-v0333 \
+  --boundary host-reported-compaction --epoch e2)" \
+  || fail "current successor controller did not produce a continuity receipt"
+case "$receipt" in refs/implementaudit/continuity-receipts/release-v0333/e2@[0-9a-f][0-9a-f]*) :;; *) fail "continuity receipt is not a ref-bound token";; esac
+receipt_oid="${receipt##*@}"
+receipt_record="$(git -C "$successor_repo" cat-file blob "$receipt_oid")"
+"${py_cmd[@]}" - "$receipt_record" "$successor_claim" "$successor_head" "$successor_tree" <<'PY' \
+  || fail "continuity receipt omitted receiver-required currentness state"
+import sys
+schema,controller,owner_oid,claim,head,tree,state,roadmap,boundary,epoch,next_action=sys.argv[1].split("\t")
+assert schema=="implementaudit.continuity-receipt.v1" and controller=="release-v0333"
+assert claim==sys.argv[2] and head==sys.argv[3] and tree==sys.argv[4]
+assert boundary=="host-reported-compaction" and epoch=="e2"
+assert next_action=="qualify the authoritative successor before release"
+assert len(owner_oid)==40 and len(state)==64 and len(roadmap)==64
+PY
+(cd "$successor_repo" && bash "$claim_helper" --verify-resume-receipt "$receipt") >/dev/null \
+  || fail "fresh successor continuity receipt did not verify"
+if (cd "$successor_repo" && bash "$claim_helper" --resume-controller release-v0333 \
+    --boundary host-reported-compaction --epoch e2) >/dev/null 2>&1; then
+  fail "a second writer claimed the same continuity epoch"
+fi
+
+# Multiple controller records are an audited ambiguity, never a guessed root.
+(cd "$successor_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller sibling-controller 'independent sibling' >/dev/null 2>&1) \
+  || fail "independent controller claim failed"
+if (cd "$successor_repo" && bash "$claim_helper" --current-controller) >/dev/null 2>&1; then
+  fail "ambiguous controller discovery guessed one current root"
+fi
+(cd "$successor_repo" && bash "$claim_helper" --current-controller release-v0333) >/dev/null \
+  || fail "explicit controller discovery failed under legitimate parallelism"
+
+# A controller blob copied into an unrelated object store is not current
+# authority there, even when its embedded run root and claim are internally
+# valid. Discovery must bind the ref store and run custody to one Git common.
+foreign_a="$tmp/foreign-a"; foreign_b="$tmp/foreign-b"
+for foreign_repo in "$foreign_a" "$foreign_b"; do
+  mkdir -p "$foreign_repo"; git -C "$foreign_repo" init -q
+  git -C "$foreign_repo" config user.name 'continuity fixture'
+  git -C "$foreign_repo" config user.email 'continuity@example.invalid'
+  printf 'repo\n' > "$foreign_repo/product.txt"
+  git -C "$foreign_repo" add product.txt; git -C "$foreign_repo" commit -qm initial
+done
+(cd "$foreign_b" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller foreign-custody 'foreign controller' >"$tmp/foreign-rel" 2>/dev/null) \
+  || fail "foreign controller fixture claim failed"
+foreign_root="$foreign_b/$(cat "$tmp/foreign-rel")"
+for f in STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
+  cp "$repo_root/skills/implementaudit/templates/$f" "$foreign_root/$f"
+done
+foreign_ref='refs/implementaudit/controllers/foreign-custody'
+foreign_oid="$(git -C "$foreign_b" rev-parse "$foreign_ref")"
+copied_oid="$(git -C "$foreign_b" cat-file blob "$foreign_oid" | git -C "$foreign_a" hash-object -w --stdin)"
+[ "$copied_oid" = "$foreign_oid" ] || fail "foreign controller blob copy changed identity"
+foreign_source=''; foreign_source_rc=0
+foreign_source="$(cd "$foreign_b" && bash "$claim_helper" --current-controller foreign-custody 2>"$tmp/foreign-source.err")" || foreign_source_rc=$?
+[ "$foreign_source_rc" -eq 0 ] || fail "source-store foreign controller was not independently valid: $(cat "$tmp/foreign-source.err")"
+foreign_a_common="$(cd "$(git -C "$foreign_a" rev-parse --path-format=absolute --git-common-dir)" && pwd -P)"
+foreign_b_common="$(cd "$(git -C "$foreign_b" rev-parse --path-format=absolute --git-common-dir)" && pwd -P)"
+[ "$foreign_a_common" != "$foreign_b_common" ] || fail "foreign custody fixture did not create distinct Git commons"
+git -C "$foreign_a" update-ref "$foreign_ref" "$copied_oid"
+foreign_current=''; foreign_current_rc=0
+foreign_current="$(cd "$foreign_a" && bash "$claim_helper" --current-controller foreign-custody 2>"$tmp/foreign.err")" || foreign_current_rc=$?
+if [ "$foreign_current_rc" -eq 0 ]; then
+  fail "controller discovery authenticated foreign Git-common custody"
+fi
+
+if (cd "$successor_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+    bash "$claim_helper" --controller release-v0333 --supersede-claim "$initial_claim" \
+    'stale competing migration') >/dev/null 2>&1; then
+  fail "stale expected claim replaced the current controller"
+fi
+
+printf 'later drift\n' >> "$successor_repo/product.txt"
+git -C "$successor_repo" add product.txt
+git -C "$successor_repo" commit -qm 'later drift'
+if (cd "$successor_repo" && bash "$claim_helper" --verify-resume-receipt "$receipt") >/dev/null 2>&1; then
+  fail "continuity receipt remained valid after repository drift"
+fi
+
+# Two successor worktrees racing from one predecessor claim cannot create two
+# current controllers.  The Git-common compare-and-swap selects exactly one;
+# the loser remains non-authoritative.
+race_repo="$tmp/race-repo"; race_a="$tmp/race-a"; race_b="$tmp/race-b"
+mkdir -p "$race_repo"; git -C "$race_repo" init -q
+git -C "$race_repo" config user.name 'continuity fixture'
+git -C "$race_repo" config user.email 'continuity@example.invalid'
+printf 'race\n' > "$race_repo/product.txt"; git -C "$race_repo" add product.txt
+git -C "$race_repo" commit -qm race
+git -C "$race_repo" worktree add -q -b race-a "$race_a"
+git -C "$race_repo" worktree add -q -b race-b "$race_b"
+race_initial_rel="$(cd "$race_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller split-brain 'initial race controller' 2>/dev/null)"
+race_claim="$(sed -n 's/^claim_id=//p' "$race_repo/$race_initial_rel/.claimed")"
+(
+  cd "$race_a" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs bash "$claim_helper" \
+    --controller split-brain --supersede-claim "$race_claim" 'racing successor a' \
+    >"$tmp/race-a.out" 2>"$tmp/race-a.err"
+) & race_a_pid=$!
+(
+  cd "$race_b" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs bash "$claim_helper" \
+    --controller split-brain --supersede-claim "$race_claim" 'racing successor b' \
+    >"$tmp/race-b.out" 2>"$tmp/race-b.err"
+) & race_b_pid=$!
+race_a_rc=0; wait "$race_a_pid" || race_a_rc=$?
+race_b_rc=0; wait "$race_b_pid" || race_b_rc=$?
+[ $(( (race_a_rc == 0) + (race_b_rc == 0) )) -eq 1 ] ||
+  fail "controller CAS did not select exactly one racing successor: $race_a_rc/$race_b_rc"
+if [ "$race_a_rc" -eq 0 ]; then
+  expected_winner="$race_a"; winner_rel="$(cat "$tmp/race-a.out")"; losing_repo="$race_b"
+else
+  expected_winner="$race_b"; winner_rel="$(cat "$tmp/race-b.out")"; losing_repo="$race_a"
+fi
+find "$losing_repo/.IMPLEMENTAUDIT/runs" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null | grep -q . &&
+  fail "losing controller CAS retained a plausible stale run root"
+for f in STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
+  cp "$repo_root/skills/implementaudit/templates/$f" "$expected_winner/$winner_rel/$f"
+done
+race_current="$(cd "$race_repo" && bash "$claim_helper" --current-controller split-brain)" ||
+  fail "winning racing controller was not discoverable"
+race_winner_repo="$(printf '%s' "$race_current" | cut -f2)"
+"${py_cmd[@]}" - "$race_winner_repo" "$expected_winner" <<'PY' || fail "CAS current controller does not name the sole winner"
+import os,sys
+assert os.path.normcase(os.path.abspath(sys.argv[1]))==os.path.normcase(os.path.abspath(sys.argv[2]))
+PY
+
+# Positive N06-style control: one controller, one worktree, current root, live
+# epoch and Next action.  It resumes without a migration or extra run.
+positive_repo="$tmp/positive-repo"; mkdir -p "$positive_repo"
+git -C "$positive_repo" init -q
+git -C "$positive_repo" config user.name 'continuity fixture'
+git -C "$positive_repo" config user.email 'continuity@example.invalid'
+printf 'positive\n' > "$positive_repo/product.txt"
+git -C "$positive_repo" add product.txt; git -C "$positive_repo" commit -qm positive
+positive_rel="$(cd "$positive_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" --controller positive-n06 'positive continuity' 2>/dev/null)"
+positive_root="$positive_repo/$positive_rel"
+for f in STATE.md PROTOCOL.md ROADMAP.md THINKING.md sidecars.md tools.md context.md; do
+  cp "$repo_root/skills/implementaudit/templates/$f" "$positive_root/$f"
+done
+"${py_cmd[@]}" - "$positive_root/STATE.md" "$positive_rel" \
+  "$(git -C "$positive_repo" rev-parse HEAD)" "$(git -C "$positive_repo" rev-parse 'HEAD^{tree}')" <<'PY'
+import sys
+from pathlib import Path
+p=Path(sys.argv[1]); run,head,tree=sys.argv[2:]
+s=p.read_text(encoding="utf-8").replace("| Run root |  |",f"| Run root | `{run}` |")
+s=s.replace("| Next action |  |","| Next action | resume the exact current checkpoint |")
+a="| Epoch | Boundary provenance | Established at | Repo identity | Reconciled | Notes |\n|---|---|---|---|---|---|"
+r=f"| e1 | host-reported-compaction | 2026-08-12T12:00:00Z | repo at `{head}` / `{tree}` | yes | separate live reads complete |"
+p.write_text(s.replace(a,a+"\n"+r),encoding="utf-8")
+PY
+(cd "$positive_repo" && bash "$claim_helper" --resume-controller positive-n06 \
+  --boundary host-reported-compaction --epoch e1) >/dev/null \
+  || fail "positive same-controller continuity case failed"
+
+# Ordinary bounded claims remain the no-registry cheap path.
+cheap_rel="$(cd "$positive_repo" && IMPLEMENTAUDIT_BASE=.IMPLEMENTAUDIT/runs \
+  bash "$claim_helper" 'small ordinary task' 2>/dev/null)"
+[ -f "$positive_repo/$cheap_rel/.claimed" ] || fail "ordinary claim cheap path regressed"
 
 printf 'continuity-contract.test: ok (surfaces + validator: legacy pass, honest-provenance, kind/status tokens, terminal-status evidence)\n'

--- a/tests/release-asset.test.sh
+++ b/tests/release-asset.test.sh
@@ -1022,13 +1022,13 @@ with zipfile.ZipFile(asset) as zf:
         )
 
     # The composed /improve dominance fold-in plus the R31 receiver-completeness
-    # countermeasure, closed frontier census, and grounded plan boundary measure
-    # 257,433 bytes. This
+    # countermeasure, closed frontier census, grounded plan boundary, and
+    # controller-currentness repair measure 257,992 bytes. This
     # owner-authorised R33 calibration keeps the smallest whole-1,000-byte
     # ceiling preserving at least 2,000 bytes of measured headroom: 260,000
-    # leaves 2,567 bytes. The 260,000-byte outer bound is a guard, not a target.
+    # leaves 2,008 bytes. The 260,000-byte outer bound is a guard, not a target.
     MAX_ASSET_BYTES = 260_000
-    CURRENT_CALIBRATION_ASSET_BYTES = 257_433
+    CURRENT_CALIBRATION_ASSET_BYTES = 257_992
     N06_BASELINE_ASSET_BYTES = 206_584
     N06_FINAL_P7_ASSET_BYTES = 215_126
     FULL_W1_FORECAST_BYTES = 144_730


### PR DESCRIPTION
## Summary

- bind post-compaction controller discovery to the caller's canonical Git-common custody
- add causal long-run migration, split-brain, stale-root, receipt, and foreign-object-store regressions
- preserve the ordinary bounded claim path and package reachability

## Evidence

- valid cross-store RED reproduced before repair
- source and exact installed continuity contracts pass
- claim-run 38/38 continuity, helper reachability, semantic preservation 21/21 pass
- canonical package: 257,992 bytes, SHA-256 c3c5a76296d38656a5064169e032670c621ce20f96c9bb030c3023536fb9f495, 2,008-byte headroom
- independent exact-diff review: PASS

Graphify remains post-release and is not part of this PR.