### PR TITLE
Bind host sessions to governed objects

### DIFF
--- a/fixtures/host-session-binding/disabled-owner.json
+++ b/fixtures/host-session-binding/disabled-owner.json
@@ -1,0 +1,6 @@
+{
+  "enabled": false,
+  "owner_id": "host-owner",
+  "schema": "implementaudit.host-session-binding-store.v1",
+  "trusted": true
+}

--- a/fixtures/host-session-binding/malformed-binding.json
+++ b/fixtures/host-session-binding/malformed-binding.json
@@ -1,0 +1,6 @@
+{
+  "schema": "implementaudit.host-session-binding-state.v0-mixed",
+  "host_id": "codex",
+  "host_session_id": "session-a",
+  "records": []
+}

--- a/fixtures/host-session-binding/untrusted-owner.json
+++ b/fixtures/host-session-binding/untrusted-owner.json
@@ -1,0 +1,6 @@
+{
+  "enabled": true,
+  "owner_id": "host-owner",
+  "schema": "implementaudit.host-session-binding-store.v1",
+  "trusted": false
+}

--- a/fixtures/semantic-preservation/cases.json
+++ b/fixtures/semantic-preservation/cases.json
@@ -15,7 +15,7 @@
       "owner": {
         "path": "skills/implementaudit/SKILL.md",
         "revision": "WORKTREE",
-        "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7",
+        "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae",
         "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"
       },
       "consumer": {
@@ -31,19 +31,19 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "lean-same-owner-equivalent": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Engineering-value admission, retention, and retirement"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "lean-lost": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
-      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "anchor": "Package semantic preservation"},
+      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "anchor": "Package semantic preservation"},
       "consumers": [
         {"kind": "checker", "required": true, "path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "bccf6672fecc88dc336b4fd9845513a2caa7a9480934a3d9d0c229c607e3b3b7", "route_anchor": "Package semantic preservation", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "bccf6672fecc88dc336b4fd9845513a2caa7a9480934a3d9d0c229c607e3b3b7", "anchor": "Package semantic preservation"}}
       ]
@@ -52,21 +52,21 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "CONTRIBUTING.md", "revision": "WORKTREE", "sha256": "c165468017372f55e906ece30be13205941bc1b03258bfc6213689767a308e4e", "anchor": "# Contributing"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "nonexistent-owner": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "references/definitely-not-shipped.md", "revision": "WORKTREE", "sha256": null, "anchor": null},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     },
     "broken-consumer": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/definitely-not-shipped.md"}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/definitely-not-shipped.md"}
       ]
     },
     "invented-consumer": {
@@ -77,22 +77,22 @@
       ]
     },
     "safe-progressive": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "anchor": "references/lean-operating-discipline.md"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "anchor": "references/lean-operating-discipline.md"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/install-codex-from-release.sh", "revision": "WORKTREE", "sha256": "f27fd089fb203af5ca60546d5f12f8ed8732d3cf5d9513cdf8866ea99a75533f", "anchor": "references/lean-operating-discipline.md"}}
+        {"kind": "runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/install-codex-from-release.sh", "revision": "WORKTREE", "sha256": "f27fd089fb203af5ca60546d5f12f8ed8732d3cf5d9513cdf8866ea99a75533f", "anchor": "references/lean-operating-discipline.md"}}
       ]
     },
     "exact-marker-changed": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
         {"kind": "parser", "required": true, "path": "scripts/check-marker-order.sh", "revision": "WORKTREE", "sha256": "9764979aa3e1324e217828684e45ef67f40f14427537502a62ce3d66b6872b31", "route_anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"}
       ]
     },
     "exact-marker-broken-consumer": {
-      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
-      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "before": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
+      "after": {"path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "anchor": "IMPLEMENTAUDIT_RUN_COMPLETE"},
       "consumers": [
         {"kind": "parser", "required": true, "path": "scripts/check-marker-order.sh", "revision": "WORKTREE", "sha256": "9764979aa3e1324e217828684e45ef67f40f14427537502a62ce3d66b6872b31", "route_anchor": "DEFINITELY_NOT_A_MARKER"}
       ]
@@ -101,14 +101,14 @@
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "held-out-runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "bccf6672fecc88dc336b4fd9845513a2caa7a9480934a3d9d0c229c607e3b3b7", "anchor": "DEFINITELY_NOT_A_HELD_OUT_ASSERTION"}}
+        {"kind": "held-out-runtime", "required": true, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md", "held_out": {"path": "scripts/check-lean-discipline.sh", "revision": "WORKTREE", "sha256": "bccf6672fecc88dc336b4fd9845513a2caa7a9480934a3d9d0c229c607e3b3b7", "anchor": "DEFINITELY_NOT_A_HELD_OUT_ASSERTION"}}
       ]
     },
     "optional-only": {
       "before": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "after": {"path": "skills/implementaudit/references/lean-operating-discipline.md", "revision": "WORKTREE", "sha256": "3cad172a60a2c4d85903543d6b36a498cbb2bb58a4f15b044e876164abb2329c", "anchor": "Package semantic preservation"},
       "consumers": [
-        {"kind": "advisory-note", "required": false, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "325cb0f7be5c89aa300d859b27b69f109dbcab65c29511dc69317c5315fa58b7", "route_anchor": "references/lean-operating-discipline.md"}
+        {"kind": "advisory-note", "required": false, "path": "skills/implementaudit/SKILL.md", "revision": "WORKTREE", "sha256": "7842b6c628673327abd299918bc41254df8adfaa3c1be2b9d1d2ef8f9775f5ae", "route_anchor": "references/lean-operating-discipline.md"}
       ]
     }
   },

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -306,6 +306,12 @@ require_file fixtures/sidecar-contract/footprint-default.md
 require_file fixtures/sidecar-contract/external-validity.md
 require_file tests/andon-class-contract.test.sh
 require_file tests/continuity-contract.test.sh
+require_file tests/host-session-binding.test.sh
+require_file fixtures/host-session-binding/disabled-owner.json
+require_file fixtures/host-session-binding/untrusted-owner.json
+require_file fixtures/host-session-binding/malformed-binding.json
+require_file skills/implementaudit/references/host-session-binding.md
+require_file skills/implementaudit/scripts/host-session-binding.py
 require_file tests/interruption-durability.test.sh
 require_file tests/lesson-lift-contract.test.sh
 require_file tests/handoff-packet-contract.test.sh
@@ -697,6 +703,7 @@ bash scripts/check-added-lines-clean.sh HEAD
 bash tests/lean-discipline.test.sh
 bash tests/andon-class-contract.test.sh
 bash tests/continuity-contract.test.sh
+bash tests/host-session-binding.test.sh
 bash tests/interruption-durability.test.sh
 bash tests/lesson-lift-contract.test.sh
 bash tests/handoff-packet-contract.test.sh

--- a/skills/implementaudit/SKILL.md
+++ b/skills/implementaudit/SKILL.md
@@ -191,8 +191,8 @@ Load references only when the current gate needs them:
 - `references/goal-format.md`: `/goal`, response, and marker shape.
 - `references/transcript-contract.md`: marker order, handoff exclusivity, and
   the state-derived RC self-dogfood evidence contract when triggered.
-- `references/continuity.md`: controller currentness, epochs, replay refusal,
-  receiver receipts, and post-boundary reconciliation before mutation.
+- `references/continuity.md` and `references/host-session-binding.md`:
+  controller currentness, boundary recovery, and exact host attribution.
 - `references/repo-state-comparison.md`: baseline/final and helper dispatch.
 - `references/sidecars.md`: optional Graphify/ActiveGraph and tooling bounds.
 - `references/lean-operating-discipline.md`: PDCA, Andon, Hansei, 5 Whys,

--- a/skills/implementaudit/references/continuity.md
+++ b/skills/implementaudit/references/continuity.md
@@ -91,6 +91,24 @@ Non-cooperating same-principal writers remain outside the guarantee.
 `.IMPLEMENTAUDIT/host-notes.md` is local context, not portable authority;
 portable rules use `AGENTS_UPDATE_DECISION`.
 
+## Host-session attribution
+
+Controller and continuity currentness remain the owners above host-event
+attribution. When governed activation associates a host session with the
+current object, or an admitted host event needs that attribution, load
+`host-session-binding.md` and use `scripts/host-session-binding.py` against an
+explicit plugin-owned or host-owned store. Bind the exact host session,
+controller, claim, run, repository, Git-common directory, worktree, continuity
+generation and receipts. Rebinding is expected-generation CAS.
+
+No binding is the zero-scan cheap path: do not inspect cwd, enumerate run roots,
+select a controller singleton, read target prose or child output, or execute a
+validator. A stale, foreign, superseded, tombstoned, ambiguous, disabled,
+untrusted or malformed binding is unavailable. R003A attribution cannot mint a
+continuity receipt, satisfy a route obligation, close an object, authorise an
+effect or prove native host activation. SessionEnd may tombstone attribution;
+it cannot close the governed object.
+
 ## Identity and instruction lifecycle
 
 ```text

--- a/skills/implementaudit/references/host-session-binding.md
+++ b/skills/implementaudit/references/host-session-binding.md
@@ -1,0 +1,97 @@
+# Host-session binding (R003A)
+
+R003A is the attribution bridge between a host session and an already governed
+IMPLEMENTAUDIT object. A host lifecycle event may affect or correlate state only
+after the exact `(host_id, host_session_id)` binding is current and all supplied
+controller, claim, run, repository, worktree and continuity identities match.
+
+This bridge consumes existing controller and continuity evidence. It does not
+mint or replace controller currentness, a continuity receipt, route satisfaction,
+closure, mutation authority, READY/JOIN state, or native host activation proof.
+
+## Custody and record
+
+`scripts/host-session-binding.py` requires an explicit `--store`. The store is
+plugin-owned or equivalently host-owned outside target-repository authority; do
+not derive it from cwd or target content. `init --owner-id <id>` creates its
+owner marker. Disabled, untrusted, malformed, aliased or mixed-version state is
+unavailable and cannot support an enforcement claim.
+
+The key is the exact host ID plus exact host-session ID. A direct session index
+also prevents one session ID from being rebound under an incompatible host
+identity without enumerating bindings. Each value records:
+
+```text
+schema
+host_id
+host_session_id
+controller_id
+claim_id
+explicit_run_root
+repository_identity
+git_common_directory_identity
+worktree_identity
+binding_generation
+activation_event_id
+activation_receipt
+applicable_continuity_generation
+applicable_continuity_receipt
+status
+predecessor_generation
+supersession_or_tombstone_reason
+```
+
+`bind` starts at `G0001`. `rebind` and `tombstone` require the exact expected
+current generation, run under the store writer lock, and advance exactly one
+generation. Records are replaced atomically. `ACTIVE`, `SUPERSEDED` and
+`TOMBSTONED` are attribution states only.
+
+The activation and continuity receipts are opaque, non-secret evidence
+identifiers supplied by their existing owners. The binding core records and
+compares them; it does not validate their underlying controller or continuity
+predicates. Callers must complete those owner checks before `bind` or `rebind`.
+
+## Read path and event correlation
+
+`lookup --host-id <host> --host-session-id <session>` is read-only. When the
+exact binding file is absent it returns `UNBOUND` immediately without creating
+the store, scanning a repository, enumerating run roots, selecting a singleton,
+or running a validator.
+
+`validate-event` is also read-only. It requires the current binding generation
+and every controller/claim/run/repository/worktree/continuity identity. It
+rejects stale, reordered, foreign, ambiguous and tombstoned attribution. Its
+correlation ID is a deterministic digest of the exact binding and admitted
+event, turn, tool-use, agent, obligation and route-transaction identifiers.
+Route obligation and transaction IDs must be supplied together; successful
+correlation does not satisfy or consume either one.
+
+Target prose, transcripts, child or subagent output, cwd, newest-run selection,
+and controller-singleton inference are never inputs to identity resolution.
+
+## Session end, GC and proof boundaries
+
+`tombstone --reason session-end` ends session attribution. It reports
+`object_closed: false` and does not write to the controller, run root,
+continuity receipts or evidence state.
+
+`gc` is store-owner-bound and expected-generation fenced. It retains at least
+the current generation and removes only explicitly named non-active generations
+that carry a separately supplied closure-owner resolution receipt. Missing
+resolution evidence fails closed. Repeating the same request is idempotent.
+GC never deletes or edits controller, run-root, continuity or evidence state.
+
+Every successful binding result separates the proof layers:
+
+```text
+source_core=PRESENT
+package=UNVERIFIED
+install=UNVERIFIED
+host_activation=UNVERIFIED
+```
+
+Source behavior therefore cannot be promoted into a package, install, native
+host discovery, activation, enforcement or universal-host claim.
+
+Rollback removes the thin host adapter and R003A store records. Preserve the
+controller, claim, governed run, continuity receipts and audit evidence.

--- a/skills/implementaudit/scripts/host-session-binding.py
+++ b/skills/implementaudit/scripts/host-session-binding.py
@@ -184,6 +184,14 @@ def session_index_path(store: Path, host_session_id: str) -> Path:
     return store / "sessions" / key[:2] / f"{key}.json"
 
 
+def binding_pair_exists(store: Path, host_id: str, host_session_id: str) -> bool:
+    state_present = os.path.lexists(state_path(store, host_id, host_session_id))
+    index_present = os.path.lexists(session_index_path(store, host_session_id))
+    if state_present != index_present:
+        fail("binding state and session host index are a partial pair")
+    return state_present
+
+
 def atomic_json(path: Path, payload: dict[str, Any]) -> None:
     parent = ensure_safe_directory(path.parent, f"{path.name} parent")
     target = parent / path.name
@@ -332,6 +340,12 @@ def validate_record(record: Any, host_id: str, host_session_id: str) -> dict[str
 
 def load_state(store: Path, host_id: str, host_session_id: str) -> tuple[Path, dict[str, Any]]:
     target = state_path(store, host_id, host_session_id)
+    if not binding_pair_exists(store, host_id, host_session_id):
+        fail("host session binding is absent")
+    expected_index = {"host_id": host_id, "host_session_id": host_session_id}
+    index = read_json(session_index_path(store, host_session_id), "session host index")
+    if set(index) != set(expected_index) or index != expected_index:
+        fail("session host index is malformed, foreign, or mismatched")
     state = read_json(target, "binding state")
     if set(state) != {"schema", "host_id", "host_session_id", "records"}:
         fail("binding state has the wrong shape")
@@ -434,14 +448,9 @@ def command_bind(args: argparse.Namespace) -> None:
     target = state_path(store, binding["host_id"], binding["host_session_id"])
     index = session_index_path(store, binding["host_session_id"])
     with writer_lock(store):
-        if target.exists():
+        if binding_pair_exists(store, binding["host_id"], binding["host_session_id"]):
             fail("binding already exists; expected-generation rebinding is required")
-        if index.exists():
-            existing = read_json(index, "session host index")
-            if existing != {"host_id": binding["host_id"], "host_session_id": binding["host_session_id"]}:
-                fail("same session identity is already bound under an incompatible host")
-        else:
-            atomic_json(index, {"host_id": binding["host_id"], "host_session_id": binding["host_session_id"]})
+        atomic_json(index, {"host_id": binding["host_id"], "host_session_id": binding["host_session_id"]})
         atomic_json(
             target,
             {
@@ -487,8 +496,7 @@ def command_lookup(args: argparse.Namespace) -> None:
     host_id = exact_text(args.host_id, "host_id")
     session_id = exact_text(args.host_session_id, "host_session_id")
     store = Path(args.store).absolute()
-    target = state_path(store, host_id, session_id)
-    if not target.exists():
+    if not binding_pair_exists(store, host_id, session_id):
         emit({"schema": RESULT_SCHEMA, "status": "UNBOUND", "enforcement_available": False})
         return
     load_owner(store)
@@ -505,9 +513,6 @@ def command_validate_event(args: argparse.Namespace) -> None:
     host_id = exact_text(args.host_id, "host_id")
     session_id = exact_text(args.host_session_id, "host_session_id")
     store = Path(args.store).absolute()
-    target = state_path(store, host_id, session_id)
-    if not target.exists():
-        fail("host session is unbound")
     load_owner(store)
     _, state = load_state(store, host_id, session_id)
     current = current_record(state, require_active=True)

--- a/skills/implementaudit/scripts/host-session-binding.py
+++ b/skills/implementaudit/scripts/host-session-binding.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""Bind one exact host session to one governed IMPLEMENTAUDIT object."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import errno
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Iterator, NoReturn
+
+
+STORE_SCHEMA = "implementaudit.host-session-binding-store.v1"
+STATE_SCHEMA = "implementaudit.host-session-binding-state.v1"
+BINDING_SCHEMA = "implementaudit.host-session-binding.v1"
+RESULT_SCHEMA = "implementaudit.host-session-binding-result.v1"
+GENERATION_RE = re.compile(r"G([0-9A-F]{4})")
+MAX_TEXT = 1024
+PROOF_LAYERS = {
+    "source_core": "PRESENT",
+    "package": "UNVERIFIED",
+    "install": "UNVERIFIED",
+    "host_activation": "UNVERIFIED",
+}
+BINDING_KEYS = {
+    "schema",
+    "host_id",
+    "host_session_id",
+    "controller_id",
+    "claim_id",
+    "explicit_run_root",
+    "repository_identity",
+    "git_common_directory_identity",
+    "worktree_identity",
+    "binding_generation",
+    "activation_event_id",
+    "activation_receipt",
+    "applicable_continuity_generation",
+    "applicable_continuity_receipt",
+    "status",
+    "predecessor_generation",
+    "supersession_or_tombstone_reason",
+}
+
+
+def fail(message: str) -> NoReturn:
+    print(
+        json.dumps(
+            {
+                "schema": RESULT_SCHEMA,
+                "status": "UNAVAILABLE",
+                "enforcement_available": False,
+                "error": message,
+            },
+            sort_keys=True,
+        )
+    )
+    raise SystemExit(2)
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def exact_text(value: str, label: str) -> str:
+    if not value or len(value) > MAX_TEXT or any(ord(char) < 32 for char in value):
+        fail(f"{label} is empty, oversized, or contains a control character")
+    return value
+
+
+def generation(value: str, label: str) -> str:
+    match = GENERATION_RE.fullmatch(value)
+    if not match or int(match.group(1), 16) < 1:
+        fail(f"{label} is not a non-zero canonical generation")
+    return value
+
+
+def next_generation(value: str) -> str:
+    current = int(generation(value, "binding_generation")[1:], 16)
+    if current >= 0xFFFF:
+        fail("binding generation is exhausted")
+    return f"G{current + 1:04X}"
+
+
+def has_reparse_flag(info: os.stat_result) -> bool:
+    return bool(getattr(info, "st_file_attributes", 0) & 0x400)
+
+
+def unsafe_file(info: os.stat_result) -> bool:
+    return (
+        not stat.S_ISREG(info.st_mode)
+        or stat.S_ISLNK(info.st_mode)
+        or has_reparse_flag(info)
+        or info.st_nlink != 1
+    )
+
+
+def safe_existing_directory(value: str, label: str) -> str:
+    raw = Path(value)
+    try:
+        absolute = raw.absolute()
+        resolved = raw.resolve(strict=True)
+        info = os.lstat(absolute)
+    except (OSError, RuntimeError) as exc:
+        fail(f"{label} is not a resolvable existing directory: {exc}")
+    if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode) or has_reparse_flag(info):
+        fail(f"{label} is a symlink, reparse point, or non-directory")
+    if absolute != resolved:
+        fail(f"{label} traverses an alias")
+    return str(resolved)
+
+
+def ensure_safe_directory(path: Path, label: str) -> Path:
+    absolute = path.absolute()
+    existing = absolute
+    while not os.path.lexists(existing):
+        parent = existing.parent
+        if parent == existing:
+            fail(f"{label} has no inspectable existing ancestor")
+        existing = parent
+    safe_existing_directory(str(existing), f"{label} ancestor")
+    try:
+        absolute.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        fail(f"{label} cannot be created: {exc}")
+    return Path(safe_existing_directory(str(absolute), label))
+
+
+def is_within(child: str, parent: str) -> bool:
+    try:
+        Path(child).relative_to(Path(parent))
+    except ValueError:
+        return False
+    return True
+
+
+def require_run_worktree_custody(run_root: str, worktree: str) -> None:
+    if run_root == worktree or not is_within(run_root, worktree):
+        fail("explicit_run_root is outside the recorded worktree")
+
+
+def require_external_store(store: Path, binding: dict[str, Any]) -> Path:
+    canonical = Path(safe_existing_directory(str(store), "store"))
+    store_text = str(canonical)
+    for label in (
+        "repository_identity",
+        "git_common_directory_identity",
+        "worktree_identity",
+        "explicit_run_root",
+    ):
+        target = binding[label]
+        if store_text == target or is_within(store_text, target) or is_within(target, store_text):
+            fail(f"binding store overlaps target-controlled {label}")
+    return canonical
+
+
+def binding_key(host_id: str, host_session_id: str) -> str:
+    return hashlib.sha256(f"{host_id}\0{host_session_id}".encode("utf-8")).hexdigest()
+
+
+def session_key(host_session_id: str) -> str:
+    return hashlib.sha256(host_session_id.encode("utf-8")).hexdigest()
+
+
+def owner_path(store: Path) -> Path:
+    return store / "owner.json"
+
+
+def state_path(store: Path, host_id: str, host_session_id: str) -> Path:
+    key = binding_key(host_id, host_session_id)
+    return store / "bindings" / key[:2] / key / "binding.json"
+
+
+def session_index_path(store: Path, host_session_id: str) -> Path:
+    key = session_key(host_session_id)
+    return store / "sessions" / key[:2] / f"{key}.json"
+
+
+def atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    parent = ensure_safe_directory(path.parent, f"{path.name} parent")
+    target = parent / path.name
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def read_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        absolute = path.absolute()
+        resolved = path.resolve(strict=True)
+        if absolute != resolved:
+            fail(f"{label} traverses an alias")
+        info = os.lstat(path)
+        if unsafe_file(info):
+            fail(f"{label} is not a safe regular file")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        fail(f"{label} is unreadable or malformed: {exc}")
+    if not isinstance(payload, dict):
+        fail(f"{label} is not an object")
+    return payload
+
+
+def load_owner(store: Path, expected_owner: str | None = None) -> dict[str, Any]:
+    marker = read_json(owner_path(store), "store owner state")
+    if set(marker) != {"schema", "owner_id", "trusted", "enabled"}:
+        fail("store owner state has the wrong shape")
+    if marker["schema"] != STORE_SCHEMA or marker["trusted"] is not True or marker["enabled"] is not True:
+        fail("store owner state is untrusted, disabled, or mixed-version")
+    if not isinstance(marker["owner_id"], str):
+        fail("store owner identity is malformed")
+    if expected_owner is not None and marker["owner_id"] != expected_owner:
+        fail("foreign store owner")
+    return marker
+
+
+@contextlib.contextmanager
+def writer_lock(store: Path) -> Iterator[None]:
+    lock_path = store / ".writer.lock"
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        fail(f"writer lock cannot be opened safely: {exc}")
+    locked = False
+    try:
+        opened = os.fstat(descriptor)
+        current = os.lstat(lock_path)
+        if unsafe_file(opened) or unsafe_file(current) or (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino):
+            fail("writer lock is unsafe")
+        if opened.st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        elif opened.st_size != 1:
+            fail("writer lock has an invalid size")
+        if os.name == "nt":
+            import msvcrt
+
+            while True:
+                try:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                    locked = True
+                    break
+                except OSError as exc:
+                    if exc.errno not in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                        raise
+                    time.sleep(0.05)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            locked = True
+        yield
+    finally:
+        try:
+            if locked and os.name == "nt":
+                import msvcrt
+
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            elif locked:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+def validate_record(record: Any, host_id: str, host_session_id: str) -> dict[str, Any]:
+    if not isinstance(record, dict) or set(record) != BINDING_KEYS:
+        fail("binding record has the wrong shape")
+    if record["schema"] != BINDING_SCHEMA:
+        fail("binding record has a mixed-version schema")
+    if record["host_id"] != host_id or record["host_session_id"] != host_session_id:
+        fail("binding record has foreign host or session identity")
+    binding_generation = generation(record["binding_generation"], "binding_generation")
+    generation(record["applicable_continuity_generation"], "applicable_continuity_generation")
+    if record["status"] not in {"ACTIVE", "SUPERSEDED", "TOMBSTONED"}:
+        fail("binding record has an invalid status")
+    for key in (
+        "controller_id",
+        "claim_id",
+        "explicit_run_root",
+        "repository_identity",
+        "git_common_directory_identity",
+        "worktree_identity",
+        "activation_event_id",
+        "activation_receipt",
+        "applicable_continuity_receipt",
+    ):
+        if not isinstance(record[key], str) or not record[key]:
+            fail(f"binding record has an invalid {key}")
+    for key in (
+        "explicit_run_root",
+        "repository_identity",
+        "git_common_directory_identity",
+        "worktree_identity",
+    ):
+        if safe_existing_directory(record[key], key) != record[key]:
+            fail(f"binding record has a non-canonical {key}")
+    require_run_worktree_custody(record["explicit_run_root"], record["worktree_identity"])
+    predecessor = record["predecessor_generation"]
+    ordinal = int(binding_generation[1:], 16)
+    expected_predecessor = None if ordinal == 1 else f"G{ordinal - 1:04X}"
+    if predecessor != expected_predecessor:
+        fail("binding record has a broken predecessor-generation chain")
+    reason = record["supersession_or_tombstone_reason"]
+    if reason is not None and (not isinstance(reason, str) or not reason):
+        fail("binding record has an invalid transition reason")
+    return record
+
+
+def load_state(store: Path, host_id: str, host_session_id: str) -> tuple[Path, dict[str, Any]]:
+    target = state_path(store, host_id, host_session_id)
+    state = read_json(target, "binding state")
+    if set(state) != {"schema", "host_id", "host_session_id", "records"}:
+        fail("binding state has the wrong shape")
+    if state["schema"] != STATE_SCHEMA or state["host_id"] != host_id or state["host_session_id"] != host_session_id:
+        fail("binding state is malformed, foreign, or mixed-version")
+    if not isinstance(state["records"], list) or not state["records"]:
+        fail("binding state has no records")
+    records = [validate_record(record, host_id, host_session_id) for record in state["records"]]
+    generations = [record["binding_generation"] for record in records]
+    if len(generations) != len(set(generations)) or generations != sorted(generations):
+        fail("binding generations are duplicate or out of order")
+    active = [record for record in records if record["status"] == "ACTIVE"]
+    if len(active) > 1 or (active and active[0] is not records[-1]):
+        fail("binding state is ambiguous")
+    if not active and records[-1]["status"] != "TOMBSTONED":
+        fail("binding state has no current active or tombstoned record")
+    for record in records[:-1]:
+        if record["status"] != "SUPERSEDED":
+            fail("non-current binding record is not superseded")
+    return target, state
+
+
+def current_record(state: dict[str, Any], *, require_active: bool) -> dict[str, Any]:
+    current = state["records"][-1]
+    if require_active and current["status"] != "ACTIVE":
+        fail("host session binding is not active")
+    return current
+
+
+def proof_result(**payload: Any) -> dict[str, Any]:
+    return {
+        "schema": RESULT_SCHEMA,
+        **payload,
+        "host_activation_proven": False,
+        "proof_layers": dict(PROOF_LAYERS),
+    }
+
+
+def command_init(args: argparse.Namespace) -> None:
+    owner = exact_text(args.owner_id, "owner_id")
+    store = Path(args.store).absolute()
+    if store.exists():
+        try:
+            info = os.lstat(store)
+        except OSError as exc:
+            fail(f"store cannot be inspected: {exc}")
+        if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode) or has_reparse_flag(info):
+            fail("store is a symlink, reparse point, or non-directory")
+        marker = owner_path(store)
+        if marker.exists():
+            existing = load_owner(store, owner)
+            emit({"schema": STORE_SCHEMA, "status": "READY", "owner_id": existing["owner_id"]})
+            return
+        if any(store.iterdir()):
+            fail("non-empty store lacks trusted owner state")
+    else:
+        store = ensure_safe_directory(store, "store")
+    atomic_json(owner_path(store), {"schema": STORE_SCHEMA, "owner_id": owner, "trusted": True, "enabled": True})
+    emit({"schema": STORE_SCHEMA, "status": "READY", "owner_id": owner})
+
+
+def binding_from_args(
+    args: argparse.Namespace,
+    *,
+    binding_generation: str,
+    predecessor_generation: str | None,
+    reason: str | None,
+) -> dict[str, Any]:
+    run_root = safe_existing_directory(args.explicit_run_root, "explicit_run_root")
+    repository = safe_existing_directory(args.repository_identity, "repository_identity")
+    common = safe_existing_directory(args.git_common_directory_identity, "git_common_directory_identity")
+    worktree = safe_existing_directory(args.worktree_identity, "worktree_identity")
+    require_run_worktree_custody(run_root, worktree)
+    return {
+        "schema": BINDING_SCHEMA,
+        "host_id": exact_text(args.host_id, "host_id"),
+        "host_session_id": exact_text(args.host_session_id, "host_session_id"),
+        "controller_id": exact_text(args.controller_id, "controller_id"),
+        "claim_id": exact_text(args.claim_id, "claim_id"),
+        "explicit_run_root": run_root,
+        "repository_identity": repository,
+        "git_common_directory_identity": common,
+        "worktree_identity": worktree,
+        "binding_generation": binding_generation,
+        "activation_event_id": exact_text(args.activation_event_id, "activation_event_id"),
+        "activation_receipt": exact_text(args.activation_receipt, "activation_receipt"),
+        "applicable_continuity_generation": generation(args.continuity_generation, "continuity_generation"),
+        "applicable_continuity_receipt": exact_text(args.continuity_receipt, "continuity_receipt"),
+        "status": "ACTIVE",
+        "predecessor_generation": predecessor_generation,
+        "supersession_or_tombstone_reason": reason,
+    }
+
+
+def command_bind(args: argparse.Namespace) -> None:
+    store = Path(args.store).absolute()
+    load_owner(store, exact_text(args.owner_id, "owner_id"))
+    binding = binding_from_args(args, binding_generation="G0001", predecessor_generation=None, reason=None)
+    store = require_external_store(store, binding)
+    target = state_path(store, binding["host_id"], binding["host_session_id"])
+    index = session_index_path(store, binding["host_session_id"])
+    with writer_lock(store):
+        if target.exists():
+            fail("binding already exists; expected-generation rebinding is required")
+        if index.exists():
+            existing = read_json(index, "session host index")
+            if existing != {"host_id": binding["host_id"], "host_session_id": binding["host_session_id"]}:
+                fail("same session identity is already bound under an incompatible host")
+        else:
+            atomic_json(index, {"host_id": binding["host_id"], "host_session_id": binding["host_session_id"]})
+        atomic_json(
+            target,
+            {
+                "schema": STATE_SCHEMA,
+                "host_id": binding["host_id"],
+                "host_session_id": binding["host_session_id"],
+                "records": [binding],
+            },
+        )
+    emit(proof_result(status="BOUND", binding=binding))
+
+
+def command_rebind(args: argparse.Namespace) -> None:
+    store = Path(args.store).absolute()
+    load_owner(store, exact_text(args.owner_id, "owner_id"))
+    host_id = exact_text(args.host_id, "host_id")
+    session_id = exact_text(args.host_session_id, "host_session_id")
+    expected = generation(args.expected_generation, "expected_generation")
+    reason = exact_text(args.reason, "reason")
+    with writer_lock(store):
+        target, state = load_state(store, host_id, session_id)
+        current = current_record(state, require_active=True)
+        if current["binding_generation"] != expected:
+            fail("expected binding generation does not match current generation")
+        successor = binding_from_args(
+            args,
+            binding_generation=next_generation(expected),
+            predecessor_generation=expected,
+            reason=reason,
+        )
+        require_external_store(store, current)
+        require_external_store(store, successor)
+        predecessor = dict(current)
+        predecessor["status"] = "SUPERSEDED"
+        predecessor["supersession_or_tombstone_reason"] = reason
+        state["records"][-1] = predecessor
+        state["records"].append(successor)
+        atomic_json(target, state)
+    emit(proof_result(status="BOUND", binding=successor))
+
+
+def command_lookup(args: argparse.Namespace) -> None:
+    host_id = exact_text(args.host_id, "host_id")
+    session_id = exact_text(args.host_session_id, "host_session_id")
+    store = Path(args.store).absolute()
+    target = state_path(store, host_id, session_id)
+    if not target.exists():
+        emit({"schema": RESULT_SCHEMA, "status": "UNBOUND", "enforcement_available": False})
+        return
+    load_owner(store)
+    _, state = load_state(store, host_id, session_id)
+    current = current_record(state, require_active=False)
+    require_external_store(store, current)
+    if current["status"] == "TOMBSTONED":
+        emit(proof_result(status="TOMBSTONED", enforcement_available=False, binding=current))
+        return
+    emit(proof_result(status="BOUND", binding=current))
+
+
+def command_validate_event(args: argparse.Namespace) -> None:
+    host_id = exact_text(args.host_id, "host_id")
+    session_id = exact_text(args.host_session_id, "host_session_id")
+    store = Path(args.store).absolute()
+    target = state_path(store, host_id, session_id)
+    if not target.exists():
+        fail("host session is unbound")
+    load_owner(store)
+    _, state = load_state(store, host_id, session_id)
+    current = current_record(state, require_active=True)
+    require_external_store(store, current)
+    observed = {
+        "binding_generation": generation(args.binding_generation, "binding_generation"),
+        "controller_id": exact_text(args.controller_id, "controller_id"),
+        "claim_id": exact_text(args.claim_id, "claim_id"),
+        "explicit_run_root": safe_existing_directory(args.explicit_run_root, "explicit_run_root"),
+        "repository_identity": safe_existing_directory(args.repository_identity, "repository_identity"),
+        "git_common_directory_identity": safe_existing_directory(
+            args.git_common_directory_identity, "git_common_directory_identity"
+        ),
+        "worktree_identity": safe_existing_directory(args.worktree_identity, "worktree_identity"),
+        "applicable_continuity_generation": generation(args.continuity_generation, "continuity_generation"),
+        "applicable_continuity_receipt": exact_text(args.continuity_receipt, "continuity_receipt"),
+    }
+    for key, value in observed.items():
+        if current[key] != value:
+            fail(f"event has stale or foreign {key}")
+    obligation = args.obligation_id
+    transaction = args.route_transaction_id
+    if (obligation is None) != (transaction is None):
+        fail("route obligation and transaction identities must be supplied together")
+    correlation = {
+        "host_id": host_id,
+        "host_session_id": session_id,
+        **observed,
+        "event_id": exact_text(args.event_id, "event_id"),
+        "turn_id": exact_text(args.turn_id, "turn_id") if args.turn_id else None,
+        "tool_use_id": exact_text(args.tool_use_id, "tool_use_id") if args.tool_use_id else None,
+        "agent_id": exact_text(args.agent_id, "agent_id") if args.agent_id else None,
+        "obligation_id": exact_text(obligation, "obligation_id") if obligation else None,
+        "route_transaction_id": exact_text(transaction, "route_transaction_id") if transaction else None,
+    }
+    digest = hashlib.sha256(json.dumps(correlation, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    result = proof_result(
+        status="ATTRIBUTED",
+        binding_generation=current["binding_generation"],
+        correlation_id=f"sha256:{digest}",
+    )
+    if obligation is not None:
+        result["obligation_id"] = obligation
+        result["route_transaction_id"] = transaction
+    emit(result)
+
+
+def command_tombstone(args: argparse.Namespace) -> None:
+    store = Path(args.store).absolute()
+    load_owner(store, exact_text(args.owner_id, "owner_id"))
+    host_id = exact_text(args.host_id, "host_id")
+    session_id = exact_text(args.host_session_id, "host_session_id")
+    expected = generation(args.expected_generation, "expected_generation")
+    reason = exact_text(args.reason, "reason")
+    with writer_lock(store):
+        target, state = load_state(store, host_id, session_id)
+        current = current_record(state, require_active=True)
+        require_external_store(store, current)
+        if current["binding_generation"] != expected:
+            fail("expected binding generation does not match current generation")
+        predecessor = dict(current)
+        predecessor["status"] = "SUPERSEDED"
+        predecessor["supersession_or_tombstone_reason"] = reason
+        tombstone = dict(current)
+        tombstone["binding_generation"] = next_generation(expected)
+        tombstone["status"] = "TOMBSTONED"
+        tombstone["predecessor_generation"] = expected
+        tombstone["supersession_or_tombstone_reason"] = reason
+        state["records"][-1] = predecessor
+        state["records"].append(tombstone)
+        atomic_json(target, state)
+    emit(proof_result(status="TOMBSTONED", binding=tombstone, object_closed=False))
+
+
+def command_gc(args: argparse.Namespace) -> None:
+    store = Path(args.store).absolute()
+    load_owner(store, exact_text(args.owner_id, "owner_id"))
+    host_id = exact_text(args.host_id, "host_id")
+    session_id = exact_text(args.host_session_id, "host_session_id")
+    expected = generation(args.expected_generation, "expected_generation")
+    if args.retain_generations < 1:
+        fail("retain_generations must preserve at least the current generation")
+    resolved = {generation(item, "resolved_generation") for item in args.resolved_generation}
+    if not resolved or not args.resolution_receipt:
+        fail("GC requires closure-owner resolution evidence for every removable generation")
+    exact_text(args.resolution_receipt, "resolution_receipt")
+    with writer_lock(store):
+        target, state = load_state(store, host_id, session_id)
+        current = current_record(state, require_active=False)
+        require_external_store(store, current)
+        if current["binding_generation"] != expected:
+            fail("expected binding generation does not match current generation")
+        protected = {record["binding_generation"] for record in state["records"][-args.retain_generations :]}
+        removed = sorted(
+            record["binding_generation"]
+            for record in state["records"]
+            if record["binding_generation"] in resolved
+            and record["binding_generation"] not in protected
+            and record["status"] != "ACTIVE"
+        )
+        if removed:
+            state["records"] = [record for record in state["records"] if record["binding_generation"] not in removed]
+            atomic_json(target, state)
+    emit(
+        proof_result(
+            status="GC_COMPLETE",
+            removed_generations=removed,
+            preserved_current_generation=current["binding_generation"],
+            governed_state_deleted=False,
+        )
+    )
+
+
+def add_binding_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--owner-id", required=True)
+    parser.add_argument("--host-id", required=True)
+    parser.add_argument("--host-session-id", required=True)
+    parser.add_argument("--controller-id", required=True)
+    parser.add_argument("--claim-id", required=True)
+    parser.add_argument("--explicit-run-root", required=True)
+    parser.add_argument("--repository-identity", required=True)
+    parser.add_argument("--git-common-directory-identity", required=True)
+    parser.add_argument("--worktree-identity", required=True)
+    parser.add_argument("--activation-event-id", required=True)
+    parser.add_argument("--activation-receipt", required=True)
+    parser.add_argument("--continuity-generation", required=True)
+    parser.add_argument("--continuity-receipt", required=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store", required=True)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init = subparsers.add_parser("init")
+    init.add_argument("--owner-id", required=True)
+    init.set_defaults(run=command_init)
+
+    bind = subparsers.add_parser("bind")
+    add_binding_arguments(bind)
+    bind.set_defaults(run=command_bind)
+
+    rebind = subparsers.add_parser("rebind")
+    add_binding_arguments(rebind)
+    rebind.add_argument("--expected-generation", required=True)
+    rebind.add_argument("--reason", required=True)
+    rebind.set_defaults(run=command_rebind)
+
+    lookup = subparsers.add_parser("lookup")
+    lookup.add_argument("--host-id", required=True)
+    lookup.add_argument("--host-session-id", required=True)
+    lookup.set_defaults(run=command_lookup)
+
+    event = subparsers.add_parser("validate-event")
+    event.add_argument("--host-id", required=True)
+    event.add_argument("--host-session-id", required=True)
+    event.add_argument("--binding-generation", required=True)
+    event.add_argument("--controller-id", required=True)
+    event.add_argument("--claim-id", required=True)
+    event.add_argument("--explicit-run-root", required=True)
+    event.add_argument("--repository-identity", required=True)
+    event.add_argument("--git-common-directory-identity", required=True)
+    event.add_argument("--worktree-identity", required=True)
+    event.add_argument("--continuity-generation", required=True)
+    event.add_argument("--continuity-receipt", required=True)
+    event.add_argument("--event-id", required=True)
+    event.add_argument("--turn-id")
+    event.add_argument("--tool-use-id")
+    event.add_argument("--agent-id")
+    event.add_argument("--obligation-id")
+    event.add_argument("--route-transaction-id")
+    event.set_defaults(run=command_validate_event)
+
+    tombstone = subparsers.add_parser("tombstone")
+    tombstone.add_argument("--owner-id", required=True)
+    tombstone.add_argument("--host-id", required=True)
+    tombstone.add_argument("--host-session-id", required=True)
+    tombstone.add_argument("--expected-generation", required=True)
+    tombstone.add_argument("--reason", required=True)
+    tombstone.set_defaults(run=command_tombstone)
+
+    gc = subparsers.add_parser("gc")
+    gc.add_argument("--owner-id", required=True)
+    gc.add_argument("--host-id", required=True)
+    gc.add_argument("--host-session-id", required=True)
+    gc.add_argument("--expected-generation", required=True)
+    gc.add_argument("--retain-generations", type=int, required=True)
+    gc.add_argument("--resolved-generation", action="append", default=[])
+    gc.add_argument("--resolution-receipt")
+    gc.set_defaults(run=command_gc)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/host-session-binding.test.sh
+++ b/tests/host-session-binding.test.sh
@@ -314,6 +314,72 @@ set -e
 }
 assert_json "$malformed_output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
 
+# A binding state is unavailable unless its required direct session index is
+# safe, well-formed, and exactly corresponds to the requested host/session.
+for operation in lookup validate-event; do
+  for index_case in missing corrupt foreign-host mismatched-session; do
+    index_store="$tmp/index-$operation-$index_case-store"
+    cp -R "$store" "$index_store"
+    index_file="$(grep -rl '"host_session_id": "session-a"' "$index_store/sessions" | head -1)"
+    case "$index_case" in
+      missing)
+        rm "$index_file"
+        ;;
+      corrupt)
+        printf '{\n' > "$index_file"
+        ;;
+      foreign-host)
+        printf '{"host_id":"claude","host_session_id":"session-a"}\n' > "$index_file"
+        ;;
+      mismatched-session)
+        printf '{"host_id":"codex","host_session_id":"session-b"}\n' > "$index_file"
+        ;;
+    esac
+    index_snapshot_before="$(find "$index_store" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+    if [ "$operation" = lookup ]; then
+      expect_unavailable_at_store "$index_case index lookup" "$index_store" lookup \
+        --host-id codex --host-session-id session-a
+    else
+      expect_unavailable_at_store "$index_case index event" "$index_store" validate-event \
+        --host-id codex --host-session-id session-a --binding-generation G0002 \
+        --controller-id controller-b --claim-id claim-a2 --explicit-run-root "$run_a2" \
+        --repository-identity "$repository" --git-common-directory-identity "$common" \
+        --worktree-identity "$worktree" --continuity-generation G0002 \
+        --continuity-receipt continuity-receipt-session-a2 --event-id "index-$index_case"
+    fi
+    index_snapshot_after="$(find "$index_store" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+    [ "$index_snapshot_before" = "$index_snapshot_after" ] || {
+      printf 'host-session-binding.test: %s index %s mutated partial store\n' \
+        "$index_case" "$operation" >&2
+      exit 1
+    }
+  done
+done
+
+# An index whose binding state is absent is crash residue, not authority to
+# recreate the binding. Bind must fail closed and preserve that residue.
+orphan_store="$tmp/orphan-index-store"
+cp -R "$store" "$orphan_store"
+orphan_binding="$(grep -rl '"host_session_id": "session-a"' "$orphan_store/bindings" | head -1)"
+orphan_index="$(grep -rl '"host_session_id": "session-a"' "$orphan_store/sessions" | head -1)"
+rm "$orphan_binding"
+orphan_index_before="$(sha256sum "$orphan_index")"
+expect_unavailable_at_store "orphan index without binding state" "$orphan_store" bind \
+  --owner-id host-owner --host-id codex --host-session-id session-a \
+  --controller-id controller-b --claim-id claim-a2 --explicit-run-root "$run_a2" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --activation-event-id orphan-rebind \
+  --activation-receipt orphan-rebind-receipt --continuity-generation G0002 \
+  --continuity-receipt orphan-continuity-receipt
+[ ! -e "$orphan_binding" ] || {
+  printf 'host-session-binding.test: bind recreated state behind an orphan index\n' >&2
+  exit 1
+}
+[ "$orphan_index_before" = "$(sha256sum "$orphan_index")" ] || {
+  printf 'host-session-binding.test: bind mutated orphan index crash residue\n' >&2
+  exit 1
+}
+
 chain_store="$tmp/broken-chain-store"
 cp -R "$store" "$chain_store"
 chain_binding="$(grep -rl '"host_session_id": "session-a"' "$chain_store/bindings" | head -1)"

--- a/tests/host-session-binding.test.sh
+++ b/tests/host-session-binding.test.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+core="$repo_root/skills/implementaudit/scripts/host-session-binding.py"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+py=()
+if command -v python >/dev/null 2>&1; then
+  py=(python)
+elif command -v py >/dev/null 2>&1; then
+  py=(py -3)
+elif command -v python3 >/dev/null 2>&1; then
+  py=(python3)
+else
+  printf 'host-session-binding.test: Python 3 is required\n' >&2
+  exit 1
+fi
+
+store="$tmp/host-owned-store"
+repository="$tmp/repository"
+common="$tmp/git-common"
+worktree="$tmp/worktree"
+worktree_b="$tmp/worktree-b"
+run_a="$worktree/.IMPLEMENTAUDIT/runs/a"
+run_b="$worktree/.IMPLEMENTAUDIT/runs/b"
+run_a2="$worktree/.IMPLEMENTAUDIT/runs/a2"
+run_c="$worktree_b/.IMPLEMENTAUDIT/runs/c"
+foreign_repository="$tmp/foreign-repository"
+foreign_worktree="$tmp/foreign-worktree"
+mkdir -p "$repository" "$common" "$run_a" "$run_b" "$run_a2" "$run_c" \
+  "$foreign_repository" "$foreign_worktree"
+
+run_core() {
+  "${py[@]}" "$core" --store "$store" "$@"
+}
+
+bind_session() {
+  local session="$1" claim="$2" run_root="$3" event="$4"
+  run_core bind \
+    --owner-id host-owner \
+    --host-id codex \
+    --host-session-id "$session" \
+    --controller-id controller-a \
+    --claim-id "$claim" \
+    --explicit-run-root "$run_root" \
+    --repository-identity "$repository" \
+    --git-common-directory-identity "$common" \
+    --worktree-identity "$worktree" \
+    --activation-event-id "$event" \
+    --activation-receipt "activation-receipt-$session" \
+    --continuity-generation G0001 \
+    --continuity-receipt "continuity-receipt-$session"
+}
+
+assert_json() {
+  local payload="$1" expression="$2"
+  "${py[@]}" - "$payload" "$expression" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+if not eval(sys.argv[2], {"__builtins__": {}}, {"value": payload}):
+    raise SystemExit(f"assertion failed: {sys.argv[2]} against {payload!r}")
+PY
+}
+
+expect_unavailable() {
+  local label="$1"
+  shift
+  local output status
+  set +e
+  if [ "${1:-}" = validate_event ]; then
+    output="$("$@" 2>&1)"
+  else
+    output="$(run_core "$@" 2>&1)"
+  fi
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    printf 'host-session-binding.test: unexpected success: %s\n' "$label" >&2
+    exit 1
+  fi
+  assert_json "$output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
+}
+
+expect_unavailable_at_store() {
+  local label="$1" selected_store="$2"
+  shift 2
+  local output status
+  set +e
+  output="$("${py[@]}" "$core" --store "$selected_store" "$@" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    printf 'host-session-binding.test: unexpected success: %s\n' "$label" >&2
+    exit 1
+  fi
+  assert_json "$output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
+}
+
+validate_event() {
+  local generation="$1" controller="$2" claim="$3" run_root="$4" repo="$5" \
+    tree="$6" continuity_generation="$7" continuity_receipt="$8" event="$9"
+  shift 9
+  run_core validate-event \
+    --host-id codex \
+    --host-session-id session-a \
+    --binding-generation "$generation" \
+    --controller-id "$controller" \
+    --claim-id "$claim" \
+    --explicit-run-root "$run_root" \
+    --repository-identity "$repo" \
+    --git-common-directory-identity "$common" \
+    --worktree-identity "$tree" \
+    --continuity-generation "$continuity_generation" \
+    --continuity-receipt "$continuity_receipt" \
+    --event-id "$event" \
+    "$@"
+}
+
+run_core init --owner-id host-owner >/dev/null
+bind_session session-a claim-a "$run_a" activation-a >/dev/null
+bind_session session-b claim-b "$run_b" activation-b >/dev/null
+
+lookup_a="$(run_core lookup --host-id codex --host-session-id session-a)"
+lookup_b="$(run_core lookup --host-id codex --host-session-id session-b)"
+assert_json "$lookup_a" 'value["status"] == "BOUND" and value["binding"]["binding_generation"] == "G0001" and value["binding"]["host_session_id"] == "session-a" and value["binding"]["claim_id"] == "claim-a"'
+assert_json "$lookup_b" 'value["status"] == "BOUND" and value["binding"]["binding_generation"] == "G0001" and value["binding"]["host_session_id"] == "session-b" and value["binding"]["claim_id"] == "claim-b"'
+assert_json "$lookup_a" 'value["binding"]["controller_id"] == "controller-a"'
+assert_json "$lookup_b" 'value["binding"]["controller_id"] == "controller-a"'
+
+# Case 1: one session resolves only to its exact controller, claim and run.
+exact="$(validate_event G0001 controller-a claim-a "$run_a" "$repository" "$worktree" G0001 continuity-receipt-session-a event-exact)"
+assert_json "$exact" 'value["status"] == "ATTRIBUTED" and value["binding_generation"] == "G0001"'
+
+# Case 3: worktrees sharing one Git-common identity remain distinct.
+run_core bind \
+  --owner-id host-owner \
+  --host-id codex \
+  --host-session-id session-c \
+  --controller-id controller-a \
+  --claim-id claim-c \
+  --explicit-run-root "$run_c" \
+  --repository-identity "$repository" \
+  --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree_b" \
+  --activation-event-id activation-c \
+  --activation-receipt activation-receipt-session-c \
+  --continuity-generation G0001 \
+  --continuity-receipt continuity-receipt-session-c >/dev/null
+lookup_c="$(run_core lookup --host-id codex --host-session-id session-c)"
+assert_json "$lookup_c" 'value["binding"]["worktree_identity"] != value.get("wrong", "") and value["binding"]["host_session_id"] == "session-c"'
+expect_unavailable "foreign worktree" validate-event \
+  --host-id codex --host-session-id session-c --binding-generation G0001 \
+  --controller-id controller-a --claim-id claim-c --explicit-run-root "$run_c" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --continuity-generation G0001 \
+  --continuity-receipt continuity-receipt-session-c --event-id wrong-worktree
+
+# Case 4: rebinding is expected-current CAS and advances exactly one generation.
+rebound="$(run_core rebind \
+  --expected-generation G0001 \
+  --reason governed-object-transfer \
+  --owner-id host-owner \
+  --host-id codex \
+  --host-session-id session-a \
+  --controller-id controller-b \
+  --claim-id claim-a2 \
+  --explicit-run-root "$run_a2" \
+  --repository-identity "$repository" \
+  --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" \
+  --activation-event-id activation-a2 \
+  --activation-receipt activation-receipt-session-a2 \
+  --continuity-generation G0002 \
+  --continuity-receipt continuity-receipt-session-a2)"
+assert_json "$rebound" 'value["status"] == "BOUND" and value["binding"]["binding_generation"] == "G0002" and value["binding"]["predecessor_generation"] == "G0001"'
+expect_unavailable "stale expected generation" rebind \
+  --expected-generation G0001 --reason stale-rebind --owner-id host-owner \
+  --host-id codex --host-session-id session-a --controller-id controller-c \
+  --claim-id claim-stale --explicit-run-root "$run_a" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --activation-event-id stale-rebind \
+  --activation-receipt stale-rebind-receipt --continuity-generation G0003 \
+  --continuity-receipt stale-continuity-receipt
+
+# Case 5: a prior-generation event is stale after CAS.
+expect_unavailable "prior-generation event" validate_event G0001 controller-a claim-a \
+  "$run_a" "$repository" "$worktree" G0001 continuity-receipt-session-a delayed-event
+
+# Case 6: foreign controller, claim, repository and worktree identities fail closed.
+expect_unavailable "foreign controller" validate_event G0002 controller-foreign claim-a2 \
+  "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 event-foreign-controller
+expect_unavailable "foreign claim" validate_event G0002 controller-b claim-foreign \
+  "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 event-foreign-claim
+expect_unavailable "foreign repository" validate_event G0002 controller-b claim-a2 \
+  "$run_a2" "$foreign_repository" "$worktree" G0002 continuity-receipt-session-a2 event-foreign-repository
+expect_unavailable "foreign worktree" validate_event G0002 controller-b claim-a2 \
+  "$run_a2" "$repository" "$foreign_worktree" G0002 continuity-receipt-session-a2 event-foreign-worktree
+expect_unavailable "incompatible host identity for reused session ID" bind \
+  --owner-id host-owner --host-id claude --host-session-id session-a \
+  --controller-id controller-b --claim-id claim-a2 --explicit-run-root "$run_a2" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --activation-event-id incompatible-host \
+  --activation-receipt incompatible-host-receipt --continuity-generation G0002 \
+  --continuity-receipt incompatible-host-continuity
+expect_unavailable "run root outside recorded worktree" bind \
+  --owner-id host-owner --host-id codex --host-session-id session-mismatch \
+  --controller-id controller-a --claim-id claim-mismatch --explicit-run-root "$run_a" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree_b" --activation-event-id mismatched-worktree \
+  --activation-receipt mismatched-worktree-receipt --continuity-generation G0001 \
+  --continuity-receipt mismatched-worktree-continuity
+
+inside_store="$worktree/target-owned-binding-store"
+"${py[@]}" "$core" --store "$inside_store" init --owner-id host-owner >/dev/null
+expect_unavailable_at_store "target-owned binding store" "$inside_store" bind \
+  --owner-id host-owner --host-id codex --host-session-id session-target-store \
+  --controller-id controller-a --claim-id claim-target-store --explicit-run-root "$run_a" \
+  --repository-identity "$worktree" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --activation-event-id target-store \
+  --activation-receipt target-store-receipt --continuity-generation G0001 \
+  --continuity-receipt target-store-continuity
+
+covering_store="$tmp/covering-binding-store"
+"${py[@]}" "$core" --store "$covering_store" init --owner-id host-owner >/dev/null
+covered_worktree="$covering_store/target-worktree"
+covered_run="$covered_worktree/.IMPLEMENTAUDIT/runs/covered"
+mkdir -p "$covered_run"
+expect_unavailable_at_store "binding store contains target custody" "$covering_store" bind \
+  --owner-id host-owner --host-id codex --host-session-id session-covered-store \
+  --controller-id controller-a --claim-id claim-covered-store --explicit-run-root "$covered_run" \
+  --repository-identity "$covered_worktree" --git-common-directory-identity "$common" \
+  --worktree-identity "$covered_worktree" --activation-event-id covered-store \
+  --activation-receipt covered-store-receipt --continuity-generation G0001 \
+  --continuity-receipt covered-store-continuity
+
+# Case 7: cwd, newest-run, singleton, target prose and child output cannot infer identity.
+inference_root="$tmp/inference-trap"
+unbound_store="$tmp/absent-store"
+mkdir -p "$inference_root/.IMPLEMENTAUDIT/runs/newest"
+printf 'controller_id=controller-b\nclaim_id=claim-a2\nchild_output=identity-is-here\n' \
+  > "$inference_root/.IMPLEMENTAUDIT/runs/newest/STATE.md"
+unbound="$(cd "$inference_root" && "${py[@]}" "$core" --store "$unbound_store" lookup \
+  --host-id codex --host-session-id unknown-session)"
+assert_json "$unbound" 'value["status"] == "UNBOUND" and value["enforcement_available"] is False'
+[ ! -e "$unbound_store" ] || {
+  printf 'host-session-binding.test: unbound lookup mutated the store\n' >&2
+  exit 1
+}
+set +e
+run_core lookup --host-id codex --host-session-id unknown-session --controller-id controller-b >/dev/null 2>&1
+inference_status=$?
+set -e
+[ "$inference_status" -ne 0 ] || {
+  printf 'host-session-binding.test: lookup accepted inferred controller input\n' >&2
+  exit 1
+}
+
+# Case 8: duplicate event identity is deterministic; reordered stale identity fails.
+before_event="$(find "$store" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+event_one="$(validate_event G0002 controller-b claim-a2 "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 event-duplicate --turn-id turn-7 --tool-use-id tool-9)"
+event_two="$(validate_event G0002 controller-b claim-a2 "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 event-duplicate --turn-id turn-7 --tool-use-id tool-9)"
+assert_json "$event_one" 'value["correlation_id"].startswith("sha256:")'
+correlation_one="$("${py[@]}" -c 'import json,sys; print(json.loads(sys.argv[1])["correlation_id"])' "$event_one")"
+correlation_two="$("${py[@]}" -c 'import json,sys; print(json.loads(sys.argv[1])["correlation_id"])' "$event_two")"
+[ "$correlation_one" = "$correlation_two" ] || {
+  printf 'host-session-binding.test: duplicate event correlation is non-deterministic\n' >&2
+  exit 1
+}
+after_event="$(find "$store" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+[ "$before_event" = "$after_event" ] || {
+  printf 'host-session-binding.test: event validation mutated binding state\n' >&2
+  exit 1
+}
+
+# Case 9: ambiguous activation cannot overwrite an active binding.
+expect_unavailable "ambiguous duplicate activation" bind \
+  --owner-id host-owner --host-id codex --host-session-id session-a \
+  --controller-id controller-b --claim-id claim-a2 --explicit-run-root "$run_a2" \
+  --repository-identity "$repository" --git-common-directory-identity "$common" \
+  --worktree-identity "$worktree" --activation-event-id duplicate-activation \
+  --activation-receipt duplicate-activation-receipt --continuity-generation G0002 \
+  --continuity-receipt duplicate-continuity-receipt
+
+# Case 10: disabled, untrusted, malformed and mixed-version states never enforce.
+for state in disabled untrusted; do
+  bad_store="$tmp/$state-store"
+  cp -R "$store" "$bad_store"
+  cp "$repo_root/fixtures/host-session-binding/$state-owner.json" "$bad_store/owner.json"
+  set +e
+  bad_output="$("${py[@]}" "$core" --store "$bad_store" lookup --host-id codex --host-session-id session-a 2>&1)"
+  bad_status=$?
+  set -e
+  [ "$bad_status" -ne 0 ] || {
+    printf 'host-session-binding.test: %s store claimed enforcement\n' "$state" >&2
+    exit 1
+  }
+  assert_json "$bad_output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
+done
+malformed_store="$tmp/malformed-store"
+cp -R "$store" "$malformed_store"
+malformed_binding="$(grep -rl '"host_session_id": "session-a"' "$malformed_store/bindings" | head -1)"
+cp "$repo_root/fixtures/host-session-binding/malformed-binding.json" "$malformed_binding"
+set +e
+malformed_output="$("${py[@]}" "$core" --store "$malformed_store" lookup --host-id codex --host-session-id session-a 2>&1)"
+malformed_status=$?
+set -e
+[ "$malformed_status" -ne 0 ] || {
+  printf 'host-session-binding.test: malformed state claimed enforcement\n' >&2
+  exit 1
+}
+assert_json "$malformed_output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
+
+chain_store="$tmp/broken-chain-store"
+cp -R "$store" "$chain_store"
+chain_binding="$(grep -rl '"host_session_id": "session-a"' "$chain_store/bindings" | head -1)"
+"${py[@]}" - "$chain_binding" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["records"][-1]["predecessor_generation"] = "G00AA"
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+set +e
+chain_output="$("${py[@]}" "$core" --store "$chain_store" lookup --host-id codex --host-session-id session-a 2>&1)"
+chain_status=$?
+set -e
+[ "$chain_status" -ne 0 ] || {
+  printf 'host-session-binding.test: broken predecessor chain claimed enforcement\n' >&2
+  exit 1
+}
+assert_json "$chain_output" 'value["status"] == "UNAVAILABLE" and value["enforcement_available"] is False'
+
+lock_store="$tmp/lock-alias-store"
+lock_target="$tmp/lock-alias-target"
+"${py[@]}" "$core" --store "$lock_store" init --owner-id host-owner >/dev/null
+printf 'X' > "$lock_target"
+if ln -s "$lock_target" "$lock_store/.writer.lock" 2>/dev/null \
+    && [ -L "$lock_store/.writer.lock" ]; then
+  expect_unavailable_at_store "aliased writer lock" "$lock_store" bind \
+    --owner-id host-owner --host-id codex --host-session-id session-lock-alias \
+    --controller-id controller-a --claim-id claim-lock-alias --explicit-run-root "$run_a" \
+    --repository-identity "$repository" --git-common-directory-identity "$common" \
+    --worktree-identity "$worktree" --activation-event-id lock-alias \
+    --activation-receipt lock-alias-receipt --continuity-generation G0001 \
+    --continuity-receipt lock-alias-continuity
+  [ "$(cat "$lock_target")" = X ] || {
+    printf 'host-session-binding.test: aliased writer lock mutated its target\n' >&2
+    exit 1
+  }
+fi
+
+parent_store="$tmp/parent-alias-store"
+parent_escape="$tmp/parent-alias-escape"
+"${py[@]}" "$core" --store "$parent_store" init --owner-id host-owner >/dev/null
+mkdir -p "$parent_escape"
+if ln -s "$parent_escape" "$parent_store/bindings" 2>/dev/null \
+    && [ -L "$parent_store/bindings" ]; then
+  expect_unavailable_at_store "aliased binding parent" "$parent_store" bind \
+    --owner-id host-owner --host-id codex --host-session-id session-parent-alias \
+    --controller-id controller-a --claim-id claim-parent-alias --explicit-run-root "$run_a" \
+    --repository-identity "$repository" --git-common-directory-identity "$common" \
+    --worktree-identity "$worktree" --activation-event-id parent-alias \
+    --activation-receipt parent-alias-receipt --continuity-generation G0001 \
+    --continuity-receipt parent-alias-continuity
+  [ -z "$(find "$parent_escape" -type f -print -quit)" ] || {
+    printf 'host-session-binding.test: aliased binding parent escaped store custody\n' >&2
+    exit 1
+  }
+fi
+
+# Case 13: route records consume, but cannot override, the current binding generation.
+route="$(validate_event G0002 controller-b claim-a2 "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 route-event --obligation-id obligation-4 --route-transaction-id route-transaction-4)"
+assert_json "$route" 'value["status"] == "ATTRIBUTED" and value["obligation_id"] == "obligation-4" and value["route_transaction_id"] == "route-transaction-4"'
+expect_unavailable "stale route generation" validate_event G0001 controller-b claim-a2 \
+  "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 stale-route-event \
+  --obligation-id obligation-4 --route-transaction-id route-transaction-4
+
+# Case 11: SessionEnd tombstones attribution but never closes the governed object.
+run_marker_before="$(find "$run_a2" -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+tombstone="$(run_core tombstone --owner-id host-owner --host-id codex \
+  --host-session-id session-a --expected-generation G0002 --reason session-end)"
+assert_json "$tombstone" 'value["status"] == "TOMBSTONED" and value["binding"]["binding_generation"] == "G0003" and value["object_closed"] is False'
+run_marker_after="$(find "$run_a2" -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)"
+[ "$run_marker_before" = "$run_marker_after" ] || {
+  printf 'host-session-binding.test: tombstone mutated governed run state\n' >&2
+  exit 1
+}
+expect_unavailable "tombstoned event" validate_event G0003 controller-b claim-a2 \
+  "$run_a2" "$repository" "$worktree" G0002 continuity-receipt-session-a2 post-session-end
+
+# Case 12: GC is owner-bound, retention-aware, idempotent and cannot delete unresolved state.
+expect_unavailable "unresolved GC" gc --owner-id host-owner --host-id codex \
+  --host-session-id session-a --expected-generation G0003 --retain-generations 1
+expect_unavailable "foreign-owner GC" gc --owner-id foreign-owner --host-id codex \
+  --host-session-id session-a --expected-generation G0003 --retain-generations 1 \
+  --resolved-generation G0001 --resolution-receipt resolution-receipt-1
+gc_one="$(run_core gc --owner-id host-owner --host-id codex --host-session-id session-a \
+  --expected-generation G0003 --retain-generations 1 --resolved-generation G0001 \
+  --resolution-receipt resolution-receipt-1)"
+assert_json "$gc_one" 'value["status"] == "GC_COMPLETE" and value["removed_generations"] == ["G0001"]'
+gc_two="$(run_core gc --owner-id host-owner --host-id codex --host-session-id session-a \
+  --expected-generation G0003 --retain-generations 1 --resolved-generation G0001 \
+  --resolution-receipt resolution-receipt-1)"
+assert_json "$gc_two" 'value["status"] == "GC_COMPLETE" and value["removed_generations"] == []'
+[ -d "$run_a" ] && [ -d "$run_a2" ] || {
+  printf 'host-session-binding.test: GC deleted governed run state\n' >&2
+  exit 1
+}
+
+# Case 14: already covered by the absent-store lookup above; it is read-only and zero-create.
+
+# Case 15: source, package, install and native activation proof stay distinct.
+assert_json "$lookup_b" 'value["host_activation_proven"] is False and value["proof_layers"] == {"source_core": "PRESENT", "package": "UNVERIFIED", "install": "UNVERIFIED", "host_activation": "UNVERIFIED"}'
+
+printf 'host-session-binding.test: ok (15/15 live R003A cases)\n'


### PR DESCRIPTION
## Summary
- add the R003A host-session binding core, contract, fixtures, and 15-case acceptance test
- route host attribution narrowly through governor and continuity owners without creating currentness, closure, or activation authority
- register the new package members and preserve semantic fixture identity
- merge current Thread-5 integration allocation before qualification

## Verification
- host-session-binding.test: 15/15
- continuity.test: 38/38
- semantic-preservation-cases: 21/21
- focused routing, continuity, durable-identity, package-contract, payload, lean, budget, and registry gates pass
- scripts/verify-package.sh: ok on commit 112f8848831bfdd2342405393f790d8ef2360fbd

## Boundaries
- draft only; do not mark ready or merge
- native host discovery and activation remain unverified and out of this core cell
- prior generated-bytecode and stale-base allocation failures are retained as historical evidence; the clean merged terminal verifier passed