### PR TITLE
HC-H8: repair finite retry-cap detection

### DIFF
--- a/scripts/check-no-terminal-cap.sh
+++ b/scripts/check-no-terminal-cap.sh
@@ -98,6 +98,9 @@ DIRECT_STRIKE_CAP_PATTERNS = [
     r"\bstrikes?\s+(?:counter|count|cap|limit)\b",
     r"\bafter\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|n|[1-9][0-9]*)\s+strikes?\b.*\b(?:stop|stops|block|blocks|handoff|hands\s+off|terminate|terminates|fail|fails|close|closes)\b",
 ]
+DIRECT_RETRY_CAP_PATTERNS = [
+    r"\bafter\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|n|[1-9][0-9]*)\s+(?:retry|retries)\b.*\b(?:stop|stops|block|blocks|handoff|hand\s+off|hands\s+off|terminate|terminates|fail|fails|close|closes)\b",
+]
 
 ALWAYS_FORBIDDEN = [
     "no subsequent phases execute",
@@ -145,11 +148,12 @@ for path in paths:
             STRIKE_POLICY_CONTEXT, lowered
         )
         direct_strike_cap = any(re.search(pattern, lowered) for pattern in DIRECT_STRIKE_CAP_PATTERNS)
-        if (counted_strike_policy or direct_strike_cap) and not any(
+        direct_retry_cap = any(re.search(pattern, lowered) for pattern in DIRECT_RETRY_CAP_PATTERNS)
+        if (counted_strike_policy or direct_strike_cap or direct_retry_cap) and not any(
             context in lowered for context in NEGATED_CONTEXT
         ):
             violations.append(
-                f"{path.as_posix()}:{lineno}: disallowed public-claim terminal-cap wording: counted/capped strike policy"
+                f"{path.as_posix()}:{lineno}: disallowed public-claim terminal-cap wording: counted/capped retry or strike policy"
             )
         if (
             "first" in lowered

--- a/tests/no-terminal-cap.test.sh
+++ b/tests/no-terminal-cap.test.sh
@@ -69,6 +69,31 @@ After three strikes, stop and hand off.
 Strike 3 stops the run.
 EOF
 
+# 3c. Counted/capped retry semantics must fail without banning ordinary retry prose.
+retry_case=0
+while IFS= read -r wording; do
+  retry_case=$((retry_case + 1))
+  dir="$tmp/bad-counted-retry-$retry_case"
+  mkdir -p "$dir/skills/implementaudit/templates"
+  printf '%s\n' "$wording" >"$dir/skills/implementaudit/templates/PROTOCOL.md"
+  if bash scripts/check-no-terminal-cap.sh --scan-root "$dir" >/dev/null 2>&1; then
+    printf 'no-terminal-cap.test: expected counted retry wording to fail: %s\n' "$wording" >&2
+    exit 1
+  fi
+done <<'EOF'
+After 3 retries, stop the run.
+After three retries, hand off the run.
+EOF
+
+# Ordinary retry guidance remains valid when it does not impose a finite
+# terminal stop or handoff policy.
+mkdir -p "$tmp/good-retry/skills/implementaudit/templates"
+cat >"$tmp/good-retry/skills/implementaudit/templates/PROTOCOL.md" <<'EOF'
+Retry after a transient evidence mismatch and continue until the evidence resolves.
+Repeated retries remain available while the currentness check is inconclusive.
+EOF
+bash scripts/check-no-terminal-cap.sh --scan-root "$tmp/good-retry"
+
 # 4. Run-stopping wording and legacy marker spellings must fail.
 mkdir -p "$tmp/bad-legacy/skills/implementaudit/references"
 cat >"$tmp/bad-legacy/skills/implementaudit/references/transcript-contract.md" <<'EOF'


### PR DESCRIPTION
## Cell

HC-H8 — R0037 retry-cap repair.

## Base and dependencies

- Base: `thread5/v041-integration` at planning head `57b48140f1266cbd3f6316718463409a134f1969`
- Dependencies: G09 preflight GREEN only
- Shared writer: no overlap with active HC-H0; HC-H3 remains serialized separately
- Public `main`: intentionally unchanged

## Change

Detect finite retry-count wording followed by terminal stop/handoff/failure
language without broadening into Stop adapters or closure semantics. Preserve
ordinary retry prose, strike/strikes/CrowdStrike and explicit no-cap denials.

## Evidence

- Semantic RED observed for `After 3 retries, stop the run.` before checker mutation
- `bash tests/no-terminal-cap.test.sh` — PASS
- `bash scripts/check-no-terminal-cap.sh` — PASS
- `bash -n scripts/check-no-terminal-cap.sh tests/no-terminal-cap.test.sh` — PASS
- `git diff --check` — PASS
- Independent task review — PASS, zero findings

## Rollback

Revert commit `3fb3683816cd8c7f7857c127ea338eca6936a76e`; no other cell or public state depends on this draft before reviewed integration.
